### PR TITLE
feat: GraphQL client + query loader + rate-limit handling (MCP-3)

### DIFF
--- a/scripts/post-build.mjs
+++ b/scripts/post-build.mjs
@@ -29,6 +29,7 @@ import {
   writeFileSync,
   chmodSync,
   cpSync,
+  rmSync,
   existsSync,
 } from "node:fs";
 import { resolve, dirname } from "node:path";
@@ -86,8 +87,16 @@ chmodSync(mjsPath, 0o755);
 // from `src/**/*.ts` and does not see `.graphql` text files; without
 // this copy step the production build would ship a package whose
 // graphql client cannot find any of its queries.
+//
+// We `rmSync` the destination tree before copying so deletions in
+// `src/graphql/queries/**` propagate. cpSync alone is union-merge: a
+// query file removed from `src` would otherwise linger in `dist`
+// across incremental builds and remain discoverable by
+// `loadAllQueries()` in production. tsc never wipes `dist/`, so this
+// is the only place that catches the deletion.
 const queriesSrc = resolve(repoRoot, "src", "graphql", "queries");
 const queriesDst = resolve(distRoot, "graphql", "queries");
+rmSync(queriesDst, { recursive: true, force: true });
 if (existsSync(queriesSrc)) {
   cpSync(queriesSrc, queriesDst, { recursive: true });
 }

--- a/scripts/post-build.mjs
+++ b/scripts/post-build.mjs
@@ -25,12 +25,18 @@
 // script) means the wrapper + chmod treatment is testable and the
 // build command stays a single tsc call.
 
-import { writeFileSync, chmodSync } from "node:fs";
+import {
+  writeFileSync,
+  chmodSync,
+  cpSync,
+  existsSync,
+} from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const distRoot = resolve(__dirname, "..", "dist");
+const repoRoot = resolve(__dirname, "..");
+const distRoot = resolve(repoRoot, "dist");
 const mjsPath = resolve(distRoot, "server.mjs");
 
 // The direct-run guard compares the canonical filesystem path of
@@ -73,5 +79,17 @@ writeFileSync(mjsPath, SHIM);
 // execute it directly on POSIX. Windows ignores the bit; npm rewrites
 // the bin shim to a .cmd file at install time anyway.
 chmodSync(mjsPath, 0o755);
+
+// Copy the GraphQL query files into the dist tree so the runtime
+// loader (src/graphql/queries.ts) can resolve them next to the
+// compiled `dist/graphql/client.js`. tsc itself only emits .js/.d.ts
+// from `src/**/*.ts` and does not see `.graphql` text files; without
+// this copy step the production build would ship a package whose
+// graphql client cannot find any of its queries.
+const queriesSrc = resolve(repoRoot, "src", "graphql", "queries");
+const queriesDst = resolve(distRoot, "graphql", "queries");
+if (existsSync(queriesSrc)) {
+  cpSync(queriesSrc, queriesDst, { recursive: true });
+}
 
 process.stdout.write(`mcp-github: dist/server.mjs ready\n`);

--- a/src/graphql/client.ts
+++ b/src/graphql/client.ts
@@ -1,0 +1,124 @@
+// src/graphql/client.ts
+//
+// Thin GraphQL client used by every domain tool from MCP-4 onwards.
+// It is a wrapper around `@octokit/request` (POST /graphql) rather
+// than `@octokit/graphql` because we need the response headers
+// (rate-limit + abuse-detection signals) that the higher-level
+// graphql client unwraps and discards.
+//
+// The public surface is a single function:
+//
+//     const graphql = createGraphqlClient(authedRequest);
+//     const data = await graphql<ResponseShape>("queries/group/name", { vars });
+//
+// Errors are mapped onto three structured classes (see ./errors.ts):
+//   - GraphqlError (response carries an `errors[]` array)
+//   - RateLimitExhaustedError (X-RateLimit-Remaining hit zero)
+//   - AbuseDetectionError (HTTP 403 + x-secondary-rate-limit)
+//
+// Anything else (network failures, 5xx, auth failures) falls through
+// as the underlying RequestError, so callers can still match on it.
+
+import { RequestError } from "@octokit/request-error";
+import type { AuthedRequest } from "../auth/octokit.js";
+import {
+  GraphqlError,
+  AbuseDetectionError,
+  type GraphqlErrorEntry,
+} from "./errors.js";
+import { enforceRateLimit } from "./rate_limit.js";
+import { loadQuery } from "./queries.js";
+
+interface GraphqlResponseBody<T> {
+  data?: T;
+  errors?: GraphqlErrorEntry[];
+}
+
+export type GraphqlClient = <T = unknown>(
+  queryName: string,
+  vars?: Record<string, unknown>,
+) => Promise<T>;
+
+export interface CreateGraphqlClientOptions {
+  // Custom warn sink, primarily for tests. Defaults to writing to
+  // stderr. Provided as an option (rather than a top-level monkey
+  // patch) so server boot can wire in a structured logger later
+  // without rewriting client internals.
+  warn?: (msg: string) => void;
+}
+
+export function createGraphqlClient(
+  authedRequest: AuthedRequest,
+  options: CreateGraphqlClientOptions = {},
+): GraphqlClient {
+  const warn = options.warn;
+  return async function graphql<T = unknown>(
+    queryName: string,
+    vars: Record<string, unknown> = {},
+  ): Promise<T> {
+    const query = await loadQuery(queryName);
+
+    let response;
+    try {
+      response = await authedRequest("POST /graphql", {
+        query,
+        variables: vars,
+      });
+    } catch (err) {
+      throw mapRequestError(err);
+    }
+
+    // Run rate-limit policy against the response headers. We do this
+    // *before* checking the GraphQL `errors[]` payload so a
+    // rate-limit response (which can sometimes also carry errors)
+    // surfaces as the more actionable RateLimitExhaustedError.
+    enforceRateLimit(
+      response.headers as Record<string, unknown>,
+      warn,
+    );
+
+    const body = response.data as GraphqlResponseBody<T>;
+    if (Array.isArray(body.errors) && body.errors.length > 0) {
+      throw new GraphqlError(body.errors);
+    }
+    if (body.data === undefined) {
+      throw new Error(
+        `mcp-github: GraphQL query '${queryName}' returned no data field`,
+      );
+    }
+    return body.data;
+  };
+}
+
+function mapRequestError(err: unknown): Error {
+  if (err instanceof RequestError) {
+    // GitHub's secondary rate limit ("abuse detection") arrives as a
+    // 403 with `x-secondary-rate-limit: true`. The retry-after value
+    // can land in either `retry-after` (seconds) or be missing — when
+    // missing we use 60s as a conservative floor that matches GitHub's
+    // own backoff guidance.
+    if (err.status === 403 && isSecondaryRateLimit(err)) {
+      const retryAfter = readRetryAfter(err) ?? 60;
+      return new AbuseDetectionError(retryAfter);
+    }
+  }
+  return err instanceof Error ? err : new Error(String(err));
+}
+
+function isSecondaryRateLimit(err: RequestError): boolean {
+  const headers = err.response?.headers as Record<string, unknown> | undefined;
+  if (!headers) return false;
+  const v = headers["x-secondary-rate-limit"];
+  return v === "true" || v === true;
+}
+
+function readRetryAfter(err: RequestError): number | undefined {
+  const headers = err.response?.headers as Record<string, unknown> | undefined;
+  const raw = headers?.["retry-after"];
+  if (typeof raw === "string") {
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : undefined;
+  }
+  if (typeof raw === "number") return raw;
+  return undefined;
+}

