### PR TITLE
feat: add PAT auth + gh.test_connection (MCP-2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,5 +32,5 @@ jobs:
         run: npm run build
       - name: Unit tests
         run: npm test
-      - name: Smoke test (server lists 0 tools at v0.1 bootstrap)
-        run: node ./tests/smoke/server-lists-zero-tools.mjs
+      - name: Smoke test (server lists registered tools)
+        run: node ./tests/smoke/server-lists-tools.mjs

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@octokit/graphql": "^8.0.0",
+        "@octokit/request": "^9.0.0",
         "@octokit/request-error": "^7.0.0"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json && node ./scripts/post-build.mjs",
-    "test": "node --test --test-reporter=spec --import tsx ./tests/unit/**/*.test.ts",
-    "test:integration": "GITHUB_PAT_LIVE=1 node --test --test-reporter=spec --import tsx ./tests/integration/**/*.test.ts",
+    "test": "node ./scripts/run-tests.mjs unit",
+    "test:integration": "node ./scripts/run-tests.mjs integration",
     "lint": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.tests.json --noEmit",
     "prepack": "npm run build"
   },

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
     "@octokit/graphql": "^8.0.0",
+    "@octokit/request": "^9.0.0",
     "@octokit/request-error": "^7.0.0"
   },
   "devDependencies": {

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// scripts/run-tests.mjs
+//
+// Cross-platform unit/integration test runner. Exists because:
+//
+//   - npm scripts run via /bin/sh on POSIX and cmd.exe on Windows;
+//     bash-only constructs like `shopt -s globstar` are not portable.
+//   - Node's `--test path/` mode resolves the path as a module
+//     (ERR_MODULE_NOT_FOUND for a directory), so we can't just hand
+//     `node --test ./tests/unit` to the test runner.
+//   - Node's bare `--test` (no args) discovers tests under CWD but
+//     can't be scoped to a subdirectory like `tests/unit/` without
+//     also picking up `tests/integration/`.
+//
+// We do the directory walk ourselves with `fs.readdir(..., { recursive: true })`
+// (stable on Node 22+) and pass the resulting file list straight to a
+// child `node --test`. Same shape on every OS.
+//
+// Usage:
+//   node scripts/run-tests.mjs unit          # tests/unit/**/*.test.ts
+//   node scripts/run-tests.mjs integration   # tests/integration/**/*.test.ts
+//
+// The integration variant also sets GITHUB_PAT_LIVE=1 so opt-in
+// integration tests know they have permission to call GitHub.
+
+import { readdir } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { resolve, dirname, join, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "..");
+
+const target = process.argv[2];
+if (target !== "unit" && target !== "integration") {
+  process.stderr.write(`run-tests: expected "unit" or "integration", got: ${target ?? "<none>"}\n`);
+  process.exit(2);
+}
+
+const testDir = resolve(repoRoot, "tests", target);
+
+async function findTestFiles(root) {
+  let entries;
+  try {
+    entries = await readdir(root, { recursive: true });
+  } catch (err) {
+    if (err && err.code === "ENOENT") {
+      return [];
+    }
+    throw err;
+  }
+  return entries
+    .filter((e) => e.endsWith(".test.ts"))
+    .map((e) => join(root, e))
+    .map((p) => (sep === "\\" ? p.replace(/\\/g, "/") : p));
+}
+
+const files = await findTestFiles(testDir);
+if (files.length === 0) {
+  process.stderr.write(`run-tests: no *.test.ts files under ${testDir}\n`);
+  // Unit suite should always have tests; integration suite is allowed
+  // to be empty (it's opt-in and may be skipped in CI without a token).
+  process.exit(target === "unit" ? 1 : 0);
+}
+
+const env = { ...process.env };
+if (target === "integration") {
+  env.GITHUB_PAT_LIVE = "1";
+}
+
+const child = spawn(
+  process.execPath,
+  ["--test", "--test-reporter=spec", "--import", "tsx", ...files],
+  { stdio: "inherit", env },
+);
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.stderr.write(`run-tests: child terminated by signal ${signal}\n`);
+    process.exit(1);
+  }
+  process.exit(code ?? 1);
+});

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -74,6 +74,15 @@ const child = spawn(
   { stdio: "inherit", env },
 );
 
+// Without an "error" handler, a failure to spawn the child (EACCES,
+// missing executable, permission errors) emits a default unhandled
+// "error" event with a stack trace. We surface a concise script-level
+// failure instead so the npm-run-script log isn't a wall of internals.
+child.on("error", (err) => {
+  process.stderr.write(`run-tests: failed to start child process: ${err.message}\n`);
+  process.exit(1);
+});
+
 child.on("exit", (code, signal) => {
   if (signal) {
     process.stderr.write(`run-tests: child terminated by signal ${signal}\n`);

--- a/src/auth/octokit.ts
+++ b/src/auth/octokit.ts
@@ -1,0 +1,32 @@
+// src/auth/octokit.ts
+//
+// Build the authenticated Octokit clients used by tool handlers.
+//
+// Two clients are exposed because they cover different needs:
+//   - `AuthedGraphql` (`@octokit/graphql`): the canonical GraphQL caller
+//     used by every domain tool from MCP-3 onwards.
+//   - `AuthedRequest` (`@octokit/request`): used by the auth-health tool
+//     (`gh.test_connection`) to read response headers like
+//     `x-oauth-scopes`, which `@octokit/graphql` does not surface to its
+//     callers because it returns the unwrapped `data` payload.
+//
+// Both clients embed the same PAT via the `authorization: token …`
+// header, matching what `gh` CLI sets for REST + GraphQL requests.
+
+import { graphql } from "@octokit/graphql";
+import { request } from "@octokit/request";
+
+export type AuthedGraphql = typeof graphql;
+export type AuthedRequest = typeof request;
+
+export function createAuthedGraphql(pat: string): AuthedGraphql {
+  return graphql.defaults({
+    headers: { authorization: `token ${pat}` },
+  });
+}
+
+export function createAuthedRequest(pat: string): AuthedRequest {
+  return request.defaults({
+    headers: { authorization: `token ${pat}` },
+  });
+}

--- a/src/auth/pat.ts
+++ b/src/auth/pat.ts
@@ -28,9 +28,12 @@ export class MissingPatError extends Error {
       `mcp-github: no GitHub token found in environment. ` +
         `Set one of: ${checked.join(", ")}.`,
     );
-    // Frozen copy: the error escapes the module and a caller could
-    // otherwise mutate `err.checkedEnv` (e.g. via `as any`) and
-    // change the resolver's precedence chain in subsequent calls.
+    // Frozen copy so the metadata exposed on the error instance is
+    // immutable for consumers and tests. resolvePat() always
+    // iterates the module-private ENV_VARS, so this freeze does NOT
+    // affect resolver behaviour — it just prevents
+    // `err.checkedEnv.push(...)` from corrupting the diagnostic
+    // record once the error has been thrown.
     this.checkedEnv = Object.freeze([...checked]);
   }
 }

--- a/src/auth/pat.ts
+++ b/src/auth/pat.ts
@@ -14,9 +14,11 @@ const ENV_VARS = [
 export type PatEnvVar = (typeof ENV_VARS)[number];
 
 // Exposed as a constant so tests can iterate the canonical list rather
-// than redeclaring it. Frozen tuple keeps insertion order and prevents
-// accidental mutation by callers.
-export const PAT_ENV_VARS: readonly PatEnvVar[] = ENV_VARS;
+// than redeclaring it. Object.freeze prevents callers from mutating
+// the array at runtime: the `readonly` annotation is only a
+// TypeScript-level guarantee, easily defeated by `as any` in JS code,
+// so we belt-and-brace it.
+export const PAT_ENV_VARS: readonly PatEnvVar[] = Object.freeze([...ENV_VARS]);
 
 export class MissingPatError extends Error {
   override readonly name = "MissingPatError";

--- a/src/auth/pat.ts
+++ b/src/auth/pat.ts
@@ -28,7 +28,10 @@ export class MissingPatError extends Error {
       `mcp-github: no GitHub token found in environment. ` +
         `Set one of: ${checked.join(", ")}.`,
     );
-    this.checkedEnv = checked;
+    // Frozen copy: the error escapes the module and a caller could
+    // otherwise mutate `err.checkedEnv` (e.g. via `as any`) and
+    // change the resolver's precedence chain in subsequent calls.
+    this.checkedEnv = Object.freeze([...checked]);
   }
 }
 

--- a/src/auth/pat.ts
+++ b/src/auth/pat.ts
@@ -35,11 +35,20 @@ export class MissingPatError extends Error {
 // `env` is parameterised (defaulting to `process.env`) so unit tests can
 // inject a synthetic environment without mutating real `process.env`,
 // which is fragile in parallel test runners.
+//
+// We trim the raw env value before checking emptiness: a value of
+// "   " (whitespace only) is almost certainly a misconfigured CI
+// secret rather than a real token, and accepting it would surface as
+// a confusing 401 from GitHub later. Treat whitespace-only as unset
+// and fall through to the next env var, the same as missing/empty.
 export function resolvePat(env: NodeJS.ProcessEnv = process.env): string {
   for (const key of ENV_VARS) {
     const v = env[key];
-    if (typeof v === "string" && v.length > 0) {
-      return v;
+    if (typeof v === "string") {
+      const trimmed = v.trim();
+      if (trimmed.length > 0) {
+        return trimmed;
+      }
     }
   }
   throw new MissingPatError();

--- a/src/auth/pat.ts
+++ b/src/auth/pat.ts
@@ -1,0 +1,44 @@
+// src/auth/pat.ts
+//
+// Resolve a GitHub Personal Access Token from the environment, walking
+// the same fallback chain `gh` CLI uses. Centralised here so every
+// caller (server start, tests, manual scripts) hits the same precedence
+// rules and the same structured-miss error.
+
+const ENV_VARS = [
+  "GITHUB_TOKEN",
+  "GH_TOKEN",
+  "GITHUB_PERSONAL_ACCESS_TOKEN",
+] as const;
+
+export type PatEnvVar = (typeof ENV_VARS)[number];
+
+// Exposed as a constant so tests can iterate the canonical list rather
+// than redeclaring it. Frozen tuple keeps insertion order and prevents
+// accidental mutation by callers.
+export const PAT_ENV_VARS: readonly PatEnvVar[] = ENV_VARS;
+
+export class MissingPatError extends Error {
+  override readonly name = "MissingPatError";
+  readonly checkedEnv: readonly PatEnvVar[];
+  constructor(checked: readonly PatEnvVar[] = ENV_VARS) {
+    super(
+      `mcp-github: no GitHub token found in environment. ` +
+        `Set one of: ${checked.join(", ")}.`,
+    );
+    this.checkedEnv = checked;
+  }
+}
+
+// `env` is parameterised (defaulting to `process.env`) so unit tests can
+// inject a synthetic environment without mutating real `process.env`,
+// which is fragile in parallel test runners.
+export function resolvePat(env: NodeJS.ProcessEnv = process.env): string {
+  for (const key of ENV_VARS) {
+    const v = env[key];
+    if (typeof v === "string" && v.length > 0) {
+      return v;
+    }
+  }
+  throw new MissingPatError();
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,9 @@
 // directly from source. The `.js` import specifier below is the
 // canonical ESM extension TypeScript preserves into the dist tree;
 // the source file is `src/registry.ts`.
+//
+// MCP-2 layers PAT resolution + auth-aware tool registration into
+// `startServer()`. Real domain tools land in MCP-3 onwards.
 
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
@@ -21,11 +24,15 @@ import {
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 
+import { resolvePat } from "./auth/pat.js";
+import { createAuthedRequest } from "./auth/octokit.js";
 import {
   getToolEntry,
   listToolDescriptors,
   normaliseArgs,
+  registerTool,
 } from "./registry.js";
+import { registerTestConnectionTool } from "./tools/auth/test_connection.js";
 
 // Read the package version from the package.json next to the dist
 // tree at startup, so a single source of truth (package.json) drives
@@ -49,6 +56,23 @@ function readPackageVersion(): string {
 }
 
 export async function startServer(): Promise<void> {
+  // Resolve the PAT and wire up the authed Octokit clients before
+  // registering any auth-aware tools. resolvePat() throws
+  // MissingPatError when no env var is set, which bubbles up to the
+  // bin shim (`dist/server.mjs`) so startup fails fast instead of
+  // partially initialising the server without authentication. The
+  // shim writes the message to stderr (prefixed with `mcp-github
+  // fatal:`) and exits non-zero — currently 1 for any startup error,
+  // including auth misses.
+  const pat = resolvePat();
+  const authedRequest = createAuthedRequest(pat);
+  // Pass `registerTool` in (rather than letting test_connection
+  // import it) so the dependency arrow is one-way:
+  // server.ts → tools/**, never tools/** → server.ts. Avoids the
+  // TDZ-prone cycle that would otherwise form once a tool registers
+  // at module-import time.
+  registerTestConnectionTool(registerTool, authedRequest);
+
   const server = new Server(
     {
       name: "@ctxr/mcp-github",

--- a/src/tools/auth/test_connection.ts
+++ b/src/tools/auth/test_connection.ts
@@ -19,7 +19,6 @@
 
 import { RequestError } from "@octokit/request-error";
 import type { AuthedRequest } from "../../auth/octokit.js";
-import { registerTool } from "../../server.js";
 
 const VIEWER_QUERY = "query { viewer { login } }";
 
@@ -33,12 +32,30 @@ interface ViewerGraphqlPayload {
   errors?: Array<{ message?: string }>;
 }
 
-// Exposed (rather than registered at module-import time) so the server
-// can pass in the resolved authed client. Tests can call `testConnection`
-// directly with a synthetic `AuthedRequest`, and the full registration
-// path is exercised in the smoke test against the built dist.
-export function registerTestConnectionTool(authedRequest: AuthedRequest): void {
-  registerTool("gh.test_connection", {
+// Shape of a tool-registry entry. Inlined here (rather than imported
+// from server.ts) so this module has no compile-time dependency on
+// the server module: server.ts → test_connection.ts is the only
+// import direction, which keeps the registry-loading sequence
+// linear at module-init time.
+interface ToolEntryShape {
+  description: string;
+  inputSchema: Record<string, unknown>;
+  handler: (args: Record<string, unknown>) => Promise<unknown>;
+}
+type RegisterToolFn = (name: string, entry: ToolEntryShape) => void;
+
+// Caller passes in `register` (typically server.ts's `registerTool`)
+// plus the resolved authed client. Decoupling the registration
+// callable from a static import breaks the would-be cycle where
+// server.ts imports this module while this module imports
+// `registerTool` back from server.ts. The same shape covers any
+// future "the tool registers itself" pattern without re-introducing
+// the cycle.
+export function registerTestConnectionTool(
+  register: RegisterToolFn,
+  authedRequest: AuthedRequest,
+): void {
+  register("gh.test_connection", {
     description:
       "Verify GitHub auth health. Runs `{ viewer { login } }` and " +
       "returns the authenticated user's login plus the OAuth scopes " +

--- a/src/tools/auth/test_connection.ts
+++ b/src/tools/auth/test_connection.ts
@@ -42,7 +42,10 @@ export function registerTestConnectionTool(authedRequest: AuthedRequest): void {
     description:
       "Verify GitHub auth health. Runs `{ viewer { login } }` and " +
       "returns the authenticated user's login plus the OAuth scopes " +
-      "attached to the resolved PAT.",
+      "advertised in the `x-oauth-scopes` response header. " +
+      "Note: `scopes` is `[]` for fine-grained PATs and most GitHub " +
+      "App tokens, where GitHub does not emit that header — an empty " +
+      "list means \"unknown\", not \"no scopes\".",
     inputSchema: {
       type: "object",
       properties: {},
@@ -83,9 +86,12 @@ export async function testConnection(
 }
 
 // `x-oauth-scopes` is a comma-separated list (e.g. "repo, read:org").
-// GitHub omits the header entirely for fine-grained PATs, in which case
-// we return an empty array; the consumer can still treat that as a
-// successful auth probe — login was returned, after all.
+// GitHub omits the header entirely for fine-grained PATs and most
+// GitHub App tokens, in which case we return an empty array. Auth is
+// still healthy in that case (login came back), but consumers must
+// not interpret `[]` as "the token has no permissions" — it means
+// "scope information is unavailable", not "scopes empty". The tool
+// description spells this out for callers.
 function parseScopes(headers: Record<string, unknown>): string[] {
   const raw = headers["x-oauth-scopes"];
   if (typeof raw !== "string") return [];

--- a/src/tools/auth/test_connection.ts
+++ b/src/tools/auth/test_connection.ts
@@ -19,6 +19,12 @@
 
 import { RequestError } from "@octokit/request-error";
 import type { AuthedRequest } from "../../auth/octokit.js";
+// Type-only import: erased at compile time, so it does NOT create
+// a runtime dependency on the registry module. We reuse the
+// canonical ToolEntry shape from `src/registry.ts` so tool typings
+// stay aligned with the registry contract; an inlined duplicate
+// would drift as soon as the registry's shape evolved.
+import type { ToolEntry } from "../../registry.js";
 
 const VIEWER_QUERY = "query { viewer { login } }";
 
@@ -32,25 +38,15 @@ interface ViewerGraphqlPayload {
   errors?: Array<{ message?: string }>;
 }
 
-// Shape of a tool-registry entry. Inlined here (rather than imported
-// from server.ts) so this module has no compile-time dependency on
-// the server module: server.ts → test_connection.ts is the only
-// import direction, which keeps the registry-loading sequence
-// linear at module-init time.
-interface ToolEntryShape {
-  description: string;
-  inputSchema: Record<string, unknown>;
-  handler: (args: Record<string, unknown>) => Promise<unknown>;
-}
-type RegisterToolFn = (name: string, entry: ToolEntryShape) => void;
+// Caller passes in the registration function (typically the
+// registry's `registerTool`) plus the resolved authed client.
+// Decoupling the registration callable from a static import keeps
+// the dependency arrow strictly server.ts → tools/**: tool modules
+// never import from server.ts at runtime, even transitively, which
+// avoids any TDZ trap if a future tool registers at module-import
+// time.
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
 
-// Caller passes in `register` (typically server.ts's `registerTool`)
-// plus the resolved authed client. Decoupling the registration
-// callable from a static import breaks the would-be cycle where
-// server.ts imports this module while this module imports
-// `registerTool` back from server.ts. The same shape covers any
-// future "the tool registers itself" pattern without re-introducing
-// the cycle.
 export function registerTestConnectionTool(
   register: RegisterToolFn,
   authedRequest: AuthedRequest,

--- a/src/tools/auth/test_connection.ts
+++ b/src/tools/auth/test_connection.ts
@@ -1,0 +1,120 @@
+// src/tools/auth/test_connection.ts
+//
+// `gh.test_connection` — verifies auth health by issuing a minimal
+// `{ viewer { login } }` GraphQL query and reading the OAuth scopes
+// from the response headers. Returns `{ login, scopes }` on success.
+//
+// Why a separate tool rather than wiring this into server bootstrap:
+// at v0.1 we want the server to start cleanly even when the PAT is
+// scope-limited, so callers can still discover the tool surface and
+// then explicitly probe auth via this tool. Crashing on startup would
+// leave consumers with no signal beyond "process exited".
+//
+// Why we go through `@octokit/request` (POST /graphql) here rather than
+// the higher-level `@octokit/graphql` client: `@octokit/graphql`
+// unwraps and returns just the `data` field, dropping response headers.
+// Scopes live in the `x-oauth-scopes` header, so we need the raw
+// response. From MCP-3 onwards every other tool uses the GraphQL
+// client; this one is the deliberate exception.
+
+import { RequestError } from "@octokit/request-error";
+import type { AuthedRequest } from "../../auth/octokit.js";
+import { registerTool } from "../../server.js";
+
+const VIEWER_QUERY = "query { viewer { login } }";
+
+export interface TestConnectionResult {
+  login: string;
+  scopes: string[];
+}
+
+interface ViewerGraphqlPayload {
+  data?: { viewer?: { login?: string } };
+  errors?: Array<{ message?: string }>;
+}
+
+// Exposed (rather than registered at module-import time) so the server
+// can pass in the resolved authed client. Tests can call `testConnection`
+// directly with a synthetic `AuthedRequest`, and the full registration
+// path is exercised in the smoke test against the built dist.
+export function registerTestConnectionTool(authedRequest: AuthedRequest): void {
+  registerTool("gh.test_connection", {
+    description:
+      "Verify GitHub auth health. Runs `{ viewer { login } }` and " +
+      "returns the authenticated user's login plus the OAuth scopes " +
+      "attached to the resolved PAT.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    handler: async () => testConnection(authedRequest),
+  });
+}
+
+export async function testConnection(
+  authedRequest: AuthedRequest,
+): Promise<TestConnectionResult> {
+  let response;
+  try {
+    response = await authedRequest("POST /graphql", { query: VIEWER_QUERY });
+  } catch (err) {
+    throw mapAuthError(err);
+  }
+
+  const payload = response.data as ViewerGraphqlPayload;
+  if (Array.isArray(payload.errors) && payload.errors.length > 0) {
+    const messages = payload.errors
+      .map((e) => e.message ?? "unknown")
+      .join("; ");
+    throw new Error(
+      `mcp-github: gh.test_connection: GraphQL errors from viewer query: ${messages}`,
+    );
+  }
+
+  const login = payload.data?.viewer?.login;
+  if (typeof login !== "string" || login.length === 0) {
+    throw new Error(
+      "mcp-github: gh.test_connection: viewer.login missing in GraphQL response",
+    );
+  }
+
+  return { login, scopes: parseScopes(response.headers) };
+}
+
+// `x-oauth-scopes` is a comma-separated list (e.g. "repo, read:org").
+// GitHub omits the header entirely for fine-grained PATs, in which case
+// we return an empty array; the consumer can still treat that as a
+// successful auth probe — login was returned, after all.
+function parseScopes(headers: Record<string, unknown>): string[] {
+  const raw = headers["x-oauth-scopes"];
+  if (typeof raw !== "string") return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+// Surface the auth-failure shapes that callers actually need to
+// distinguish (token wrong vs. token correct but missing scope) as a
+// structured Error rather than letting a raw RequestError stack-trace
+// bubble up through the MCP transport.
+function mapAuthError(err: unknown): Error {
+  if (err instanceof RequestError) {
+    if (err.status === 401) {
+      return new Error(
+        "mcp-github: gh.test_connection: 401 Unauthorized — token is missing, expired, or revoked",
+      );
+    }
+    if (err.status === 403) {
+      return new Error(
+        "mcp-github: gh.test_connection: 403 Forbidden — token rejected (insufficient scopes or rate-limited)",
+      );
+    }
+    return new Error(
+      `mcp-github: gh.test_connection: HTTP ${err.status} — ${err.message}`,
+    );
+  }
+  if (err instanceof Error) return err;
+  return new Error(`mcp-github: gh.test_connection: ${String(err)}`);
+}

--- a/src/tools/auth/test_connection.ts
+++ b/src/tools/auth/test_connection.ts
@@ -122,15 +122,26 @@ function parseScopes(headers: Record<string, unknown>): string[] {
 // distinguish (token wrong vs. token correct but missing scope) as a
 // structured Error rather than letting a raw RequestError stack-trace
 // bubble up through the MCP transport.
+//
+// We append the upstream RequestError message via `withDetail()`
+// because GitHub's 401/403 responses often carry useful context like
+// "SSO required", "API rate limit exceeded", or the specific scope
+// the token is missing. Dropping that on the floor would leave the
+// caller staring at a generic "401 Unauthorized" with no diagnostic
+// trail.
 function mapAuthError(err: unknown): Error {
   if (err instanceof RequestError) {
+    const detail =
+      typeof err.message === "string" ? err.message.trim() : "";
+    const withDetail = (message: string): Error =>
+      new Error(detail.length > 0 ? `${message} — upstream: ${detail}` : message);
     if (err.status === 401) {
-      return new Error(
+      return withDetail(
         "mcp-github: gh.test_connection: 401 Unauthorized — token is missing, expired, or revoked",
       );
     }
     if (err.status === 403) {
-      return new Error(
+      return withDetail(
         "mcp-github: gh.test_connection: 403 Forbidden — token rejected (insufficient scopes or rate-limited)",
       );
     }

--- a/tests/smoke/server-lists-tools.mjs
+++ b/tests/smoke/server-lists-tools.mjs
@@ -1,16 +1,22 @@
 #!/usr/bin/env node
-// tests/smoke/server-lists-zero-tools.mjs
+// tests/smoke/server-lists-tools.mjs
 //
 // End-to-end smoke test: spawn the freshly-built dist/server.mjs over
 // stdio, send the MCP `initialize` handshake + `tools/list`, assert
-// the server responds with an empty tools array. Proves at v0.1
-// bootstrap that the SDK wiring is correct end-to-end without
-// pulling in the full unit-test framework.
+// the registered tool surface (currently just `gh.test_connection`
+// from MCP-2). Proves the SDK wiring + auth bootstrap + tool
+// registration chain end-to-end without pulling in the unit-test
+// framework.
 //
 // Wire format: the MCP SDK's StdioServerTransport uses newline-
 // delimited JSON-RPC (one JSON message per `\n`-terminated line),
 // not LSP-style Content-Length framing. Confirmed in the SDK
 // source at @modelcontextprotocol/sdk/dist/esm/shared/stdio.js.
+//
+// Auth: the server runs `resolvePat()` at startup, so we inject a
+// fake `GITHUB_TOKEN`. The smoke test never *invokes* a tool — it
+// only asks the server to list its tools — so the fake token never
+// hits the network; it just satisfies the env-presence check.
 
 import { spawn } from "node:child_process";
 import { resolve, dirname } from "node:path";
@@ -18,6 +24,8 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SERVER = resolve(__dirname, "..", "..", "dist", "server.mjs");
+
+const EXPECTED_TOOLS = ["gh.test_connection"];
 
 function frame(payload) {
   // Newline-delimited JSON-RPC. JSON.stringify cannot emit a literal
@@ -50,6 +58,10 @@ function parseFrames(buffer) {
 
 const child = spawn(process.execPath, [SERVER], {
   stdio: ["pipe", "pipe", "inherit"],
+  env: {
+    ...process.env,
+    GITHUB_TOKEN: "ghp_smoke_test_fake_token",
+  },
 });
 
 let buffer = "";
@@ -91,10 +103,19 @@ child.stdout.on("data", (chunk) => {
       try {
         const { tools } = m.result;
         if (!Array.isArray(tools)) throw new Error("expected tools array");
-        if (tools.length !== 0) {
-          throw new Error(`expected 0 tools at v0.1 bootstrap, got ${tools.length}: ${tools.map((t) => t.name).join(", ")}`);
+        const names = tools.map((t) => t.name).sort();
+        const expected = [...EXPECTED_TOOLS].sort();
+        if (
+          names.length !== expected.length ||
+          names.some((n, i) => n !== expected[i])
+        ) {
+          throw new Error(
+            `expected tools ${JSON.stringify(expected)}, got ${JSON.stringify(names)}`,
+          );
         }
-        process.stdout.write("smoke: server lists 0 tools as expected\n");
+        process.stdout.write(
+          `smoke: server lists ${names.length} tool(s) as expected: ${names.join(", ")}\n`,
+        );
         clearTimeout(timeout);
         resolved = true;
         child.kill("SIGTERM");

--- a/tests/unit/auth/pat.test.ts
+++ b/tests/unit/auth/pat.test.ts
@@ -49,6 +49,19 @@ test("resolvePat: precedence — GITHUB_TOKEN beats GH_TOKEN beats GITHUB_PERSON
   assert.equal(resolvePat(env), "first");
 });
 
+test("resolvePat: skips whitespace-only values and trims real ones", () => {
+  // A whitespace-only env value is almost always a misconfigured CI
+  // secret; accepting it would surface as a confusing 401 from
+  // GitHub. We treat it as unset and fall through to the next slot.
+  // We also trim padding from real values so tokens copy-pasted with
+  // a trailing newline don't fail auth.
+  const env = syntheticEnv({
+    GITHUB_TOKEN: "   ",
+    GH_TOKEN: "  ghp_padded \n",
+  });
+  assert.equal(resolvePat(env), "ghp_padded");
+});
+
 test("resolvePat: skips empty-string values (treats them as unset)", () => {
   // CI runners frequently set GITHUB_TOKEN="" when no token is configured,
   // which would silently mask the GH_TOKEN fallback if we only checked

--- a/tests/unit/auth/pat.test.ts
+++ b/tests/unit/auth/pat.test.ts
@@ -1,0 +1,87 @@
+// tests/unit/auth/pat.test.ts
+//
+// Unit tests for `resolvePat()`. Exercise each fallback env var in
+// isolation, verify precedence when multiple are set, and confirm the
+// missing-everything path surfaces `MissingPatError` (not a generic
+// Error) so downstream callers can distinguish auth misconfig from a
+// runtime crash.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  resolvePat,
+  MissingPatError,
+  PAT_ENV_VARS,
+} from "../../../src/auth/pat.ts";
+
+// Build a synthetic env that matches the NodeJS.ProcessEnv shape the
+// resolver expects. Tests pass these in directly rather than mutating
+// `process.env`, which would race other tests in the same `node --test`
+// run.
+function syntheticEnv(
+  overrides: Partial<Record<string, string>>,
+): NodeJS.ProcessEnv {
+  return overrides as NodeJS.ProcessEnv;
+}
+
+test("resolvePat: GITHUB_TOKEN is the first-choice source", () => {
+  const env = syntheticEnv({ GITHUB_TOKEN: "ghp_one" });
+  assert.equal(resolvePat(env), "ghp_one");
+});
+
+test("resolvePat: falls back to GH_TOKEN when GITHUB_TOKEN is unset", () => {
+  const env = syntheticEnv({ GH_TOKEN: "ghp_two" });
+  assert.equal(resolvePat(env), "ghp_two");
+});
+
+test("resolvePat: falls back to GITHUB_PERSONAL_ACCESS_TOKEN as last resort", () => {
+  const env = syntheticEnv({ GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_three" });
+  assert.equal(resolvePat(env), "ghp_three");
+});
+
+test("resolvePat: precedence — GITHUB_TOKEN beats GH_TOKEN beats GITHUB_PERSONAL_ACCESS_TOKEN", () => {
+  const env = syntheticEnv({
+    GITHUB_TOKEN: "first",
+    GH_TOKEN: "second",
+    GITHUB_PERSONAL_ACCESS_TOKEN: "third",
+  });
+  assert.equal(resolvePat(env), "first");
+});
+
+test("resolvePat: skips empty-string values (treats them as unset)", () => {
+  // CI runners frequently set GITHUB_TOKEN="" when no token is configured,
+  // which would silently mask the GH_TOKEN fallback if we only checked
+  // for `undefined`.
+  const env = syntheticEnv({
+    GITHUB_TOKEN: "",
+    GH_TOKEN: "ghp_real",
+  });
+  assert.equal(resolvePat(env), "ghp_real");
+});
+
+test("resolvePat: throws MissingPatError listing every checked env var when none set", () => {
+  const env = syntheticEnv({});
+  assert.throws(
+    () => resolvePat(env),
+    (err: unknown) => {
+      assert.ok(err instanceof MissingPatError);
+      // Spot-check that the message names every fallback so a developer
+      // hitting this in the wild knows exactly which envs to set.
+      for (const v of PAT_ENV_VARS) {
+        assert.match((err as Error).message, new RegExp(v));
+      }
+      return true;
+    },
+  );
+});
+
+test("PAT_ENV_VARS: declares the canonical fallback chain in priority order", () => {
+  // Pin the contract so any future re-ordering shows up as a test
+  // change rather than a silent behavioural drift.
+  assert.deepEqual(PAT_ENV_VARS, [
+    "GITHUB_TOKEN",
+    "GH_TOKEN",
+    "GITHUB_PERSONAL_ACCESS_TOKEN",
+  ]);
+});

--- a/tests/unit/tools/auth/test_connection.test.ts
+++ b/tests/unit/tools/auth/test_connection.test.ts
@@ -1,0 +1,132 @@
+// tests/unit/tools/auth/test_connection.test.ts
+//
+// Unit tests for the `gh.test_connection` handler. We exercise the
+// handler in isolation (not via the registerTool / MCP transport path,
+// which the smoke test covers end-to-end) by feeding it a synthetic
+// `AuthedRequest` that returns whatever shape we want for the case
+// under test.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { RequestError } from "@octokit/request-error";
+
+import { testConnection } from "../../../../src/tools/auth/test_connection.ts";
+import type { AuthedRequest } from "../../../../src/auth/octokit.ts";
+
+interface StubResponse {
+  data: unknown;
+  headers: Record<string, string>;
+  status?: number;
+}
+
+// Octokit's `request` type is a callable with overloads + `defaults` +
+// `endpoint` properties. For unit tests we only invoke the call shape,
+// so we cast a minimal stub to the full type. The cast is annotated
+// so a future change that makes the test rely on the heavier surface
+// (e.g. `endpoint`) breaks here loudly.
+function stubAuthedRequest(
+  fn: (route: string, opts: Record<string, unknown>) => Promise<StubResponse>,
+): AuthedRequest {
+  return fn as unknown as AuthedRequest;
+}
+
+function stubReject(err: unknown): AuthedRequest {
+  return stubAuthedRequest(() => Promise.reject(err));
+}
+
+function buildRequestError(status: number): RequestError {
+  // The constructor takes a message + status + opts containing the
+  // originating RequestOptions. We pass a minimal route since this
+  // error never actually flows back through Octokit.
+  return new RequestError(`HTTP ${status}`, status, {
+    request: {
+      method: "POST",
+      url: "https://api.github.com/graphql",
+      headers: {},
+    },
+  });
+}
+
+test("testConnection: returns login + parsed scopes on a healthy response", async () => {
+  const stub = stubAuthedRequest(async (route, opts) => {
+    assert.equal(route, "POST /graphql");
+    assert.equal(
+      (opts as { query?: string }).query,
+      "query { viewer { login } }",
+    );
+    return {
+      data: { data: { viewer: { login: "alice" } } },
+      headers: { "x-oauth-scopes": "repo, read:org, workflow" },
+    };
+  });
+  const result = await testConnection(stub);
+  assert.deepEqual(result, {
+    login: "alice",
+    scopes: ["repo", "read:org", "workflow"],
+  });
+});
+
+test("testConnection: empty scopes when x-oauth-scopes header is missing (fine-grained PAT)", async () => {
+  // Fine-grained PATs and some GitHub App installations don't emit
+  // `x-oauth-scopes` at all. That's still a valid auth probe — we
+  // got `viewer.login` back — so we return scopes: [].
+  const stub = stubAuthedRequest(async () => ({
+    data: { data: { viewer: { login: "bob" } } },
+    headers: {},
+  }));
+  const result = await testConnection(stub);
+  assert.deepEqual(result, { login: "bob", scopes: [] });
+});
+
+test("testConnection: tolerates whitespace-only entries in the scopes header", async () => {
+  const stub = stubAuthedRequest(async () => ({
+    data: { data: { viewer: { login: "carol" } } },
+    headers: { "x-oauth-scopes": "repo,  ,read:user" },
+  }));
+  const result = await testConnection(stub);
+  assert.deepEqual(result.scopes, ["repo", "read:user"]);
+});
+
+test("testConnection: throws structured 401 error when token is unauthorized", async () => {
+  const stub = stubReject(buildRequestError(401));
+  await assert.rejects(testConnection(stub), /401 Unauthorized/);
+});
+
+test("testConnection: throws structured 403 error when token is forbidden", async () => {
+  const stub = stubReject(buildRequestError(403));
+  await assert.rejects(testConnection(stub), /403 Forbidden/);
+});
+
+test("testConnection: surfaces other HTTP statuses with the status code preserved", async () => {
+  const stub = stubReject(buildRequestError(502));
+  await assert.rejects(testConnection(stub), /HTTP 502/);
+});
+
+test("testConnection: throws when GraphQL response carries errors", async () => {
+  const stub = stubAuthedRequest(async () => ({
+    data: {
+      data: null,
+      errors: [{ message: "Bad credentials" }],
+    },
+    headers: {},
+  }));
+  await assert.rejects(testConnection(stub), /Bad credentials/);
+});
+
+test("testConnection: throws when viewer.login is missing", async () => {
+  // Defensive: GitHub has been known to return `data: { viewer: null }`
+  // for tokens with no user context (e.g. some installation tokens).
+  // We treat that as a misconfiguration rather than letting the
+  // empty-string login propagate to consumers.
+  const stub = stubAuthedRequest(async () => ({
+    data: { data: { viewer: null } },
+    headers: {},
+  }));
+  await assert.rejects(testConnection(stub), /viewer\.login missing/);
+});
+
+test("testConnection: passes through non-RequestError errors unchanged shape", async () => {
+  const original = new Error("network exploded");
+  const stub = stubReject(original);
+  await assert.rejects(testConnection(stub), /network exploded/);
+});


### PR DESCRIPTION
## Summary

Reopened against main after the bootstrap PR (#16) merged. Same content as the previously-clean PR #17 (auto-closed when its base branch was deleted), now rebased onto main.

- `src/auth/pat.ts`: `resolvePat()` walks the `GITHUB_TOKEN` → `GH_TOKEN` → `GITHUB_PERSONAL_ACCESS_TOKEN` env-var chain (matching `gh` CLI). Misses surface as `MissingPatError` (with frozen `checkedEnv` metadata for diagnostics). Whitespace-only values are treated as unset; real values are returned trimmed.
- `src/auth/octokit.ts`: builds an authed `@octokit/graphql` client (canonical caller for future tools) and an `@octokit/request` client (used by `gh.test_connection` to read `x-oauth-scopes` from response headers, which the graphql wrapper drops).
- `src/tools/auth/test_connection.ts`: implements `gh.test_connection`. Runs `{ viewer { login } }`, returns `{ login, scopes }`, and maps 401/403/other `RequestError` shapes to a structured handler error that preserves the upstream message (`— upstream: <detail>`) so SSO / rate-limit / scope-missing diagnostics aren't dropped.
- Wires PAT resolution + tool registration into `startServer()` via the imported `registerTool` from the registry module. The bin shim writes "mcp-github fatal: <reason>" to stderr and exits non-zero on any startup error, including `MissingPatError`.
- `scripts/run-tests.mjs`: cross-platform unit/integration test runner. Walks the test directory via `fs.readdir({ recursive: true })` and hands the paths to a child `node --test`. Replaces the previous bash-globstar script so the test commands work identically on Windows. Has a `child.on("error", ...)` handler for clean script-level failure on spawn errors (EACCES, missing executable, etc.).
- `tests/smoke/server-lists-tools.mjs`: renamed from `server-lists-zero-tools.mjs`, now asserts the registered tool surface (`gh.test_connection` only at MCP-2). Injects a fake `GITHUB_TOKEN` so the env-presence check is satisfied.

## Test plan

- [x] `npm run lint` (tsc --noEmit on both src and tests configs) clean
- [x] `npm run build` produces `dist/server.mjs` (shim) + `dist/server.js` (importable) + the auth/tool tree
- [x] `npm test` — 29/29 unit tests pass via the cross-platform `scripts/run-tests.mjs` runner
- [x] `node tests/smoke/server-lists-tools.mjs` — server boots with fake token, lists `gh.test_connection` exactly
- [x] Eight rounds of Copilot review on the predecessor PR #17, all converged clean before that PR was auto-closed by the #16 merge
- [ ] Live integration probe (`gh.test_connection` against a real token) lands later in MCP-12

## Stack

Second in the stacked sequence: **MCP-1 (#16, merged) → MCP-2 (this) → MCP-3 (#18)**.

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)