--- a/src/graphql/client.ts
+++ b/src/graphql/client.ts
@@ -127,10 +127,16 @@ function isSecondaryRateLimit(err: RequestError): boolean {
 function readRetryAfter(err: RequestError): number | undefined {
   const headers = err.response?.headers as Record<string, unknown> | undefined;
   const raw = headers?.["retry-after"];
-  if (typeof raw === "string") {
-    const n = Number(raw);
-    return Number.isFinite(n) ? n : undefined;
-  }
-  if (typeof raw === "number") return raw;
+  // Keep the parsed value only if it's finite AND non-negative. The
+  // numeric branch was previously trusted as-is, which let `NaN` or
+  // `Infinity` bypass the call-site `?? 60` fallback and produce
+  // an AbuseDetectionError with an unusable retryAfterSeconds value.
+  const n =
+    typeof raw === "string"
+      ? Number(raw)
+      : typeof raw === "number"
+        ? raw
+        : NaN;
+  if (Number.isFinite(n) && n >= 0) return n;
   return undefined;
 }

--- a/src/graphql/client.ts
+++ b/src/graphql/client.ts
@@ -9,7 +9,12 @@
 // The public surface is a single function:
 //
 //     const graphql = createGraphqlClient(authedRequest);
-//     const data = await graphql<ResponseShape>("queries/group/name", { vars });
+//     const data = await graphql<ResponseShape>("group/name", { vars });
+//
+// The query name is the file path under `src/graphql/queries/` minus
+// the `.graphql` suffix (e.g. `_health/viewer` → loads
+// `src/graphql/queries/_health/viewer.graphql`). It does NOT include
+// a leading `queries/` segment.
 //
 // Errors are mapped onto three structured classes (see ./errors.ts):
 //   - GraphqlError (response carries an `errors[]` array)

--- a/src/graphql/client.ts
+++ b/src/graphql/client.ts
@@ -77,10 +77,17 @@ export function createGraphqlClient(
     // *before* checking the GraphQL `errors[]` payload so a
     // rate-limit response (which can sometimes also carry errors)
     // surfaces as the more actionable RateLimitExhaustedError.
-    enforceRateLimit(
-      response.headers as Record<string, unknown>,
-      warn,
-    );
+    //
+    // Branch on the optional warn explicitly. Passing `undefined` to
+    // a parameter with a default works at runtime, but under
+    // exactOptionalPropertyTypes the call-site spelling matters: the
+    // two-arg form requires a definite function, so we only take it
+    // when the caller actually supplied one.
+    if (warn !== undefined) {
+      enforceRateLimit(response.headers as Record<string, unknown>, warn);
+    } else {
+      enforceRateLimit(response.headers as Record<string, unknown>);
+    }
 
     const body = response.data as GraphqlResponseBody<T>;
     if (Array.isArray(body.errors) && body.errors.length > 0) {

--- a/src/graphql/errors.ts
+++ b/src/graphql/errors.ts
@@ -1,0 +1,59 @@
+// src/graphql/errors.ts
+//
+// Structured error classes for the GraphQL client. Each one preserves
+// the GitHub-side signal a consumer would actually use to decide
+// behaviour:
+//
+//   - GraphqlError carries the response's `errors[]` shape so callers
+//     can branch on `type` ("NOT_FOUND", "FORBIDDEN", etc.).
+//   - RateLimitExhaustedError carries the reset epoch so a polling
+//     consumer knows when to retry.
+//   - AbuseDetectionError carries the `retry-after` seconds (or 60 as
+//     a safe default) for the same reason.
+//
+// All three extend Error so the MCP transport's default surface
+// (stack trace + message) still works. Subclassing also lets unit
+// tests use `instanceof` rather than parsing message strings.
+
+export interface GraphqlErrorEntry {
+  type?: string;
+  message?: string;
+  path?: ReadonlyArray<string | number>;
+}
+
+export class GraphqlError extends Error {
+  override readonly name = "GraphqlError";
+  readonly errors: readonly GraphqlErrorEntry[];
+  constructor(errors: readonly GraphqlErrorEntry[]) {
+    const summary = errors
+      .map((e) => `${e.type ?? "ERROR"}: ${e.message ?? "unknown"}`)
+      .join("; ");
+    super(`mcp-github: GraphQL response errors: ${summary}`);
+    this.errors = errors;
+  }
+}
+
+export class RateLimitExhaustedError extends Error {
+  override readonly name = "RateLimitExhaustedError";
+  readonly resetAt: number; // unix epoch seconds, from X-RateLimit-Reset
+  readonly limit: number;
+  constructor(resetAt: number, limit: number) {
+    super(
+      `mcp-github: GraphQL rate limit exhausted (limit=${limit}, ` +
+        `resetAt=${new Date(resetAt * 1000).toISOString()})`,
+    );
+    this.resetAt = resetAt;
+    this.limit = limit;
+  }
+}
+
+export class AbuseDetectionError extends Error {
+  override readonly name = "AbuseDetectionError";
+  readonly retryAfterSeconds: number;
+  constructor(retryAfterSeconds: number) {
+    super(
+      `mcp-github: GraphQL secondary rate limit hit (retry after ${retryAfterSeconds}s)`,
+    );
+    this.retryAfterSeconds = retryAfterSeconds;
+  }
+}

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -22,7 +22,7 @@
 // pipeline working?" smoke target and is exercised by the unit tests.
 
 import { readFile, readdir } from "node:fs/promises";
-import { resolve, dirname, relative } from "node:path";
+import { resolve, dirname, relative, isAbsolute } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -104,8 +104,14 @@ async function readQueryFile(name: string): Promise<string> {
   // come from server-side code (not user input), but the registry
   // is also conceptually a public API; preventing escape from the
   // queries root keeps the surface honest.
+  //
+  // The `isAbsolute(rel)` check is the Windows-cross-drive case: when
+  // `abs` lives on a different drive than `QUERIES_ROOT`,
+  // `path.relative()` returns an absolute path (e.g. `D:\\...`)
+  // rather than a `..`-prefixed relative one. Just checking the
+  // `..` / `/` prefixes would let that through.
   const rel = relative(QUERIES_ROOT, abs);
-  if (rel.startsWith("..") || rel.startsWith("/")) {
+  if (rel.startsWith("..") || rel.startsWith("/") || isAbsolute(rel)) {
     throw new Error(
       `mcp-github: query name '${name}' escapes queries root`,
     );

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -1,0 +1,133 @@
+// src/graphql/queries.ts
+//
+// Query loader. Resolves a query name like `auth/viewer` to the
+// contents of the matching `.graphql` file under
+// `src/graphql/queries/<group>/<name>.graphql` (or the parallel path
+// in dist after build). Names are deliberately path-shaped so the
+// directory layout is also the registry: a new query is just a new
+// file, no central manifest to update.
+//
+// Caching policy:
+//
+//   - production (NODE_ENV === "production"): the first call eagerly
+//     loads every query in the queries directory and caches it. Later
+//     calls hit the cache.
+//   - development (anything else): each call re-reads the file from
+//     disk so editing a `.graphql` file produces immediate feedback
+//     without restarting the server.
+//
+// At v0.1 the queries directory is intentionally near-empty: queries
+// land alongside the tools that consume them (MCP-4 onwards). The
+// `_health/viewer.graphql` placeholder is the canonical "is the
+// pipeline working?" smoke target and is exercised by the unit tests.
+
+import { readFile, readdir } from "node:fs/promises";
+import { resolve, dirname, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const QUERIES_ROOT = resolve(HERE, "queries");
+
+// Module-level cache keyed by canonical query name (e.g. `_health/viewer`).
+// Only populated under production. In dev we bypass this entirely so
+// HMR-style edits surface without a process restart.
+const cache = new Map<string, string>();
+let initialized = false;
+
+function isProduction(): boolean {
+  return process.env["NODE_ENV"] === "production";
+}
+
+export async function loadQuery(name: string): Promise<string> {
+  if (!isProduction()) {
+    return readQueryFile(name);
+  }
+  if (!initialized) {
+    await loadAllQueries();
+  }
+  const cached = cache.get(name);
+  if (typeof cached !== "string") {
+    throw new Error(
+      `mcp-github: unknown GraphQL query '${name}'. ` +
+        `Looked under ${QUERIES_ROOT}.`,
+    );
+  }
+  return cached;
+}
+
+// Eagerly populate the cache. Exposed for tests + for the server
+// startup path that wants to fail fast if the queries directory is
+// malformed (rather than at first tool call).
+export async function loadAllQueries(): Promise<ReadonlyMap<string, string>> {
+  cache.clear();
+  let entries: string[];
+  try {
+    entries = await readdir(QUERIES_ROOT, { recursive: true });
+  } catch (err) {
+    if (isErrnoNotFound(err)) {
+      // No queries directory at all — happens on a fresh checkout
+      // before any query files have been added. Cache stays empty;
+      // any loadQuery() call will then throw the "unknown query"
+      // error, which is the right signal.
+      initialized = true;
+      return cache;
+    }
+    throw err;
+  }
+  for (const entry of entries) {
+    if (!entry.endsWith(".graphql")) continue;
+    const abs = resolve(QUERIES_ROOT, entry);
+    const name = entry
+      .slice(0, -".graphql".length)
+      // Normalise Windows backslashes to forward slashes in the
+      // canonical name so queries resolve identically across platforms.
+      .replace(/\\/g, "/");
+    const contents = await readFile(abs, "utf8");
+    cache.set(name, contents);
+  }
+  initialized = true;
+  return cache;
+}
+
+// Test-only hook: drop the cached state so a fresh `loadAllQueries`
+// re-reads the directory. Not exported through the public surface,
+// but kept on a separate function so tests can grab it via the
+// module's internal namespace if needed.
+export function _resetQueryCache(): void {
+  cache.clear();
+  initialized = false;
+}
+
+async function readQueryFile(name: string): Promise<string> {
+  const abs = resolve(QUERIES_ROOT, `${name}.graphql`);
+  // Defence-in-depth against `..`-traversal in query names. Names
+  // come from server-side code (not user input), but the registry
+  // is also conceptually a public API; preventing escape from the
+  // queries root keeps the surface honest.
+  const rel = relative(QUERIES_ROOT, abs);
+  if (rel.startsWith("..") || rel.startsWith("/")) {
+    throw new Error(
+      `mcp-github: query name '${name}' escapes queries root`,
+    );
+  }
+  try {
+    return await readFile(abs, "utf8");
+  } catch (err) {
+    if (isErrnoNotFound(err)) {
+      throw new Error(
+        `mcp-github: unknown GraphQL query '${name}'. ` +
+          `Looked at ${abs}.`,
+      );
+    }
+    throw err;
+  }
+}
+
+function isErrnoNotFound(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code?: unknown }).code === "ENOENT"
+  );
+}

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -22,7 +22,7 @@
 // pipeline working?" smoke target and is exercised by the unit tests.
 
 import { readFile, readdir } from "node:fs/promises";
-import { resolve, dirname, relative, isAbsolute } from "node:path";
+import { resolve, dirname, relative, isAbsolute, posix } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -72,14 +72,15 @@ function isProduction(): boolean {
 }
 
 export async function loadQuery(name: string): Promise<string> {
-  // Normalise the caller-supplied name so dev and prod resolve
-  // identically. Internal `populateCache()` already converts file
-  // paths from backslashes to forward slashes when indexing on
-  // Windows; doing the same here means a caller passing
-  // `_health\viewer` works in both modes (dev resolves via the
-  // filesystem, prod looks up the canonical key) instead of dev
-  // succeeding silently and prod throwing "unknown query".
-  const canonical = name.replace(/\\/g, "/");
+  // Normalise the caller-supplied name to the canonical posix
+  // shape: convert backslashes to forward slashes, then collapse
+  // ".", "..", and duplicate slashes via posix.normalize. Without
+  // this, dev (which goes through the filesystem and benefits from
+  // path.resolve's own normalisation) would happily resolve names
+  // like `x/../_health/viewer` while prod (a literal cache lookup
+  // by string key) would miss. Both paths now agree on the same
+  // canonical key shape.
+  const canonical = canonicaliseQueryName(name);
   if (!isProduction()) {
     return readQueryFile(canonical);
   }
@@ -96,6 +97,29 @@ export async function loadQuery(name: string): Promise<string> {
     );
   }
   return cached;
+}
+
+// Posix-normalise a query name and reject any form that would
+// escape the queries root. Shared by both the dev and prod paths
+// so the canonical key shape is identical end-to-end.
+function canonicaliseQueryName(name: string): string {
+  const slashified = name.replace(/\\/g, "/");
+  // posix.normalize collapses "./" and "..", drops duplicate
+  // slashes, and is idempotent — exactly the contract we want for
+  // a cache key. It does keep leading ".." segments though, so we
+  // still need the explicit escape check below.
+  const normalized = posix.normalize(slashified);
+  if (
+    normalized.startsWith("..") ||
+    normalized.startsWith("/") ||
+    normalized.length === 0 ||
+    normalized === "."
+  ) {
+    throw new Error(
+      `mcp-github: query name '${name}' escapes queries root or resolves to empty`,
+    );
+  }
+  return normalized;
 }
 
 // Eagerly populate the cache. Exposed for tests + for the server

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -34,7 +34,19 @@ const QUERIES_ROOT = resolve(HERE, "queries");
 const cache = new Map<string, string>();
 let initialized = false;
 
+// Test-only override for the dev/prod switch. Node's test runner
+// executes tests concurrently by default, so the production-cache-path
+// test flipping `process.env.NODE_ENV` directly would race other
+// tests in this file (and conflict with the repo's stated approach of
+// not mutating process.env in tests). The override is module-scoped
+// and reset alongside the cache by `_resetQueryCache()`.
+let productionOverride: boolean | undefined;
+export function _setProductionOverride(value: boolean | undefined): void {
+  productionOverride = value;
+}
+
 function isProduction(): boolean {
+  if (productionOverride !== undefined) return productionOverride;
   return process.env["NODE_ENV"] === "production";
 }
 
@@ -90,12 +102,14 @@ export async function loadAllQueries(): Promise<ReadonlyMap<string, string>> {
 }
 
 // Test-only hook: drop the cached state so a fresh `loadAllQueries`
-// re-reads the directory. Not exported through the public surface,
-// but kept on a separate function so tests can grab it via the
-// module's internal namespace if needed.
+// re-reads the directory. Also clears the production-mode override so
+// each test starts in dev mode unless it explicitly opts in. Not
+// exported through the public surface, but kept on a separate function
+// so tests can grab it via the module's internal namespace if needed.
 export function _resetQueryCache(): void {
   cache.clear();
   initialized = false;
+  productionOverride = undefined;
 }
 
 async function readQueryFile(name: string): Promise<string> {

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -29,9 +29,13 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 const QUERIES_ROOT = resolve(HERE, "queries");
 
 // Module-level cache keyed by canonical query name (e.g. `_health/viewer`).
-// Only populated under production. In dev we bypass this entirely so
-// HMR-style edits surface without a process restart.
-const cache = new Map<string, string>();
+// Populated by `loadAllQueries()` / `ensureInitialized()`. In production
+// `loadQuery` reads from this cache. In development `loadQuery`
+// bypasses it and re-reads from disk per call so HMR-style edits
+// surface without a process restart, but `loadAllQueries()` (used by
+// the unit tests and the prod startup-validation path) still
+// populates the cache regardless of mode.
+let cache = new Map<string, string>();
 
 // Single shared init promise so concurrent loadQuery() calls don't
 // each kick off their own loadAllQueries() and fight over the shared
@@ -68,18 +72,26 @@ function isProduction(): boolean {
 }
 
 export async function loadQuery(name: string): Promise<string> {
+  // Normalise the caller-supplied name so dev and prod resolve
+  // identically. Internal `populateCache()` already converts file
+  // paths from backslashes to forward slashes when indexing on
+  // Windows; doing the same here means a caller passing
+  // `_health\viewer` works in both modes (dev resolves via the
+  // filesystem, prod looks up the canonical key) instead of dev
+  // succeeding silently and prod throwing "unknown query".
+  const canonical = name.replace(/\\/g, "/");
   if (!isProduction()) {
-    return readQueryFile(name);
+    return readQueryFile(canonical);
   }
   // ensureInitialized routes every concurrent caller through the same
   // promise. After it resolves the cache is populated and we can
   // serve all subsequent loadQuery calls in O(1) without ever
   // touching the filesystem.
   await ensureInitialized();
-  const cached = cache.get(name);
+  const cached = cache.get(canonical);
   if (typeof cached !== "string") {
     throw new Error(
-      `mcp-github: unknown GraphQL query '${name}'. ` +
+      `mcp-github: unknown GraphQL query '${canonical}'. ` +
         `Looked under ${QUERIES_ROOT}.`,
     );
   }
@@ -118,20 +130,23 @@ function ensureInitialized(): Promise<ReadonlyMap<string, string>> {
 }
 
 async function populateCache(): Promise<ReadonlyMap<string, string>> {
-  // We don't `cache.clear()` here: under the shared-promise pattern
-  // there is exactly one populateCache call per cache lifetime, and
-  // a clear+rebuild would be a footgun if a future change ever
-  // triggers populateCache mid-read.
+  // Build into a fresh Map and swap it in on success. If a partial
+  // populate fails midway (transient FS read error), the swap never
+  // happens and `cache` keeps its previous state — there is no
+  // "stale half-populated" mid-state visible to readers, and a
+  // retry starts from a clean slate.
+  const next = new Map<string, string>();
   let entries: string[];
   try {
     entries = await readdir(QUERIES_ROOT, { recursive: true });
   } catch (err) {
     if (isErrnoNotFound(err)) {
       // No queries directory at all — happens on a fresh checkout
-      // before any query files have been added. Cache stays empty;
-      // any loadQuery() call will then throw the "unknown query"
-      // error, which is the right signal.
-      return cache;
+      // before any query files have been added. Swap in the empty
+      // map so subsequent `loadQuery()` calls observe the absence
+      // (they'll throw "unknown query", which is the right signal).
+      cache = next;
+      return next;
     }
     throw err;
   }
@@ -145,9 +160,12 @@ async function populateCache(): Promise<ReadonlyMap<string, string>> {
       .replace(/\\/g, "/");
     const contents = await readFile(abs, "utf8");
     diskReadCount += 1;
-    cache.set(name, contents);
+    next.set(name, contents);
   }
-  return cache;
+  // Atomic swap on success: prior cache contents are replaced
+  // wholesale, so deletions in the queries directory propagate.
+  cache = next;
+  return next;
 }
 
 // Test-only hook: drop the cached state so a fresh init re-reads
@@ -156,7 +174,7 @@ async function populateCache(): Promise<ReadonlyMap<string, string>> {
 // exported through the public surface, but kept on a separate function
 // so tests can grab it via the module's internal namespace if needed.
 export function _resetQueryCache(): void {
-  cache.clear();
+  cache = new Map<string, string>();
   initPromise = null;
   productionOverride = undefined;
   diskReadCount = 0;

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -97,10 +97,24 @@ export function loadAllQueries(): Promise<ReadonlyMap<string, string>> {
 // Internal: shared-promise initializer. Concurrent callers all get
 // the same promise; the underlying `populateCache()` runs at most
 // once per cache lifetime.
+//
+// On rejection (e.g. a transient FS error reading a query file) we
+// clear `initPromise` so the next caller can retry. Without this
+// reset, a single transient failure would cache the rejected
+// promise and poison every subsequent loadQuery() call until the
+// process restarts.
 function ensureInitialized(): Promise<ReadonlyMap<string, string>> {
   if (initPromise) return initPromise;
-  initPromise = populateCache();
-  return initPromise;
+  const fresh: Promise<ReadonlyMap<string, string>> = populateCache().catch((err) => {
+    // Identity check guards against `_resetQueryCache()` (or another
+    // failed caller) clearing/replacing the slot before we observe
+    // our own rejection. Only blank the slot if it still holds the
+    // exact promise we just attempted.
+    if (initPromise === fresh) initPromise = null;
+    throw err;
+  });
+  initPromise = fresh;
+  return fresh;
 }
 
 async function populateCache(): Promise<ReadonlyMap<string, string>> {

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -32,7 +32,24 @@ const QUERIES_ROOT = resolve(HERE, "queries");
 // Only populated under production. In dev we bypass this entirely so
 // HMR-style edits surface without a process restart.
 const cache = new Map<string, string>();
-let initialized = false;
+
+// Single shared init promise so concurrent loadQuery() calls don't
+// each kick off their own loadAllQueries() and fight over the shared
+// cache mid-flight. The first call creates the promise; later
+// callers await the same one and observe a fully-populated cache.
+// `null` means uninitialised; once set, the value sticks until
+// `_resetQueryCache()` clears it.
+let initPromise: Promise<ReadonlyMap<string, string>> | null = null;
+
+// Test-only counter so the production-cache test can verify the
+// caching contract in observable terms (file reads happen at most
+// once per query across calls), instead of just asserting that two
+// calls return equal contents — which would also pass on the dev
+// path or under a regression that re-reads on every call.
+let diskReadCount = 0;
+export function _getDiskReadCount(): number {
+  return diskReadCount;
+}
 
 // Test-only override for the dev/prod switch. Node's test runner
 // executes tests concurrently by default, so the production-cache-path
@@ -54,9 +71,11 @@ export async function loadQuery(name: string): Promise<string> {
   if (!isProduction()) {
     return readQueryFile(name);
   }
-  if (!initialized) {
-    await loadAllQueries();
-  }
+  // ensureInitialized routes every concurrent caller through the same
+  // promise. After it resolves the cache is populated and we can
+  // serve all subsequent loadQuery calls in O(1) without ever
+  // touching the filesystem.
+  await ensureInitialized();
   const cached = cache.get(name);
   if (typeof cached !== "string") {
     throw new Error(
@@ -69,9 +88,26 @@ export async function loadQuery(name: string): Promise<string> {
 
 // Eagerly populate the cache. Exposed for tests + for the server
 // startup path that wants to fail fast if the queries directory is
-// malformed (rather than at first tool call).
-export async function loadAllQueries(): Promise<ReadonlyMap<string, string>> {
-  cache.clear();
+// malformed (rather than at first tool call). Idempotent: subsequent
+// calls return the same shared init promise.
+export function loadAllQueries(): Promise<ReadonlyMap<string, string>> {
+  return ensureInitialized();
+}
+
+// Internal: shared-promise initializer. Concurrent callers all get
+// the same promise; the underlying `populateCache()` runs at most
+// once per cache lifetime.
+function ensureInitialized(): Promise<ReadonlyMap<string, string>> {
+  if (initPromise) return initPromise;
+  initPromise = populateCache();
+  return initPromise;
+}
+
+async function populateCache(): Promise<ReadonlyMap<string, string>> {
+  // We don't `cache.clear()` here: under the shared-promise pattern
+  // there is exactly one populateCache call per cache lifetime, and
+  // a clear+rebuild would be a footgun if a future change ever
+  // triggers populateCache mid-read.
   let entries: string[];
   try {
     entries = await readdir(QUERIES_ROOT, { recursive: true });
@@ -81,7 +117,6 @@ export async function loadAllQueries(): Promise<ReadonlyMap<string, string>> {
       // before any query files have been added. Cache stays empty;
       // any loadQuery() call will then throw the "unknown query"
       // error, which is the right signal.
-      initialized = true;
       return cache;
     }
     throw err;
@@ -95,21 +130,22 @@ export async function loadAllQueries(): Promise<ReadonlyMap<string, string>> {
       // canonical name so queries resolve identically across platforms.
       .replace(/\\/g, "/");
     const contents = await readFile(abs, "utf8");
+    diskReadCount += 1;
     cache.set(name, contents);
   }
-  initialized = true;
   return cache;
 }
 
-// Test-only hook: drop the cached state so a fresh `loadAllQueries`
-// re-reads the directory. Also clears the production-mode override so
-// each test starts in dev mode unless it explicitly opts in. Not
+// Test-only hook: drop the cached state so a fresh init re-reads
+// the directory. Also clears the production-mode override and the
+// disk-read counter so each test starts from a known state. Not
 // exported through the public surface, but kept on a separate function
 // so tests can grab it via the module's internal namespace if needed.
 export function _resetQueryCache(): void {
   cache.clear();
-  initialized = false;
+  initPromise = null;
   productionOverride = undefined;
+  diskReadCount = 0;
 }
 
 async function readQueryFile(name: string): Promise<string> {
@@ -131,7 +167,9 @@ async function readQueryFile(name: string): Promise<string> {
     );
   }
   try {
-    return await readFile(abs, "utf8");
+    const contents = await readFile(abs, "utf8");
+    diskReadCount += 1;
+    return contents;
   } catch (err) {
     if (isErrnoNotFound(err)) {
       throw new Error(

--- a/src/graphql/queries/_health/viewer.graphql
+++ b/src/graphql/queries/_health/viewer.graphql
@@ -1,0 +1,5 @@
+query Viewer {
+  viewer {
+    login
+  }
+}

--- a/src/graphql/rate_limit.ts
+++ b/src/graphql/rate_limit.ts
@@ -15,6 +15,17 @@
 
 import { RateLimitExhaustedError } from "./errors.js";
 
+// Accept both shapes that callers actually have: a plain object
+// (`@octokit/request` always returns `Record<string, string>` for
+// `response.headers`) and a `Headers` instance (which Node's stock
+// `fetch` returns). The parser detects the latter via
+// `headers instanceof Headers` and routes through `Headers.get(...)`,
+// while the former is read by direct property lookup. Without this
+// dual support a `Headers` argument would silently report "no
+// rate-limit info" because the property-style read returns
+// `undefined`.
+type HeaderBag = Record<string, unknown> | Headers;
+
 // 10 is GitHub's own internal "you're getting close" line in their
 // public guidance for the GraphQL API. Below that, parallel runners
 // can easily blow past zero before we observe the next response.
@@ -27,17 +38,14 @@ export interface ParsedRateLimit {
   used: number;
 }
 
-// `headers` is typed loosely (Record<string, unknown>) because both
-// `@octokit/request` (which always returns `Record<string, string>`)
-// and Node's stock `fetch` (which returns `Headers`) need to flow
-// through here. Callers normalise to a plain object before calling.
 export function parseRateLimit(
-  headers: Record<string, unknown>,
+  headers: HeaderBag,
 ): ParsedRateLimit | undefined {
-  const limit = readNumber(headers["x-ratelimit-limit"]);
-  const remaining = readNumber(headers["x-ratelimit-remaining"]);
-  const resetAt = readNumber(headers["x-ratelimit-reset"]);
-  const used = readNumber(headers["x-ratelimit-used"]);
+  const get = headerReader(headers);
+  const limit = readNumber(get("x-ratelimit-limit"));
+  const remaining = readNumber(get("x-ratelimit-remaining"));
+  const resetAt = readNumber(get("x-ratelimit-reset"));
+  const used = readNumber(get("x-ratelimit-used"));
   // GitHub returns these as a unit; if any are missing we treat the
   // header set as absent. Don't half-parse — a partial record would
   // mislead the threshold checks below.
@@ -58,7 +66,7 @@ export function parseRateLimit(
 // `warn` is parameterised so tests can capture invocations without
 // taking over `console.warn` globally.
 export function enforceRateLimit(
-  headers: Record<string, unknown>,
+  headers: HeaderBag,
   warn: (msg: string) => void = (msg) => process.stderr.write(`${msg}\n`),
 ): ParsedRateLimit | undefined {
   const rl = parseRateLimit(headers);
@@ -82,4 +90,17 @@ function readNumber(v: unknown): number | undefined {
     return Number.isFinite(n) ? n : undefined;
   }
   return undefined;
+}
+
+// Returns a unified accessor that handles both header shapes (plain
+// object lookup vs `Headers.get()`). The Headers branch deliberately
+// uses `instanceof` rather than duck-typing on `.get` because plain
+// objects can legitimately have a `get` property of a different shape
+// (e.g. a `Map` masquerading as headers).
+function headerReader(headers: HeaderBag): (name: string) => unknown {
+  if (typeof Headers !== "undefined" && headers instanceof Headers) {
+    return (name) => headers.get(name) ?? undefined;
+  }
+  const obj = headers as Record<string, unknown>;
+  return (name) => obj[name];
 }

--- a/src/graphql/rate_limit.ts
+++ b/src/graphql/rate_limit.ts
@@ -1,0 +1,85 @@
+// src/graphql/rate_limit.ts
+//
+// GitHub's primary rate-limit signal lives in `X-RateLimit-*` response
+// headers. We surface three states:
+//
+//   - healthy: no action needed
+//   - low: remaining < threshold; emit a structured warning so
+//     long-running runners notice the cliff before they hit it
+//   - exhausted: remaining == 0; throw RateLimitExhaustedError so the
+//     caller can back off until `resetAt`
+//
+// Secondary rate limits (the "abuse detection" path) are NOT in these
+// headers — those arrive as HTTP 403 with `x-secondary-rate-limit: true`
+// and are handled in client.ts.
+
+import { RateLimitExhaustedError } from "./errors.js";
+
+// 10 is GitHub's own internal "you're getting close" line in their
+// public guidance for the GraphQL API. Below that, parallel runners
+// can easily blow past zero before we observe the next response.
+export const LOW_REMAINING_THRESHOLD = 10;
+
+export interface ParsedRateLimit {
+  limit: number;
+  remaining: number;
+  resetAt: number; // unix epoch seconds
+  used: number;
+}
+
+// `headers` is typed loosely (Record<string, unknown>) because both
+// `@octokit/request` (which always returns `Record<string, string>`)
+// and Node's stock `fetch` (which returns `Headers`) need to flow
+// through here. Callers normalise to a plain object before calling.
+export function parseRateLimit(
+  headers: Record<string, unknown>,
+): ParsedRateLimit | undefined {
+  const limit = readNumber(headers["x-ratelimit-limit"]);
+  const remaining = readNumber(headers["x-ratelimit-remaining"]);
+  const resetAt = readNumber(headers["x-ratelimit-reset"]);
+  const used = readNumber(headers["x-ratelimit-used"]);
+  // GitHub returns these as a unit; if any are missing we treat the
+  // header set as absent. Don't half-parse — a partial record would
+  // mislead the threshold checks below.
+  if (
+    limit === undefined ||
+    remaining === undefined ||
+    resetAt === undefined ||
+    used === undefined
+  ) {
+    return undefined;
+  }
+  return { limit, remaining, resetAt, used };
+}
+
+// Return the rate-limit record for callers who want to inspect it,
+// after applying the warn/throw policy. Throws RateLimitExhaustedError
+// if remaining == 0; emits a stderr warning if remaining < threshold.
+// `warn` is parameterised so tests can capture invocations without
+// taking over `console.warn` globally.
+export function enforceRateLimit(
+  headers: Record<string, unknown>,
+  warn: (msg: string) => void = (msg) => process.stderr.write(`${msg}\n`),
+): ParsedRateLimit | undefined {
+  const rl = parseRateLimit(headers);
+  if (!rl) return undefined;
+  if (rl.remaining === 0) {
+    throw new RateLimitExhaustedError(rl.resetAt, rl.limit);
+  }
+  if (rl.remaining < LOW_REMAINING_THRESHOLD) {
+    warn(
+      `mcp-github: GraphQL rate limit low: ${rl.remaining}/${rl.limit} ` +
+        `remaining (resets at ${new Date(rl.resetAt * 1000).toISOString()})`,
+    );
+  }
+  return rl;
+}
+
+function readNumber(v: unknown): number | undefined {
+  if (typeof v === "number" && Number.isFinite(v)) return v;
+  if (typeof v === "string") {
+    const n = Number(v);
+    return Number.isFinite(n) ? n : undefined;
+  }
+  return undefined;
+}

--- a/tests/unit/graphql/client.test.ts
+++ b/tests/unit/graphql/client.test.ts
@@ -1,0 +1,185 @@
+// tests/unit/graphql/client.test.ts
+//
+// Tests the GraphQL client end-to-end with a stubbed `AuthedRequest`.
+// We feed the loader the real `_health/viewer.graphql` (so the
+// query-name → file-contents path is exercised against the
+// canonical layout) and synthesize the network response in each
+// test for the bits we want to assert.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { RequestError } from "@octokit/request-error";
+
+import { createGraphqlClient } from "../../../src/graphql/client.ts";
+import {
+  GraphqlError,
+  RateLimitExhaustedError,
+  AbuseDetectionError,
+} from "../../../src/graphql/errors.ts";
+import { _resetQueryCache } from "../../../src/graphql/queries.ts";
+import type { AuthedRequest } from "../../../src/auth/octokit.ts";
+
+interface StubResponse {
+  data: unknown;
+  headers: Record<string, unknown>;
+  status?: number;
+}
+
+function stubAuthedRequest(
+  fn: (route: string, opts: Record<string, unknown>) => Promise<StubResponse>,
+): AuthedRequest {
+  return fn as unknown as AuthedRequest;
+}
+
+function stubReject(err: unknown): AuthedRequest {
+  return stubAuthedRequest(() => Promise.reject(err));
+}
+
+function rlHeaders(remaining: number): Record<string, string> {
+  return {
+    "x-ratelimit-limit": "5000",
+    "x-ratelimit-remaining": String(remaining),
+    "x-ratelimit-reset": "1800000000",
+    "x-ratelimit-used": String(5000 - remaining),
+  };
+}
+
+function buildAbuseError(headers: Record<string, unknown>): RequestError {
+  const err = new RequestError("Forbidden", 403, {
+    request: {
+      method: "POST",
+      url: "https://api.github.com/graphql",
+      headers: {},
+    },
+  });
+  // RequestError exposes `response` as readonly; assigning works at
+  // runtime because the getter is plain. We synthesize a minimal
+  // OctokitResponse-shaped object — only the headers matter to the
+  // mapper under test.
+  (err as unknown as { response: { headers: Record<string, unknown> } }).response = {
+    headers,
+  };
+  return err;
+}
+
+test("graphql: loads query by name, posts, returns unwrapped data", async () => {
+  _resetQueryCache();
+  let capturedQuery: string | undefined;
+  let capturedVars: unknown;
+  const stub = stubAuthedRequest(async (route, opts) => {
+    assert.equal(route, "POST /graphql");
+    capturedQuery = (opts as { query?: string }).query;
+    capturedVars = (opts as { variables?: unknown }).variables;
+    return {
+      data: { data: { viewer: { login: "alice" } } },
+      headers: rlHeaders(4999),
+    };
+  });
+  const graphql = createGraphqlClient(stub, { warn: () => {} });
+  const result = await graphql<{ viewer: { login: string } }>(
+    "_health/viewer",
+    { x: 1 },
+  );
+  assert.deepEqual(result, { viewer: { login: "alice" } });
+  assert.match(capturedQuery ?? "", /viewer/);
+  assert.deepEqual(capturedVars, { x: 1 });
+});
+
+test("graphql: maps response.errors[] onto GraphqlError, preserving the array", async () => {
+  _resetQueryCache();
+  const stub = stubAuthedRequest(async () => ({
+    data: {
+      data: null,
+      errors: [
+        { type: "NOT_FOUND", message: "no such repo", path: ["repository"] },
+      ],
+    },
+    headers: rlHeaders(4999),
+  }));
+  const graphql = createGraphqlClient(stub, { warn: () => {} });
+  await assert.rejects(
+    graphql("_health/viewer"),
+    (err: unknown) => {
+      assert.ok(err instanceof GraphqlError);
+      assert.equal((err as GraphqlError).errors[0]?.type, "NOT_FOUND");
+      return true;
+    },
+  );
+});
+
+test("graphql: emits warning when rate-limit remaining drops below threshold", async () => {
+  _resetQueryCache();
+  const stub = stubAuthedRequest(async () => ({
+    data: { data: { viewer: { login: "alice" } } },
+    headers: rlHeaders(5),
+  }));
+  const warnings: string[] = [];
+  const graphql = createGraphqlClient(stub, {
+    warn: (m) => warnings.push(m),
+  });
+  await graphql("_health/viewer");
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0] ?? "", /rate limit low/);
+});
+
+test("graphql: throws RateLimitExhaustedError when remaining hits zero", async () => {
+  _resetQueryCache();
+  const stub = stubAuthedRequest(async () => ({
+    data: { data: { viewer: { login: "alice" } } },
+    headers: rlHeaders(0),
+  }));
+  const graphql = createGraphqlClient(stub, { warn: () => {} });
+  await assert.rejects(graphql("_health/viewer"), RateLimitExhaustedError);
+});
+
+test("graphql: maps 403 + x-secondary-rate-limit onto AbuseDetectionError with retry-after", async () => {
+  _resetQueryCache();
+  const err = buildAbuseError({
+    "x-secondary-rate-limit": "true",
+    "retry-after": "30",
+  });
+  const stub = stubReject(err);
+  const graphql = createGraphqlClient(stub, { warn: () => {} });
+  await assert.rejects(graphql("_health/viewer"), (caught: unknown) => {
+    assert.ok(caught instanceof AbuseDetectionError);
+    assert.equal((caught as AbuseDetectionError).retryAfterSeconds, 30);
+    return true;
+  });
+});
+
+test("graphql: AbuseDetectionError defaults to 60s when retry-after header is missing", async () => {
+  _resetQueryCache();
+  const err = buildAbuseError({ "x-secondary-rate-limit": "true" });
+  const stub = stubReject(err);
+  const graphql = createGraphqlClient(stub, { warn: () => {} });
+  await assert.rejects(graphql("_health/viewer"), (caught: unknown) => {
+    assert.equal((caught as AbuseDetectionError).retryAfterSeconds, 60);
+    return true;
+  });
+});
+
+test("graphql: 403 without x-secondary-rate-limit falls through as the underlying RequestError", async () => {
+  _resetQueryCache();
+  // Ordinary auth-failure 403s must not be mistaken for abuse-detection,
+  // otherwise the consumer gets a "retry in 60s" message for what is
+  // actually a permanent permissions problem.
+  const err = buildAbuseError({});
+  const stub = stubReject(err);
+  const graphql = createGraphqlClient(stub, { warn: () => {} });
+  await assert.rejects(graphql("_health/viewer"), (caught: unknown) => {
+    assert.ok(caught instanceof RequestError);
+    return true;
+  });
+});
+
+test("graphql: throws when query name doesn't resolve to any file", async () => {
+  _resetQueryCache();
+  const stub = stubAuthedRequest(async () => {
+    throw new Error("network should not be hit when query is missing");
+  });
+  const graphql = createGraphqlClient(stub, { warn: () => {} });
+  await assert.rejects(
+    graphql("does_not_exist/anywhere"),
+    /unknown GraphQL query/,
+  );
+});

--- a/tests/unit/graphql/errors.test.ts
+++ b/tests/unit/graphql/errors.test.ts
@@ -1,0 +1,53 @@
+// tests/unit/graphql/errors.test.ts
+//
+// Pin the structured error classes so consumers can rely on
+// `instanceof` + the documented properties (errors[], resetAt,
+// retryAfterSeconds). These tests are intentionally lightweight —
+// they exist mainly so a future refactor of error shapes is forced
+// to update the contract here, not silently change consumer-visible
+// behaviour.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  GraphqlError,
+  RateLimitExhaustedError,
+  AbuseDetectionError,
+} from "../../../src/graphql/errors.ts";
+
+test("GraphqlError: preserves the response errors[] array verbatim", () => {
+  const errors = [
+    { type: "NOT_FOUND", message: "Could not resolve to a User", path: ["viewer"] },
+    { type: "FORBIDDEN", message: "must have admin access" },
+  ];
+  const e = new GraphqlError(errors);
+  assert.equal(e.name, "GraphqlError");
+  assert.equal(e.errors.length, 2);
+  assert.equal(e.errors[0]?.type, "NOT_FOUND");
+  assert.match(e.message, /NOT_FOUND/);
+  assert.match(e.message, /FORBIDDEN/);
+});
+
+test("GraphqlError: handles errors with no type/message gracefully", () => {
+  const e = new GraphqlError([{}]);
+  assert.match(e.message, /ERROR: unknown/);
+});
+
+test("RateLimitExhaustedError: surfaces resetAt + limit + ISO date in message", () => {
+  // Pick a deterministic instant (not Date.now) so the message check
+  // doesn't drift with the test clock.
+  const resetAt = Math.floor(Date.UTC(2026, 0, 15, 12, 0, 0) / 1000);
+  const e = new RateLimitExhaustedError(resetAt, 5000);
+  assert.equal(e.name, "RateLimitExhaustedError");
+  assert.equal(e.resetAt, resetAt);
+  assert.equal(e.limit, 5000);
+  assert.match(e.message, /2026-01-15T12:00:00\.000Z/);
+});
+
+test("AbuseDetectionError: stores retry-after seconds", () => {
+  const e = new AbuseDetectionError(120);
+  assert.equal(e.name, "AbuseDetectionError");
+  assert.equal(e.retryAfterSeconds, 120);
+  assert.match(e.message, /retry after 120s/);
+});

--- a/tests/unit/graphql/queries.test.ts
+++ b/tests/unit/graphql/queries.test.ts
@@ -103,6 +103,15 @@ test("loadQuery: production path is concurrency-safe (single shared init)", asyn
   freshCache();
   _setProductionOverride(true);
   try {
+    // Derive the expected read count from the actual queries
+    // directory rather than hardcoding a constant. A pre-loaded
+    // peek at loadAllQueries() gives the real number of .graphql
+    // files; we then reset and run the concurrent workload.
+    const probe = await loadAllQueries();
+    const expectedFiles = probe.size;
+    freshCache();
+    _setProductionOverride(true);
+
     const beforeCount = _getDiskReadCount();
     const [a, b, c] = await Promise.all([
       loadQuery("_health/viewer"),
@@ -113,11 +122,13 @@ test("loadQuery: production path is concurrency-safe (single shared init)", asyn
     assert.equal(a, b);
     assert.equal(b, c);
     // All three concurrent callers awaited the same init, so each
-    // file is read exactly once across the trio.
+    // file is read exactly once across the trio. The total disk
+    // reads matches the on-disk file count, not 3 × that count.
     const reads = afterCount - beforeCount;
-    assert.ok(
-      reads > 0 && reads <= 16,
-      `expected a single bounded init pass, observed ${reads} disk reads`,
+    assert.equal(
+      reads,
+      expectedFiles,
+      `expected exactly ${expectedFiles} disk reads (one per query file), observed ${reads}`,
     );
   } finally {
     _setProductionOverride(undefined);

--- a/tests/unit/graphql/queries.test.ts
+++ b/tests/unit/graphql/queries.test.ts
@@ -13,6 +13,7 @@ import {
   loadQuery,
   loadAllQueries,
   _resetQueryCache,
+  _setProductionOverride,
 } from "../../../src/graphql/queries.ts";
 
 // Reset the in-process cache between tests so production-mode
@@ -55,9 +56,12 @@ test("loadAllQueries: indexes the canonical placeholder", async () => {
 });
 
 test("loadQuery: production path serves from the cache after first init", async () => {
+  // Use the module-scoped production override rather than mutating
+  // process.env.NODE_ENV. Node's test runner runs tests concurrently,
+  // and a global env mutation here would race the dev-path tests
+  // above; the override flips just this one module's switch.
   freshCache();
-  const original = process.env["NODE_ENV"];
-  process.env["NODE_ENV"] = "production";
+  _setProductionOverride(true);
   try {
     // Two sequential loads should both succeed and return identical
     // contents; in prod mode the second call goes through the cache.
@@ -66,11 +70,10 @@ test("loadQuery: production path serves from the cache after first init", async 
     assert.equal(a, b);
     assert.match(a, /viewer/);
   } finally {
-    if (original === undefined) {
-      delete process.env["NODE_ENV"];
-    } else {
-      process.env["NODE_ENV"] = original;
-    }
+    // freshCache() also clears the override, but we belt-and-brace it
+    // so a future change that splits cache-reset from override-reset
+    // doesn't leak prod mode into later tests.
+    _setProductionOverride(undefined);
     freshCache();
   }
 });

--- a/tests/unit/graphql/queries.test.ts
+++ b/tests/unit/graphql/queries.test.ts
@@ -47,6 +47,26 @@ test("loadQuery: rejects names that try to escape the queries root", async () =>
   );
 });
 
+test("loadQuery: posix-normalises caller-supplied names (dev + prod agree)", async () => {
+  // `x/../_health/viewer` collapses to `_health/viewer`. Without
+  // canonicalisation, dev resolved this happily via path.resolve()
+  // while prod missed the cache (literal-string lookup), producing
+  // a dev/prod mismatch. The normalisation runs on both paths.
+  freshCache();
+  const q = await loadQuery("./x/../_health//viewer");
+  assert.match(q, /viewer/);
+});
+
+test("loadQuery: rejects empty / dot-only names after normalisation", async () => {
+  // posix.normalize("") returns ".", and posix.normalize(".") also
+  // returns "." — both should be rejected because they don't name
+  // any real query and would otherwise produce confusing error
+  // surfaces (or, with an unrelated bug, expose the queries root).
+  freshCache();
+  await assert.rejects(loadQuery(""), /escapes queries root or resolves to empty/);
+  await assert.rejects(loadQuery("."), /escapes queries root or resolves to empty/);
+});
+
 test("loadAllQueries: indexes the canonical placeholder", async () => {
   freshCache();
   const all = await loadAllQueries();

--- a/tests/unit/graphql/queries.test.ts
+++ b/tests/unit/graphql/queries.test.ts
@@ -1,0 +1,76 @@
+// tests/unit/graphql/queries.test.ts
+//
+// Tests the query loader. We point the loader at the *real*
+// queries directory under `src/graphql/queries/` (rather than a
+// synthetic fixture tree) so we exercise the actual on-disk
+// layout the runtime uses. The `_health/viewer.graphql` file
+// is the seeded placeholder we depend on.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  loadQuery,
+  loadAllQueries,
+  _resetQueryCache,
+} from "../../../src/graphql/queries.ts";
+
+// Reset the in-process cache between tests so production-mode
+// caching doesn't leak across cases. The dev path (default
+// NODE_ENV) re-reads from disk on every call and is unaffected.
+function freshCache() {
+  _resetQueryCache();
+}
+
+test("loadQuery: resolves a known name to file contents (dev path)", async () => {
+  freshCache();
+  const q = await loadQuery("_health/viewer");
+  assert.match(q, /viewer/);
+  assert.match(q, /login/);
+});
+
+test("loadQuery: throws a structured error for an unknown name (dev path)", async () => {
+  freshCache();
+  await assert.rejects(
+    loadQuery("not_a_real_group/no_such_query"),
+    /unknown GraphQL query 'not_a_real_group\/no_such_query'/,
+  );
+});
+
+test("loadQuery: rejects names that try to escape the queries root", async () => {
+  freshCache();
+  await assert.rejects(
+    loadQuery("../auth/pat"),
+    /escapes queries root/,
+  );
+});
+
+test("loadAllQueries: indexes the canonical placeholder", async () => {
+  freshCache();
+  const all = await loadAllQueries();
+  // We don't pin the full set (queries land per tool in later PRs),
+  // but the bootstrap placeholder must be present — it's the entry
+  // point for the integration smoke probe in MCP-12.
+  assert.ok(all.has("_health/viewer"), `expected _health/viewer in ${[...all.keys()].join(", ")}`);
+});
+
+test("loadQuery: production path serves from the cache after first init", async () => {
+  freshCache();
+  const original = process.env["NODE_ENV"];
+  process.env["NODE_ENV"] = "production";
+  try {
+    // Two sequential loads should both succeed and return identical
+    // contents; in prod mode the second call goes through the cache.
+    const a = await loadQuery("_health/viewer");
+    const b = await loadQuery("_health/viewer");
+    assert.equal(a, b);
+    assert.match(a, /viewer/);
+  } finally {
+    if (original === undefined) {
+      delete process.env["NODE_ENV"];
+    } else {
+      process.env["NODE_ENV"] = original;
+    }
+    freshCache();
+  }
+});

--- a/tests/unit/graphql/queries.test.ts
+++ b/tests/unit/graphql/queries.test.ts
@@ -14,6 +14,7 @@ import {
   loadAllQueries,
   _resetQueryCache,
   _setProductionOverride,
+  _getDiskReadCount,
 } from "../../../src/graphql/queries.ts";
 
 // Reset the in-process cache between tests so production-mode
@@ -60,19 +61,65 @@ test("loadQuery: production path serves from the cache after first init", async 
   // process.env.NODE_ENV. Node's test runner runs tests concurrently,
   // and a global env mutation here would race the dev-path tests
   // above; the override flips just this one module's switch.
+  //
+  // The disk-read counter is the actual caching contract. Asserting
+  // only that two calls return equal strings would also pass on the
+  // dev path (which re-reads on each call) — that's the failure mode
+  // the round-3 review flagged. Counting reads pins the cache.
   freshCache();
   _setProductionOverride(true);
   try {
-    // Two sequential loads should both succeed and return identical
-    // contents; in prod mode the second call goes through the cache.
+    const beforeCount = _getDiskReadCount();
     const a = await loadQuery("_health/viewer");
+    const afterFirst = _getDiskReadCount();
     const b = await loadQuery("_health/viewer");
+    const afterSecond = _getDiskReadCount();
     assert.equal(a, b);
     assert.match(a, /viewer/);
+    assert.ok(
+      afterFirst > beforeCount,
+      "first call must hit disk to populate the cache",
+    );
+    assert.equal(
+      afterSecond,
+      afterFirst,
+      "second call must hit the cache, not disk",
+    );
   } finally {
     // freshCache() also clears the override, but we belt-and-brace it
     // so a future change that splits cache-reset from override-reset
     // doesn't leak prod mode into later tests.
+    _setProductionOverride(undefined);
+    freshCache();
+  }
+});
+
+test("loadQuery: production path is concurrency-safe (single shared init)", async () => {
+  // Three concurrent calls to loadQuery in production mode must all
+  // resolve correctly and must NOT each trigger their own
+  // cache-population pass. Without the shared init promise, a clear+
+  // rebuild race could leave one of the callers observing an empty
+  // cache and throwing a spurious "unknown query" error.
+  freshCache();
+  _setProductionOverride(true);
+  try {
+    const beforeCount = _getDiskReadCount();
+    const [a, b, c] = await Promise.all([
+      loadQuery("_health/viewer"),
+      loadQuery("_health/viewer"),
+      loadQuery("_health/viewer"),
+    ]);
+    const afterCount = _getDiskReadCount();
+    assert.equal(a, b);
+    assert.equal(b, c);
+    // All three concurrent callers awaited the same init, so each
+    // file is read exactly once across the trio.
+    const reads = afterCount - beforeCount;
+    assert.ok(
+      reads > 0 && reads <= 16,
+      `expected a single bounded init pass, observed ${reads} disk reads`,
+    );
+  } finally {
     _setProductionOverride(undefined);
     freshCache();
   }

--- a/tests/unit/graphql/rate_limit.test.ts
+++ b/tests/unit/graphql/rate_limit.test.ts
@@ -1,0 +1,110 @@
+// tests/unit/graphql/rate_limit.test.ts
+//
+// Tests the rate-limit policy: header parsing, the low-remaining
+// warning threshold, and the hard-zero throw. These run with no
+// network access — the input to `enforceRateLimit` is a plain
+// headers object that we construct directly.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  parseRateLimit,
+  enforceRateLimit,
+  LOW_REMAINING_THRESHOLD,
+} from "../../../src/graphql/rate_limit.ts";
+import { RateLimitExhaustedError } from "../../../src/graphql/errors.ts";
+
+function rlHeaders(overrides: Partial<Record<string, string>> = {}) {
+  return {
+    "x-ratelimit-limit": "5000",
+    "x-ratelimit-remaining": "4999",
+    "x-ratelimit-reset": "1800000000",
+    "x-ratelimit-used": "1",
+    ...overrides,
+  } as Record<string, unknown>;
+}
+
+test("parseRateLimit: parses the canonical four headers", () => {
+  const rl = parseRateLimit(rlHeaders());
+  assert.deepEqual(rl, {
+    limit: 5000,
+    remaining: 4999,
+    resetAt: 1800000000,
+    used: 1,
+  });
+});
+
+test("parseRateLimit: returns undefined when any header is missing", () => {
+  // Half-parsed records would mislead the threshold checks; treat
+  // partial sets as absent.
+  const headers = rlHeaders();
+  delete (headers as Record<string, unknown>)["x-ratelimit-reset"];
+  assert.equal(parseRateLimit(headers), undefined);
+});
+
+test("parseRateLimit: tolerates numeric values (not just strings)", () => {
+  // node:fetch sometimes hands us numeric headers; @octokit/request
+  // always strings. We support both for safety.
+  const headers = {
+    "x-ratelimit-limit": 5000,
+    "x-ratelimit-remaining": 4999,
+    "x-ratelimit-reset": 1800000000,
+    "x-ratelimit-used": 1,
+  };
+  const rl = parseRateLimit(headers);
+  assert.equal(rl?.limit, 5000);
+});
+
+test("enforceRateLimit: healthy response is silent", () => {
+  const warnings: string[] = [];
+  const rl = enforceRateLimit(rlHeaders(), (m) => warnings.push(m));
+  assert.equal(warnings.length, 0);
+  assert.equal(rl?.remaining, 4999);
+});
+
+test(`enforceRateLimit: warns when remaining drops below ${LOW_REMAINING_THRESHOLD}`, () => {
+  const warnings: string[] = [];
+  enforceRateLimit(
+    rlHeaders({ "x-ratelimit-remaining": String(LOW_REMAINING_THRESHOLD - 1) }),
+    (m) => warnings.push(m),
+  );
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0] ?? "", /rate limit low/);
+  assert.match(warnings[0] ?? "", new RegExp(String(LOW_REMAINING_THRESHOLD - 1)));
+});
+
+test("enforceRateLimit: does not warn at exactly the threshold", () => {
+  // The threshold is "< LOW_REMAINING_THRESHOLD", not "<=", so a value
+  // sitting exactly on the line is still considered healthy. Pin this
+  // boundary explicitly so a future refactor that flips the comparator
+  // surfaces here.
+  const warnings: string[] = [];
+  enforceRateLimit(
+    rlHeaders({ "x-ratelimit-remaining": String(LOW_REMAINING_THRESHOLD) }),
+    (m) => warnings.push(m),
+  );
+  assert.equal(warnings.length, 0);
+});
+
+test("enforceRateLimit: throws RateLimitExhaustedError when remaining is 0", () => {
+  assert.throws(
+    () => enforceRateLimit(rlHeaders({ "x-ratelimit-remaining": "0" }), () => {}),
+    (err: unknown) => {
+      assert.ok(err instanceof RateLimitExhaustedError);
+      assert.equal((err as RateLimitExhaustedError).resetAt, 1800000000);
+      assert.equal((err as RateLimitExhaustedError).limit, 5000);
+      return true;
+    },
+  );
+});
+
+test("enforceRateLimit: returns undefined and is silent when headers are absent", () => {
+  // Some test fixtures (and a few legitimate GitHub responses, like
+  // `200 OK` from a cached static asset) don't carry rate-limit
+  // headers at all. Treat that as "no signal" rather than crashing.
+  const warnings: string[] = [];
+  const rl = enforceRateLimit({}, (m) => warnings.push(m));
+  assert.equal(rl, undefined);
+  assert.equal(warnings.length, 0);
+});

--- a/tests/unit/graphql/rate_limit.test.ts
+++ b/tests/unit/graphql/rate_limit.test.ts
@@ -56,6 +56,21 @@ test("parseRateLimit: tolerates numeric values (not just strings)", () => {
   assert.equal(rl?.limit, 5000);
 });
 
+test("parseRateLimit: reads from a `Headers` instance (Node fetch path)", () => {
+  // Stock `fetch` returns response.headers as a `Headers` instance,
+  // which doesn't support property-style access. The parser detects
+  // the instance and routes through `.get(name)`.
+  const headers = new Headers({
+    "x-ratelimit-limit": "5000",
+    "x-ratelimit-remaining": "4999",
+    "x-ratelimit-reset": "1800000000",
+    "x-ratelimit-used": "1",
+  });
+  const rl = parseRateLimit(headers);
+  assert.equal(rl?.limit, 5000);
+  assert.equal(rl?.remaining, 4999);
+});
+
 test("enforceRateLimit: healthy response is silent", () => {
   const warnings: string[] = [];
   const rl = enforceRateLimit(rlHeaders(), (m) => warnings.push(m));


### PR DESCRIPTION
## Summary

Reopened against main after the auth PR (now-merged #19) landed. Same content as the previously-clean PR #18 (auto-closed when its base branch was deleted), now rebased onto main.

Establishes the canonical pattern every domain tool will use to talk to GitHub: a thin GraphQL wrapper that loads named queries from `src/graphql/queries/<group>/<name>.graphql`, executes them via the authed Octokit request client, and surfaces structured errors for the three operationally-distinct failure modes.

- `src/graphql/client.ts` — `createGraphqlClient(authedRequest) → graphql<T>(name, vars)`
- `src/graphql/queries.ts` — name-to-file resolver; eager + cached in prod (single-shared-promise init), re-read per call in dev. Posix-normalises caller-supplied query names so dev and prod resolve identically. Atomic-swap cache so transient FS errors can't corrupt mid-populate.
- `src/graphql/rate_limit.ts` — header parser + `enforceRateLimit` policy (warn at <10, throw at 0). Accepts both plain header objects and `Headers` instances.
- `src/graphql/errors.ts` — `GraphqlError`, `RateLimitExhaustedError`, `AbuseDetectionError` (with finite + non-negative retry-after parsing).
- `src/graphql/queries/_health/viewer.graphql` — seeded placeholder, target for the integration probe in MCP-12.
- `scripts/post-build.mjs` — copies `.graphql` files into `dist/graphql/queries/**` (with rmSync first so deletions propagate) so the loader can find them at runtime.

## Test plan

- [x] `npm run lint` (tsc --noEmit on both src and tests configs) clean
- [x] `npm run build` produces `dist/graphql/queries/_health/viewer.graphql` alongside the compiled `.js` files
- [x] `npm test` — 58/58 pass (registry + auth + graphql client + queries loader + rate-limit + errors)
- [x] `node tests/smoke/server-lists-tools.mjs` — server boots and lists `gh.test_connection`
- [x] Eight rounds of Copilot review on the predecessor PR #18, all converged clean before that PR was auto-closed by the #19 merge
- [ ] Live integration probe (real `_health/viewer` query against a real PAT) lands in MCP-12

## Stack

Third in the stacked sequence: **MCP-1 (#16, merged) → MCP-2 (#19, merged) → MCP-3 (this)**.

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)