### PR TITLE
feat: 7 issue-ops tools + ajv-backed schema validation (MCP-4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@octokit/graphql": "^8.0.0",
         "@octokit/request": "^9.0.0",
-        "@octokit/request-error": "^7.0.0"
+        "@octokit/request-error": "^7.0.0",
+        "ajv": "8.20.0"
       },
       "bin": {
         "mcp-github": "dist/server.mjs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@octokit/graphql": "^8.0.0",
         "@octokit/request": "^9.0.0",
         "@octokit/request-error": "^7.0.0",
-        "ajv": "8.20.0"
+        "ajv": "^8.20.0",
+        "ajv-formats": "3.0.1"
       },
       "bin": {
         "mcp-github": "dist/server.mjs"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "@octokit/graphql": "^8.0.0",
     "@octokit/request": "^9.0.0",
     "@octokit/request-error": "^7.0.0",
-    "ajv": "^8.20.0"
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "@modelcontextprotocol/sdk": "^1.0.0",
     "@octokit/graphql": "^8.0.0",
     "@octokit/request": "^9.0.0",
-    "@octokit/request-error": "^7.0.0"
+    "@octokit/request-error": "^7.0.0",
+    "ajv": "^8.20.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/src/graphql/queries/issue/_issue-lookup.graphql
+++ b/src/graphql/queries/issue/_issue-lookup.graphql
@@ -1,0 +1,7 @@
+query IssueLookup($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    issue(number: $number) {
+      id
+    }
+  }
+}

--- a/src/graphql/queries/issue/_repo-context.graphql
+++ b/src/graphql/queries/issue/_repo-context.graphql
@@ -2,12 +2,18 @@ query RepoContext($owner: String!, $name: String!) {
   repository(owner: $owner, name: $name) {
     id
     labels(first: 100) {
+      pageInfo {
+        hasNextPage
+      }
       nodes {
         id
         name
       }
     }
     assignableUsers(first: 100) {
+      pageInfo {
+        hasNextPage
+      }
       nodes {
         id
         login

--- a/src/graphql/queries/issue/_repo-context.graphql
+++ b/src/graphql/queries/issue/_repo-context.graphql
@@ -1,0 +1,17 @@
+query RepoContext($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) {
+    id
+    labels(first: 100) {
+      nodes {
+        id
+        name
+      }
+    }
+    assignableUsers(first: 100) {
+      nodes {
+        id
+        login
+      }
+    }
+  }
+}

--- a/src/graphql/queries/issue/close.graphql
+++ b/src/graphql/queries/issue/close.graphql
@@ -7,12 +7,18 @@ mutation IssueClose($input: CloseIssueInput!) {
       title
       state
       body
-      labels(first: 50) {
+      labels(first: 100) {
+        pageInfo {
+          hasNextPage
+        }
         nodes {
           name
         }
       }
-      assignees(first: 20) {
+      assignees(first: 100) {
+        pageInfo {
+          hasNextPage
+        }
         nodes {
           login
         }

--- a/src/graphql/queries/issue/close.graphql
+++ b/src/graphql/queries/issue/close.graphql
@@ -1,0 +1,28 @@
+mutation IssueClose($input: CloseIssueInput!) {
+  closeIssue(input: $input) {
+    issue {
+      number
+      url
+      id
+      title
+      state
+      body
+      labels(first: 50) {
+        nodes {
+          name
+        }
+      }
+      assignees(first: 20) {
+        nodes {
+          login
+        }
+      }
+      author {
+        login
+      }
+      createdAt
+      updatedAt
+      closedAt
+    }
+  }
+}

--- a/src/graphql/queries/issue/comment.graphql
+++ b/src/graphql/queries/issue/comment.graphql
@@ -1,0 +1,10 @@
+mutation IssueComment($input: AddCommentInput!) {
+  addComment(input: $input) {
+    commentEdge {
+      node {
+        id
+        url
+      }
+    }
+  }
+}

--- a/src/graphql/queries/issue/create.graphql
+++ b/src/graphql/queries/issue/create.graphql
@@ -7,12 +7,18 @@ mutation IssueCreate($input: CreateIssueInput!) {
       title
       state
       body
-      labels(first: 50) {
+      labels(first: 100) {
+        pageInfo {
+          hasNextPage
+        }
         nodes {
           name
         }
       }
-      assignees(first: 20) {
+      assignees(first: 100) {
+        pageInfo {
+          hasNextPage
+        }
         nodes {
           login
         }

--- a/src/graphql/queries/issue/create.graphql
+++ b/src/graphql/queries/issue/create.graphql
@@ -1,0 +1,28 @@
+mutation IssueCreate($input: CreateIssueInput!) {
+  createIssue(input: $input) {
+    issue {
+      number
+      url
+      id
+      title
+      state
+      body
+      labels(first: 50) {
+        nodes {
+          name
+        }
+      }
+      assignees(first: 20) {
+        nodes {
+          login
+        }
+      }
+      author {
+        login
+      }
+      createdAt
+      updatedAt
+      closedAt
+    }
+  }
+}

--- a/src/graphql/queries/issue/edit.graphql
+++ b/src/graphql/queries/issue/edit.graphql
@@ -1,0 +1,28 @@
+mutation IssueEdit($input: UpdateIssueInput!) {
+  updateIssue(input: $input) {
+    issue {
+      number
+      url
+      id
+      title
+      state
+      body
+      labels(first: 50) {
+        nodes {
+          name
+        }
+      }
+      assignees(first: 20) {
+        nodes {
+          login
+        }
+      }
+      author {
+        login
+      }
+      createdAt
+      updatedAt
+      closedAt
+    }
+  }
+}

--- a/src/graphql/queries/issue/edit.graphql
+++ b/src/graphql/queries/issue/edit.graphql
@@ -7,12 +7,18 @@ mutation IssueEdit($input: UpdateIssueInput!) {
       title
       state
       body
-      labels(first: 50) {
+      labels(first: 100) {
+        pageInfo {
+          hasNextPage
+        }
         nodes {
           name
         }
       }
-      assignees(first: 20) {
+      assignees(first: 100) {
+        pageInfo {
+          hasNextPage
+        }
         nodes {
           login
         }

--- a/src/graphql/queries/issue/list.graphql
+++ b/src/graphql/queries/issue/list.graphql
@@ -25,12 +25,18 @@ query IssueList(
         title
         state
         body
-        labels(first: 50) {
+        labels(first: 100) {
+          pageInfo {
+            hasNextPage
+          }
           nodes {
             name
           }
         }
-        assignees(first: 20) {
+        assignees(first: 100) {
+          pageInfo {
+            hasNextPage
+          }
           nodes {
             login
           }

--- a/src/graphql/queries/issue/list.graphql
+++ b/src/graphql/queries/issue/list.graphql
@@ -1,0 +1,47 @@
+query IssueList(
+  $owner: String!
+  $name: String!
+  $states: [IssueState!]
+  $labels: [String!]
+  $first: Int!
+  $after: String
+) {
+  repository(owner: $owner, name: $name) {
+    issues(
+      first: $first
+      after: $after
+      states: $states
+      labels: $labels
+      orderBy: { field: UPDATED_AT, direction: DESC }
+    ) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        number
+        url
+        id
+        title
+        state
+        body
+        labels(first: 50) {
+          nodes {
+            name
+          }
+        }
+        assignees(first: 20) {
+          nodes {
+            login
+          }
+        }
+        author {
+          login
+        }
+        createdAt
+        updatedAt
+        closedAt
+      }
+    }
+  }
+}

--- a/src/graphql/queries/issue/search.graphql
+++ b/src/graphql/queries/issue/search.graphql
@@ -14,12 +14,18 @@ query IssueSearch($q: String!, $first: Int!, $after: String) {
         title
         state
         body
-        labels(first: 50) {
+        labels(first: 100) {
+          pageInfo {
+            hasNextPage
+          }
           nodes {
             name
           }
         }
-        assignees(first: 20) {
+        assignees(first: 100) {
+          pageInfo {
+            hasNextPage
+          }
           nodes {
             login
           }

--- a/src/graphql/queries/issue/search.graphql
+++ b/src/graphql/queries/issue/search.graphql
@@ -1,0 +1,39 @@
+query IssueSearch($q: String!, $first: Int!, $after: String) {
+  search(query: $q, type: ISSUE, first: $first, after: $after) {
+    issueCount
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    nodes {
+      __typename
+      ... on Issue {
+        number
+        url
+        id
+        title
+        state
+        body
+        labels(first: 50) {
+          nodes {
+            name
+          }
+        }
+        assignees(first: 20) {
+          nodes {
+            login
+          }
+        }
+        author {
+          login
+        }
+        createdAt
+        updatedAt
+        closedAt
+        repository {
+          nameWithOwner
+        }
+      }
+    }
+  }
+}

--- a/src/graphql/queries/issue/view.graphql
+++ b/src/graphql/queries/issue/view.graphql
@@ -1,0 +1,28 @@
+query IssueView($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    issue(number: $number) {
+      number
+      url
+      id
+      title
+      state
+      body
+      labels(first: 50) {
+        nodes {
+          name
+        }
+      }
+      assignees(first: 20) {
+        nodes {
+          login
+        }
+      }
+      author {
+        login
+      }
+      createdAt
+      updatedAt
+      closedAt
+    }
+  }
+}

--- a/src/graphql/queries/issue/view.graphql
+++ b/src/graphql/queries/issue/view.graphql
@@ -7,12 +7,18 @@ query IssueView($owner: String!, $name: String!, $number: Int!) {
       title
       state
       body
-      labels(first: 50) {
+      labels(first: 100) {
+        pageInfo {
+          hasNextPage
+        }
         nodes {
           name
         }
       }
-      assignees(first: 20) {
+      assignees(first: 100) {
+        pageInfo {
+          hasNextPage
+        }
         nodes {
           login
         }

--- a/src/server.ts
+++ b/src/server.ts
@@ -26,6 +26,7 @@ import {
 
 import { resolvePat } from "./auth/pat.js";
 import { createAuthedRequest } from "./auth/octokit.js";
+import { createGraphqlClient } from "./graphql/client.js";
 import {
   getToolEntry,
   listToolDescriptors,
@@ -33,6 +34,7 @@ import {
   registerTool,
 } from "./registry.js";
 import { registerTestConnectionTool } from "./tools/auth/test_connection.js";
+import { registerIssueTools } from "./tools/issue/index.js";
 
 // Read the package version from the package.json next to the dist
 // tree at startup, so a single source of truth (package.json) drives
@@ -66,12 +68,14 @@ export async function startServer(): Promise<void> {
   // including auth misses.
   const pat = resolvePat();
   const authedRequest = createAuthedRequest(pat);
-  // Pass `registerTool` in (rather than letting test_connection
-  // import it) so the dependency arrow is one-way:
-  // server.ts → tools/**, never tools/** → server.ts. Avoids the
-  // TDZ-prone cycle that would otherwise form once a tool registers
-  // at module-import time.
+  // Build the canonical GraphQL client once and hand it to every
+  // domain-tool registrar. Tools never construct their own client;
+  // sharing a single instance preserves the rate-limit policy state
+  // across calls and keeps the dependency arrow one-way:
+  // server.ts → tools/**, never tools/** → server.ts.
+  const graphql = createGraphqlClient(authedRequest);
   registerTestConnectionTool(registerTool, authedRequest);
+  registerIssueTools(registerTool, graphql);
 
   const server = new Server(
     {

--- a/src/tools/issue/_shared.ts
+++ b/src/tools/issue/_shared.ts
@@ -149,7 +149,16 @@ export async function lookupIssueNodeId(
     name: coords.name,
     number,
   });
-  const issueId = data.repository?.issue?.id;
+  // Distinguish "repo missing / no access" from "issue missing".
+  // Collapsing the two confused operators staring at typos in the
+  // repo slug — they'd see "issue X not found" and start hunting
+  // for the issue when the real problem was the repo.
+  if (!data.repository) {
+    throw new Error(
+      `mcp-github: ${where}: repository '${coords.owner}/${coords.name}' not found or token lacks read access`,
+    );
+  }
+  const issueId = data.repository.issue?.id;
   if (typeof issueId !== "string") {
     throw new Error(
       `mcp-github: ${where}: issue ${coords.owner}/${coords.name}#${number} not found`,

--- a/src/tools/issue/_shared.ts
+++ b/src/tools/issue/_shared.ts
@@ -60,6 +60,7 @@ interface RepoContextResponse {
 export async function loadRepoContext(
   graphql: GraphqlClient,
   coords: RepoCoords,
+  where: string,
 ): Promise<RepoContext> {
   const data = await graphql<RepoContextResponse>("issue/_repo-context", {
     owner: coords.owner,
@@ -67,26 +68,28 @@ export async function loadRepoContext(
   });
   if (!data.repository) {
     throw new Error(
-      `mcp-github: repository '${coords.owner}/${coords.name}' not found or token lacks read access`,
+      `mcp-github: ${where}: repository '${coords.owner}/${coords.name}' not found or token lacks read access`,
     );
   }
   // Detect truncation. With `first: 100` on each connection, a
   // repo with more than 100 labels or assignable users would
   // silently produce false "unknown label" / "unknown login"
   // errors for valid inputs that happened to live on page 2+. v0.1
-  // doesn't paginate; we throw a clear, actionable error instead
-  // so the caller sees the real cause and can pre-resolve IDs
-  // externally until full pagination lands in a later PR.
+  // doesn't paginate; we throw a clear, actionable error pointing
+  // the caller at the only workarounds the current tool surface
+  // supports (omit the field, or talk to GitHub directly).
   if (data.repository.labels.pageInfo.hasNextPage) {
     throw new Error(
-      `mcp-github: repository '${coords.owner}/${coords.name}' has more than 100 labels; ` +
-        `name-based resolution is not supported on this repo at v0.1. Use label IDs directly or paginate externally.`,
+      `mcp-github: ${where}: repository '${coords.owner}/${coords.name}' has more than 100 labels; ` +
+        `name-based label resolution is not supported on this repo at v0.1. ` +
+        `Omit 'labels' for now, or use the GitHub API / another client that can paginate labels.`,
     );
   }
   if (data.repository.assignableUsers.pageInfo.hasNextPage) {
     throw new Error(
-      `mcp-github: repository '${coords.owner}/${coords.name}' has more than 100 assignable users; ` +
-        `login-based resolution is not supported on this repo at v0.1. Use user IDs directly or paginate externally.`,
+      `mcp-github: ${where}: repository '${coords.owner}/${coords.name}' has more than 100 assignable users; ` +
+        `login-based assignee resolution is not supported on this repo at v0.1. ` +
+        `Omit 'assignees' for now, or paginate assignable users externally to find the intended login and retry.`,
     );
   }
   // Build name→id maps once so the per-label / per-assignee resolve
@@ -254,7 +257,15 @@ export const issueSummarySchema = {
 
 // Shape returned by GraphQL for an Issue: a superset of what we
 // expose. Tools use this to type the response, then map to
-// `IssueSummary` before validating.
+// `IssueSummary` before validating. The label/assignee connections
+// carry `pageInfo.hasNextPage` so `summariseIssue` can detect when
+// GitHub returned a truncated set and surface a warning rather
+// than silently emit a partial array.
+interface PaginatedNodes<T> {
+  pageInfo: { hasNextPage: boolean };
+  nodes: T[];
+}
+
 export interface RawIssue {
   number: number;
   url: string;
@@ -262,15 +273,35 @@ export interface RawIssue {
   title: string;
   state: "OPEN" | "CLOSED";
   body: string | null;
-  labels: { nodes: Array<{ name: string }> };
-  assignees: { nodes: Array<{ login: string }> };
+  labels: PaginatedNodes<{ name: string }>;
+  assignees: PaginatedNodes<{ login: string }>;
   author: { login: string } | null;
   createdAt: string;
   updatedAt: string;
   closedAt: string | null;
 }
 
-export function summariseIssue(raw: RawIssue): IssueSummary {
+// Issues with > 100 labels or > 100 assignees are vanishingly rare
+// in practice. Rather than fail or paginate, we warn once per
+// truncation event so observability tools (and test runs) see
+// the signal, without breaking otherwise-valid call paths. The
+// warn function is parameterised primarily so unit tests can
+// capture it; default writes to stderr.
+export function summariseIssue(
+  raw: RawIssue,
+  warn: (msg: string) => void = (msg) =>
+    process.stderr.write(`${msg}\n`),
+): IssueSummary {
+  if (raw.labels.pageInfo.hasNextPage) {
+    warn(
+      `mcp-github: issue ${raw.url} has more than 100 labels; output is truncated to the first page.`,
+    );
+  }
+  if (raw.assignees.pageInfo.hasNextPage) {
+    warn(
+      `mcp-github: issue ${raw.url} has more than 100 assignees; output is truncated to the first page.`,
+    );
+  }
   return {
     number: raw.number,
     url: raw.url,

--- a/src/tools/issue/_shared.ts
+++ b/src/tools/issue/_shared.ts
@@ -1,0 +1,256 @@
+// src/tools/issue/_shared.ts
+//
+// Helpers shared across the seven `gh.issue_*` tools. Lives here
+// (rather than in registry.ts or under src/) because everything in
+// this file is specific to the issue domain.
+//
+// The MCP-4 surface accepts repo as `"owner/name"` (matching `gh`
+// CLI ergonomics) plus labels/assignees as login-strings, and runs
+// the name-to-ID resolution against the GraphQL API. Centralising
+// the parsers + resolvers here keeps the tool files focused on
+// their specific operation rather than re-implementing the same
+// lookups seven times.
+
+import type { GraphqlClient } from "../../graphql/client.js";
+
+// Format used everywhere: `"owner/name"`. Spaces are rejected so a
+// caller mis-passing `" owner/name"` doesn't silently produce a
+// "repository not found" error from GitHub later.
+const REPO_SLUG_RE = /^([A-Za-z0-9._-]+)\/([A-Za-z0-9._-]+)$/;
+
+export interface RepoCoords {
+  owner: string;
+  name: string;
+}
+
+export function parseRepoSlug(slug: string, where: string): RepoCoords {
+  const match = REPO_SLUG_RE.exec(slug);
+  if (!match) {
+    throw new Error(
+      `mcp-github: ${where}: invalid repo '${slug}', expected "owner/name"`,
+    );
+  }
+  return { owner: match[1] as string, name: match[2] as string };
+}
+
+// Result of `_repo-context`: the repository's GraphQL node ID plus
+// the first page of its labels and assignable users. Used by
+// `gh.issue_create` and `gh.issue_edit` to resolve label names /
+// assignee logins to the GraphQL IDs that mutations require.
+export interface RepoContext {
+  repositoryId: string;
+  labelsByName: Map<string, string>;
+  usersByLogin: Map<string, string>;
+}
+
+interface RepoContextResponse {
+  repository: {
+    id: string;
+    labels: { nodes: Array<{ id: string; name: string }> };
+    assignableUsers: { nodes: Array<{ id: string; login: string }> };
+  } | null;
+}
+
+export async function loadRepoContext(
+  graphql: GraphqlClient,
+  coords: RepoCoords,
+): Promise<RepoContext> {
+  const data = await graphql<RepoContextResponse>("issue/_repo-context", {
+    owner: coords.owner,
+    name: coords.name,
+  });
+  if (!data.repository) {
+    throw new Error(
+      `mcp-github: repository '${coords.owner}/${coords.name}' not found or token lacks read access`,
+    );
+  }
+  // Build name→id maps once so the per-label / per-assignee resolve
+  // is O(1). The `first: 100` page-size on each connection is the
+  // v0.1 limit; repos with more than 100 labels / collaborators will
+  // need pagination support added in a later PR.
+  const labelsByName = new Map<string, string>();
+  for (const node of data.repository.labels.nodes) {
+    labelsByName.set(node.name, node.id);
+  }
+  const usersByLogin = new Map<string, string>();
+  for (const node of data.repository.assignableUsers.nodes) {
+    usersByLogin.set(node.login, node.id);
+  }
+  return {
+    repositoryId: data.repository.id,
+    labelsByName,
+    usersByLogin,
+  };
+}
+
+export function resolveLabelIds(
+  context: RepoContext,
+  names: readonly string[],
+  where: string,
+): string[] {
+  const ids: string[] = [];
+  const missing: string[] = [];
+  for (const name of names) {
+    const id = context.labelsByName.get(name);
+    if (id === undefined) {
+      missing.push(name);
+    } else {
+      ids.push(id);
+    }
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      `mcp-github: ${where}: unknown label(s): ${missing.join(", ")}`,
+    );
+  }
+  return ids;
+}
+
+export function resolveAssigneeIds(
+  context: RepoContext,
+  logins: readonly string[],
+  where: string,
+): string[] {
+  const ids: string[] = [];
+  const missing: string[] = [];
+  for (const login of logins) {
+    const id = context.usersByLogin.get(login);
+    if (id === undefined) {
+      missing.push(login);
+    } else {
+      ids.push(id);
+    }
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      `mcp-github: ${where}: unknown / non-assignable login(s): ${missing.join(", ")}`,
+    );
+  }
+  return ids;
+}
+
+// Looks up an issue's GraphQL node ID by repo + number. Used by the
+// three mutations that operate on an existing issue (edit, close,
+// comment) and don't otherwise need the full repo context.
+interface IssueLookupResponse {
+  repository: {
+    issue: { id: string } | null;
+  } | null;
+}
+
+export async function lookupIssueNodeId(
+  graphql: GraphqlClient,
+  coords: RepoCoords,
+  number: number,
+  where: string,
+): Promise<string> {
+  const data = await graphql<IssueLookupResponse>("issue/_issue-lookup", {
+    owner: coords.owner,
+    name: coords.name,
+    number,
+  });
+  const issueId = data.repository?.issue?.id;
+  if (typeof issueId !== "string") {
+    throw new Error(
+      `mcp-github: ${where}: issue ${coords.owner}/${coords.name}#${number} not found`,
+    );
+  }
+  return issueId;
+}
+
+// Common JSON-Schema fragment for `repo` (used by every input
+// schema in this domain). Inlined into each tool's schema rather
+// than `$ref`'d because ajv's strict-false config doesn't load
+// external schemas implicitly and the savings of ~5 lines per file
+// is not worth the indirection.
+export const repoSlugSchema = {
+  type: "string",
+  pattern: "^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$",
+  description: "Repository in the form `owner/name`",
+} as const;
+
+// Shape we return from view/edit/close handlers. Matches the
+// `Issue` GraphQL type's most useful fields; tools can omit
+// nullable fields when constructing this from their response.
+export interface IssueSummary {
+  number: number;
+  url: string;
+  node_id: string;
+  title: string;
+  state: string;
+  body: string | null;
+  labels: string[];
+  assignees: string[];
+  author: string | null;
+  created_at: string;
+  updated_at: string;
+  closed_at: string | null;
+}
+
+export const issueSummarySchema = {
+  type: "object",
+  required: [
+    "number",
+    "url",
+    "node_id",
+    "title",
+    "state",
+    "body",
+    "labels",
+    "assignees",
+    "author",
+    "created_at",
+    "updated_at",
+    "closed_at",
+  ],
+  properties: {
+    number: { type: "integer" },
+    url: { type: "string" },
+    node_id: { type: "string" },
+    title: { type: "string" },
+    state: { type: "string", enum: ["OPEN", "CLOSED"] },
+    body: { type: ["string", "null"] },
+    labels: { type: "array", items: { type: "string" } },
+    assignees: { type: "array", items: { type: "string" } },
+    author: { type: ["string", "null"] },
+    created_at: { type: "string" },
+    updated_at: { type: "string" },
+    closed_at: { type: ["string", "null"] },
+  },
+  additionalProperties: false,
+} as const;
+
+// Shape returned by GraphQL for an Issue: a superset of what we
+// expose. Tools use this to type the response, then map to
+// `IssueSummary` before validating.
+export interface RawIssue {
+  number: number;
+  url: string;
+  id: string;
+  title: string;
+  state: "OPEN" | "CLOSED";
+  body: string | null;
+  labels: { nodes: Array<{ name: string }> };
+  assignees: { nodes: Array<{ login: string }> };
+  author: { login: string } | null;
+  createdAt: string;
+  updatedAt: string;
+  closedAt: string | null;
+}
+
+export function summariseIssue(raw: RawIssue): IssueSummary {
+  return {
+    number: raw.number,
+    url: raw.url,
+    node_id: raw.id,
+    title: raw.title,
+    state: raw.state,
+    body: raw.body,
+    labels: raw.labels.nodes.map((n) => n.name),
+    assignees: raw.assignees.nodes.map((n) => n.login),
+    author: raw.author?.login ?? null,
+    created_at: raw.createdAt,
+    updated_at: raw.updatedAt,
+    closed_at: raw.closedAt,
+  };
+}

--- a/src/tools/issue/_shared.ts
+++ b/src/tools/issue/_shared.ts
@@ -46,8 +46,14 @@ export interface RepoContext {
 interface RepoContextResponse {
   repository: {
     id: string;
-    labels: { nodes: Array<{ id: string; name: string }> };
-    assignableUsers: { nodes: Array<{ id: string; login: string }> };
+    labels: {
+      pageInfo: { hasNextPage: boolean };
+      nodes: Array<{ id: string; name: string }>;
+    };
+    assignableUsers: {
+      pageInfo: { hasNextPage: boolean };
+      nodes: Array<{ id: string; login: string }>;
+    };
   } | null;
 }
 
@@ -64,10 +70,27 @@ export async function loadRepoContext(
       `mcp-github: repository '${coords.owner}/${coords.name}' not found or token lacks read access`,
     );
   }
+  // Detect truncation. With `first: 100` on each connection, a
+  // repo with more than 100 labels or assignable users would
+  // silently produce false "unknown label" / "unknown login"
+  // errors for valid inputs that happened to live on page 2+. v0.1
+  // doesn't paginate; we throw a clear, actionable error instead
+  // so the caller sees the real cause and can pre-resolve IDs
+  // externally until full pagination lands in a later PR.
+  if (data.repository.labels.pageInfo.hasNextPage) {
+    throw new Error(
+      `mcp-github: repository '${coords.owner}/${coords.name}' has more than 100 labels; ` +
+        `name-based resolution is not supported on this repo at v0.1. Use label IDs directly or paginate externally.`,
+    );
+  }
+  if (data.repository.assignableUsers.pageInfo.hasNextPage) {
+    throw new Error(
+      `mcp-github: repository '${coords.owner}/${coords.name}' has more than 100 assignable users; ` +
+        `login-based resolution is not supported on this repo at v0.1. Use user IDs directly or paginate externally.`,
+    );
+  }
   // Build name→id maps once so the per-label / per-assignee resolve
-  // is O(1). The `first: 100` page-size on each connection is the
-  // v0.1 limit; repos with more than 100 labels / collaborators will
-  // need pagination support added in a later PR.
+  // is O(1).
   const labelsByName = new Map<string, string>();
   for (const node of data.repository.labels.nodes) {
     labelsByName.set(node.name, node.id);

--- a/src/tools/issue/_shared.ts
+++ b/src/tools/issue/_shared.ts
@@ -186,7 +186,7 @@ export interface IssueSummary {
   url: string;
   node_id: string;
   title: string;
-  state: string;
+  state: "OPEN" | "CLOSED";
   body: string | null;
   labels: string[];
   assignees: string[];

--- a/src/tools/issue/close.ts
+++ b/src/tools/issue/close.ts
@@ -1,0 +1,98 @@
+// src/tools/issue/close.ts
+//
+// `gh.issue_close` — closes an issue with a stated reason
+// (`completed` or `not_planned`). Two-step: look up the node ID,
+// then run the closeIssue mutation. If a `comment` is supplied, we
+// post it BEFORE closing so it lands on the still-open issue and
+// authors who watch close events see the comment in context.
+
+import type { GraphqlClient } from "../../graphql/client.js";
+import type { ToolEntry } from "../../registry.js";
+import { validate } from "../../validation/validator.js";
+import {
+  type IssueSummary,
+  type RawIssue,
+  issueSummarySchema,
+  lookupIssueNodeId,
+  parseRepoSlug,
+  repoSlugSchema,
+  summariseIssue,
+} from "./_shared.js";
+
+const inputSchema = {
+  type: "object",
+  required: ["repo", "number", "reason"],
+  properties: {
+    repo: repoSlugSchema,
+    number: { type: "integer", minimum: 1 },
+    reason: { type: "string", enum: ["completed", "not_planned"] },
+    comment: {
+      type: "string",
+      minLength: 1,
+      description: "Optional closing comment posted before the close.",
+    },
+  },
+  additionalProperties: false,
+} as const;
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+interface Input {
+  repo: string;
+  number: number;
+  reason: "completed" | "not_planned";
+  comment?: string;
+}
+
+interface CloseResponse {
+  closeIssue: { issue: RawIssue };
+}
+
+interface CommentResponse {
+  addComment: { commentEdge: { node: { id: string } } };
+}
+
+const REASON_GRAPHQL: Record<Input["reason"], "COMPLETED" | "NOT_PLANNED"> = {
+  completed: "COMPLETED",
+  not_planned: "NOT_PLANNED",
+};
+
+export function registerIssueCloseTool(
+  register: RegisterToolFn,
+  graphql: GraphqlClient,
+): void {
+  register("gh.issue_close", {
+    description:
+      "Close an issue with a stated reason (completed | not_planned). " +
+      "Optionally post a closing comment before the close so watchers " +
+      "see the rationale alongside the state change.",
+    inputSchema,
+    handler: async (raw) => {
+      const args = validate<Input>(inputSchema, raw, "gh.issue_close input");
+      const coords = parseRepoSlug(args.repo, "gh.issue_close input");
+      const issueId = await lookupIssueNodeId(
+        graphql,
+        coords,
+        args.number,
+        "gh.issue_close",
+      );
+      if (args.comment !== undefined) {
+        await graphql<CommentResponse>("issue/comment", {
+          input: { subjectId: issueId, body: args.comment },
+        });
+      }
+      const data = await graphql<CloseResponse>("issue/close", {
+        input: {
+          issueId,
+          stateReason: REASON_GRAPHQL[args.reason],
+        },
+      });
+      const summary = summariseIssue(data.closeIssue.issue);
+      return validate<IssueSummary>(
+        issueSummarySchema,
+        summary,
+        "gh.issue_close output",
+      );
+    },
+  });
+}

--- a/src/tools/issue/comment.ts
+++ b/src/tools/issue/comment.ts
@@ -1,0 +1,91 @@
+// src/tools/issue/comment.ts
+//
+// `gh.issue_comment` — adds a comment to an existing issue.
+// Two-step: look up the issue's GraphQL node ID by repo + number,
+// then run the AddComment mutation against that ID. The two-step
+// flow is necessary because AddComment's `subjectId` requires a
+// node ID, not a (repo, number) pair.
+
+import type { GraphqlClient } from "../../graphql/client.js";
+import type { ToolEntry } from "../../registry.js";
+import { validate } from "../../validation/validator.js";
+import {
+  lookupIssueNodeId,
+  parseRepoSlug,
+  repoSlugSchema,
+} from "./_shared.js";
+
+const inputSchema = {
+  type: "object",
+  required: ["repo", "number", "body"],
+  properties: {
+    repo: repoSlugSchema,
+    number: { type: "integer", minimum: 1 },
+    body: { type: "string", minLength: 1 },
+  },
+  additionalProperties: false,
+} as const;
+
+const outputSchema = {
+  type: "object",
+  required: ["comment_id", "url"],
+  properties: {
+    comment_id: { type: "string" },
+    url: { type: "string" },
+  },
+  additionalProperties: false,
+} as const;
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+interface Input {
+  repo: string;
+  number: number;
+  body: string;
+}
+
+interface Output {
+  comment_id: string;
+  url: string;
+}
+
+interface CommentResponse {
+  addComment: {
+    commentEdge: {
+      node: { id: string; url: string };
+    };
+  };
+}
+
+export function registerIssueCommentTool(
+  register: RegisterToolFn,
+  graphql: GraphqlClient,
+): void {
+  register("gh.issue_comment", {
+    description:
+      "Add a comment to an issue. Returns the new comment's node ID " +
+      "and HTML url.",
+    inputSchema,
+    handler: async (raw) => {
+      const args = validate<Input>(inputSchema, raw, "gh.issue_comment input");
+      const coords = parseRepoSlug(args.repo, "gh.issue_comment input");
+      const issueId = await lookupIssueNodeId(
+        graphql,
+        coords,
+        args.number,
+        "gh.issue_comment",
+      );
+      const data = await graphql<CommentResponse>("issue/comment", {
+        input: {
+          subjectId: issueId,
+          body: args.body,
+        },
+      });
+      const out: Output = {
+        comment_id: data.addComment.commentEdge.node.id,
+        url: data.addComment.commentEdge.node.url,
+      };
+      return validate<Output>(outputSchema, out, "gh.issue_comment output");
+    },
+  });
+}

--- a/src/tools/issue/create.ts
+++ b/src/tools/issue/create.ts
@@ -1,0 +1,102 @@
+// src/tools/issue/create.ts
+//
+// `gh.issue_create` — creates an issue. The MCP-4 input shape is
+// gh-CLI-friendly (`repo: "owner/name"` plus label NAMES and
+// assignee LOGINS), but GitHub's `createIssue` mutation requires
+// the repository's GraphQL node ID, label IDs, and user IDs. So we
+// run a prep query (`issue/_repo-context`) first to resolve names
+// to IDs, then the mutation. The prep query also doubles as a
+// repo-existence check: a missing repo throws cleanly here rather
+// than producing a "repositoryId required" error from the mutation.
+
+import type { GraphqlClient } from "../../graphql/client.js";
+import type { ToolEntry } from "../../registry.js";
+import { validate } from "../../validation/validator.js";
+import {
+  type IssueSummary,
+  type RawIssue,
+  issueSummarySchema,
+  loadRepoContext,
+  parseRepoSlug,
+  repoSlugSchema,
+  resolveAssigneeIds,
+  resolveLabelIds,
+  summariseIssue,
+} from "./_shared.js";
+
+const inputSchema = {
+  type: "object",
+  required: ["repo", "title"],
+  properties: {
+    repo: repoSlugSchema,
+    title: { type: "string", minLength: 1 },
+    body: { type: "string" },
+    labels: {
+      type: "array",
+      items: { type: "string", minLength: 1 },
+      description: "Label names (must already exist on the repo).",
+    },
+    assignees: {
+      type: "array",
+      items: { type: "string", minLength: 1 },
+      description: "User logins (must be assignable to this repo).",
+    },
+  },
+  additionalProperties: false,
+} as const;
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+interface Input {
+  repo: string;
+  title: string;
+  body?: string;
+  labels?: string[];
+  assignees?: string[];
+}
+
+interface CreateResponse {
+  createIssue: { issue: RawIssue };
+}
+
+export function registerIssueCreateTool(
+  register: RegisterToolFn,
+  graphql: GraphqlClient,
+): void {
+  register("gh.issue_create", {
+    description:
+      "Create an issue. `repo` is `owner/name`; `labels` and " +
+      "`assignees` are name / login arrays — names that don't " +
+      "exist on the repo (or logins that aren't assignable) " +
+      "produce a structured error before the mutation runs.",
+    inputSchema,
+    handler: async (raw) => {
+      const args = validate<Input>(inputSchema, raw, "gh.issue_create input");
+      const coords = parseRepoSlug(args.repo, "gh.issue_create input");
+      const context = await loadRepoContext(graphql, coords);
+      const labelIds = args.labels
+        ? resolveLabelIds(context, args.labels, "gh.issue_create")
+        : undefined;
+      const assigneeIds = args.assignees
+        ? resolveAssigneeIds(context, args.assignees, "gh.issue_create")
+        : undefined;
+      // Build the mutation input object incrementally so unset
+      // fields stay absent rather than carrying explicit `undefined`
+      // values, which GraphQL serialises as `null` and rejects.
+      const input: Record<string, unknown> = {
+        repositoryId: context.repositoryId,
+        title: args.title,
+      };
+      if (args.body !== undefined) input.body = args.body;
+      if (labelIds !== undefined) input.labelIds = labelIds;
+      if (assigneeIds !== undefined) input.assigneeIds = assigneeIds;
+      const data = await graphql<CreateResponse>("issue/create", { input });
+      const summary = summariseIssue(data.createIssue.issue);
+      return validate<IssueSummary>(
+        issueSummarySchema,
+        summary,
+        "gh.issue_create output",
+      );
+    },
+  });
+}

--- a/src/tools/issue/create.ts
+++ b/src/tools/issue/create.ts
@@ -73,7 +73,7 @@ export function registerIssueCreateTool(
     handler: async (raw) => {
       const args = validate<Input>(inputSchema, raw, "gh.issue_create input");
       const coords = parseRepoSlug(args.repo, "gh.issue_create input");
-      const context = await loadRepoContext(graphql, coords);
+      const context = await loadRepoContext(graphql, coords, "gh.issue_create");
       const labelIds = args.labels
         ? resolveLabelIds(context, args.labels, "gh.issue_create")
         : undefined;

--- a/src/tools/issue/edit.ts
+++ b/src/tools/issue/edit.ts
@@ -1,0 +1,124 @@
+// src/tools/issue/edit.ts
+//
+// `gh.issue_edit` — updates an existing issue. Like `create`, the
+// MCP-4 surface accepts label NAMES + assignee LOGINS while the
+// GraphQL mutation needs IDs, so we run a repo-context query first
+// to resolve names. We use the issue's GraphQL node ID (not the
+// (repo, number) pair) because UpdateIssue's `id` input requires it.
+//
+// Semantics: passing `labels` / `assignees` REPLACES the issue's
+// current set with the new one. To clear, pass an empty array. To
+// leave unchanged, omit the field. Same as `gh issue edit`.
+
+import type { GraphqlClient } from "../../graphql/client.js";
+import type { ToolEntry } from "../../registry.js";
+import { validate } from "../../validation/validator.js";
+import {
+  type IssueSummary,
+  type RawIssue,
+  issueSummarySchema,
+  loadRepoContext,
+  lookupIssueNodeId,
+  parseRepoSlug,
+  repoSlugSchema,
+  resolveAssigneeIds,
+  resolveLabelIds,
+  summariseIssue,
+} from "./_shared.js";
+
+const inputSchema = {
+  type: "object",
+  required: ["repo", "number"],
+  properties: {
+    repo: repoSlugSchema,
+    number: { type: "integer", minimum: 1 },
+    title: { type: "string", minLength: 1 },
+    body: { type: "string" },
+    state: {
+      type: "string",
+      enum: ["OPEN", "CLOSED"],
+      description: "OPEN reopens; CLOSED closes (without a reason — use gh.issue_close for that).",
+    },
+    labels: {
+      type: "array",
+      items: { type: "string", minLength: 1 },
+      description: "Replaces the current label set. [] clears, omitting leaves unchanged.",
+    },
+    assignees: {
+      type: "array",
+      items: { type: "string", minLength: 1 },
+      description: "Replaces the current assignee set. [] clears, omitting leaves unchanged.",
+    },
+  },
+  additionalProperties: false,
+} as const;
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+interface Input {
+  repo: string;
+  number: number;
+  title?: string;
+  body?: string;
+  state?: "OPEN" | "CLOSED";
+  labels?: string[];
+  assignees?: string[];
+}
+
+interface EditResponse {
+  updateIssue: { issue: RawIssue };
+}
+
+export function registerIssueEditTool(
+  register: RegisterToolFn,
+  graphql: GraphqlClient,
+): void {
+  register("gh.issue_edit", {
+    description:
+      "Update fields on an existing issue. `labels` / `assignees` " +
+      "REPLACE the current set when supplied; pass `[]` to clear. " +
+      "Omitting a field leaves it unchanged.",
+    inputSchema,
+    handler: async (raw) => {
+      const args = validate<Input>(inputSchema, raw, "gh.issue_edit input");
+      const coords = parseRepoSlug(args.repo, "gh.issue_edit input");
+      const issueId = await lookupIssueNodeId(
+        graphql,
+        coords,
+        args.number,
+        "gh.issue_edit",
+      );
+      // Only spin up the repo-context lookup when the caller
+      // actually passes label or assignee arrays — view/title/body/
+      // state-only edits don't need to walk the repo's name maps.
+      let labelIds: string[] | undefined;
+      let assigneeIds: string[] | undefined;
+      if (args.labels !== undefined || args.assignees !== undefined) {
+        const context = await loadRepoContext(graphql, coords);
+        if (args.labels !== undefined) {
+          labelIds = resolveLabelIds(context, args.labels, "gh.issue_edit");
+        }
+        if (args.assignees !== undefined) {
+          assigneeIds = resolveAssigneeIds(
+            context,
+            args.assignees,
+            "gh.issue_edit",
+          );
+        }
+      }
+      const input: Record<string, unknown> = { id: issueId };
+      if (args.title !== undefined) input.title = args.title;
+      if (args.body !== undefined) input.body = args.body;
+      if (args.state !== undefined) input.state = args.state;
+      if (labelIds !== undefined) input.labelIds = labelIds;
+      if (assigneeIds !== undefined) input.assigneeIds = assigneeIds;
+      const data = await graphql<EditResponse>("issue/edit", { input });
+      const summary = summariseIssue(data.updateIssue.issue);
+      return validate<IssueSummary>(
+        issueSummarySchema,
+        summary,
+        "gh.issue_edit output",
+      );
+    },
+  });
+}

--- a/src/tools/issue/edit.ts
+++ b/src/tools/issue/edit.ts
@@ -94,7 +94,7 @@ export function registerIssueEditTool(
       let labelIds: string[] | undefined;
       let assigneeIds: string[] | undefined;
       if (args.labels !== undefined || args.assignees !== undefined) {
-        const context = await loadRepoContext(graphql, coords);
+        const context = await loadRepoContext(graphql, coords, "gh.issue_edit");
         if (args.labels !== undefined) {
           labelIds = resolveLabelIds(context, args.labels, "gh.issue_edit");
         }

--- a/src/tools/issue/index.ts
+++ b/src/tools/issue/index.ts
@@ -1,0 +1,32 @@
+// src/tools/issue/index.ts
+//
+// Aggregator for the seven `gh.issue_*` tools. Imported by
+// `src/server.ts`'s `startServer()` and called once at boot to
+// register every issue-domain tool against the registry. Each
+// individual tool lives in its own file to keep the per-tool
+// schemas + handlers manageable; this file just orchestrates.
+
+import type { GraphqlClient } from "../../graphql/client.js";
+import type { ToolEntry } from "../../registry.js";
+import { registerIssueCloseTool } from "./close.js";
+import { registerIssueCommentTool } from "./comment.js";
+import { registerIssueCreateTool } from "./create.js";
+import { registerIssueEditTool } from "./edit.js";
+import { registerIssueListTool } from "./list.js";
+import { registerIssueSearchTool } from "./search.js";
+import { registerIssueViewTool } from "./view.js";
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+export function registerIssueTools(
+  register: RegisterToolFn,
+  graphql: GraphqlClient,
+): void {
+  registerIssueCreateTool(register, graphql);
+  registerIssueViewTool(register, graphql);
+  registerIssueListTool(register, graphql);
+  registerIssueEditTool(register, graphql);
+  registerIssueCloseTool(register, graphql);
+  registerIssueCommentTool(register, graphql);
+  registerIssueSearchTool(register, graphql);
+}

--- a/src/tools/issue/list.ts
+++ b/src/tools/issue/list.ts
@@ -133,24 +133,29 @@ export function registerIssueListTool(
           `mcp-github: gh.issue_list: repository '${coords.owner}/${coords.name}' not found or token lacks read access`,
         );
       }
+      // Filter the raw GraphQL nodes BEFORE summarising. Mapping
+      // each node through `summariseIssue` allocates new arrays for
+      // labels + assignees, so doing it for items that will be
+      // dropped wastes work proportional to the page size. Inline
+      // checks on the raw shape are cheaper and only the survivors
+      // pay the summarisation cost.
       const sinceMs = args.since ? Date.parse(args.since) : NaN;
-      const filtered = data.repository.issues.nodes
-        .map(summariseIssue)
-        .filter((issue) => {
-          if (
-            args.assignee &&
-            !issue.assignees.includes(args.assignee)
-          ) {
-            return false;
+      const filtered: IssueSummary[] = [];
+      for (const issue of data.repository.issues.nodes) {
+        if (
+          args.assignee &&
+          !issue.assignees.nodes.some((a) => a.login === args.assignee)
+        ) {
+          continue;
+        }
+        if (Number.isFinite(sinceMs)) {
+          const updatedMs = Date.parse(issue.updatedAt);
+          if (Number.isFinite(updatedMs) && updatedMs < sinceMs) {
+            continue;
           }
-          if (Number.isFinite(sinceMs)) {
-            const updatedMs = Date.parse(issue.updated_at);
-            if (Number.isFinite(updatedMs) && updatedMs < sinceMs) {
-              return false;
-            }
-          }
-          return true;
-        });
+        }
+        filtered.push(summariseIssue(issue));
+      }
       const out: Output = {
         items: filtered,
         hasNextPage: data.repository.issues.pageInfo.hasNextPage,

--- a/src/tools/issue/list.ts
+++ b/src/tools/issue/list.ts
@@ -40,11 +40,12 @@ const inputSchema = {
     },
     labels: {
       type: "array",
-      items: { type: "string" },
+      items: { type: "string", minLength: 1 },
       description: "Filter to issues that have ALL of these labels.",
     },
     assignee: {
       type: "string",
+      minLength: 1,
       description: "Filter to issues assigned to this login.",
     },
     since: {

--- a/src/tools/issue/list.ts
+++ b/src/tools/issue/list.ts
@@ -60,6 +60,7 @@ const inputSchema = {
     },
     after: {
       type: "string",
+      minLength: 1,
       description: "Opaque cursor from a previous page's endCursor.",
     },
   },

--- a/src/tools/issue/list.ts
+++ b/src/tools/issue/list.ts
@@ -1,0 +1,174 @@
+// src/tools/issue/list.ts
+//
+// `gh.issue_list` — paginated list of issues in a repo, optionally
+// filtered by state / labels / assignee / since. Output is one
+// page; the caller advances through pages via the returned
+// `endCursor` (passed back as `after` on the next call).
+//
+// Note on `assignee` + `since`: GraphQL's `Repository.issues`
+// doesn't support these directly. We accept them in the input
+// (matching `gh issue list`'s ergonomics) and post-filter the
+// returned page client-side. That means the page-size budget is
+// "best effort" — a heavy `assignee` filter can produce a small
+// page from a large fetch — but the surface stays consistent with
+// the gh CLI.
+
+import type { GraphqlClient } from "../../graphql/client.js";
+import type { ToolEntry } from "../../registry.js";
+import { validate } from "../../validation/validator.js";
+import {
+  type IssueSummary,
+  type RawIssue,
+  issueSummarySchema,
+  parseRepoSlug,
+  repoSlugSchema,
+  summariseIssue,
+} from "./_shared.js";
+
+const PER_PAGE_DEFAULT = 30;
+const PER_PAGE_MAX = 100;
+
+const inputSchema = {
+  type: "object",
+  required: ["repo"],
+  properties: {
+    repo: repoSlugSchema,
+    state: {
+      type: "string",
+      enum: ["OPEN", "CLOSED", "ALL"],
+      description: "Defaults to OPEN.",
+    },
+    labels: {
+      type: "array",
+      items: { type: "string" },
+      description: "Filter to issues that have ALL of these labels.",
+    },
+    assignee: {
+      type: "string",
+      description: "Filter to issues assigned to this login.",
+    },
+    since: {
+      type: "string",
+      format: "date-time",
+      description: "ISO-8601; only issues updated at-or-after this instant.",
+    },
+    perPage: {
+      type: "integer",
+      minimum: 1,
+      maximum: PER_PAGE_MAX,
+    },
+    after: {
+      type: "string",
+      description: "Opaque cursor from a previous page's endCursor.",
+    },
+  },
+  additionalProperties: false,
+} as const;
+
+const outputSchema = {
+  type: "object",
+  required: ["items", "hasNextPage", "endCursor"],
+  properties: {
+    items: { type: "array", items: issueSummarySchema },
+    hasNextPage: { type: "boolean" },
+    endCursor: { type: ["string", "null"] },
+  },
+  additionalProperties: false,
+} as const;
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+interface Input {
+  repo: string;
+  state?: "OPEN" | "CLOSED" | "ALL";
+  labels?: string[];
+  assignee?: string;
+  since?: string;
+  perPage?: number;
+  after?: string;
+}
+
+interface Output {
+  items: IssueSummary[];
+  hasNextPage: boolean;
+  endCursor: string | null;
+}
+
+interface Response {
+  repository: {
+    issues: {
+      pageInfo: { hasNextPage: boolean; endCursor: string | null };
+      nodes: RawIssue[];
+    };
+  } | null;
+}
+
+export function registerIssueListTool(
+  register: RegisterToolFn,
+  graphql: GraphqlClient,
+): void {
+  register("gh.issue_list", {
+    description:
+      "List issues in a repository with optional state / label / " +
+      "assignee / since filters. Returns one page; advance with the " +
+      "returned `endCursor` (pass as `after` next call). " +
+      "`assignee` and `since` are post-filtered client-side because " +
+      "GraphQL Repository.issues doesn't index them directly.",
+    inputSchema,
+    handler: async (raw) => {
+      const args = validate<Input>(inputSchema, raw, "gh.issue_list input");
+      const coords = parseRepoSlug(args.repo, "gh.issue_list input");
+      const states = mapStateFilter(args.state);
+      const data = await graphql<Response>("issue/list", {
+        owner: coords.owner,
+        name: coords.name,
+        states,
+        labels: args.labels && args.labels.length > 0 ? args.labels : null,
+        first: args.perPage ?? PER_PAGE_DEFAULT,
+        after: args.after ?? null,
+      });
+      if (!data.repository) {
+        throw new Error(
+          `mcp-github: gh.issue_list: repository '${coords.owner}/${coords.name}' not found or token lacks read access`,
+        );
+      }
+      const sinceMs = args.since ? Date.parse(args.since) : NaN;
+      const filtered = data.repository.issues.nodes
+        .map(summariseIssue)
+        .filter((issue) => {
+          if (
+            args.assignee &&
+            !issue.assignees.includes(args.assignee)
+          ) {
+            return false;
+          }
+          if (Number.isFinite(sinceMs)) {
+            const updatedMs = Date.parse(issue.updated_at);
+            if (Number.isFinite(updatedMs) && updatedMs < sinceMs) {
+              return false;
+            }
+          }
+          return true;
+        });
+      const out: Output = {
+        items: filtered,
+        hasNextPage: data.repository.issues.pageInfo.hasNextPage,
+        endCursor: data.repository.issues.pageInfo.endCursor,
+      };
+      return validate<Output>(outputSchema, out, "gh.issue_list output");
+    },
+  });
+}
+
+// Map our caller-friendly enum onto the GraphQL `IssueState` shape.
+// `ALL` translates to "no filter" (null), which GraphQL interprets
+// as both states. Unset defaults to OPEN, matching `gh issue list`
+// ergonomics — callers who want every state pass `state: "ALL"`
+// explicitly rather than relying on a noisy default.
+function mapStateFilter(
+  state: Input["state"],
+): Array<"OPEN" | "CLOSED"> | null {
+  if (state === "ALL") return null;
+  if (state === undefined) return ["OPEN"];
+  return [state];
+}

--- a/src/tools/issue/search.ts
+++ b/src/tools/issue/search.ts
@@ -40,6 +40,7 @@ const inputSchema = {
     },
     after: {
       type: "string",
+      minLength: 1,
       description: "Opaque cursor from a previous page's endCursor.",
     },
   },

--- a/src/tools/issue/search.ts
+++ b/src/tools/issue/search.ts
@@ -1,0 +1,149 @@
+// src/tools/issue/search.ts
+//
+// `gh.issue_search` — runs a GitHub search query (`type: ISSUE`)
+// and returns a paginated result page. Output items extend the
+// canonical `IssueSummary` shape with a `repo` field
+// (`owner/name`) so cross-repo searches are usable without an
+// extra round-trip to look up which repo each hit belongs to.
+//
+// The search query syntax is GitHub's standard one (e.g.
+// `is:issue is:open repo:foo/bar label:bug`). We pass it through
+// verbatim; the caller is responsible for shaping it correctly.
+
+import type { GraphqlClient } from "../../graphql/client.js";
+import type { ToolEntry } from "../../registry.js";
+import { validate } from "../../validation/validator.js";
+import {
+  type IssueSummary,
+  type RawIssue,
+  issueSummarySchema,
+  summariseIssue,
+} from "./_shared.js";
+
+const PER_PAGE_DEFAULT = 30;
+const PER_PAGE_MAX = 100;
+
+const inputSchema = {
+  type: "object",
+  required: ["q"],
+  properties: {
+    q: {
+      type: "string",
+      minLength: 1,
+      description:
+        "GitHub search query, e.g. `is:issue is:open repo:foo/bar label:bug`.",
+    },
+    perPage: {
+      type: "integer",
+      minimum: 1,
+      maximum: PER_PAGE_MAX,
+    },
+    after: {
+      type: "string",
+      description: "Opaque cursor from a previous page's endCursor.",
+    },
+  },
+  additionalProperties: false,
+} as const;
+
+const itemSchema = {
+  ...issueSummarySchema,
+  required: [...issueSummarySchema.required, "repo"],
+  properties: {
+    ...issueSummarySchema.properties,
+    repo: { type: "string", description: "owner/name of the issue's repo" },
+  },
+} as const;
+
+const outputSchema = {
+  type: "object",
+  required: ["items", "total", "hasNextPage", "endCursor"],
+  properties: {
+    items: { type: "array", items: itemSchema },
+    total: {
+      type: "integer",
+      description: "Total matches across all pages (search.issueCount).",
+    },
+    hasNextPage: { type: "boolean" },
+    endCursor: { type: ["string", "null"] },
+  },
+  additionalProperties: false,
+} as const;
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+interface Input {
+  q: string;
+  perPage?: number;
+  after?: string;
+}
+
+interface RawSearchHit extends RawIssue {
+  __typename: "Issue";
+  repository: { nameWithOwner: string };
+}
+
+interface RawNonIssueHit {
+  __typename: string;
+}
+
+interface Response {
+  search: {
+    issueCount: number;
+    pageInfo: { hasNextPage: boolean; endCursor: string | null };
+    nodes: Array<RawSearchHit | RawNonIssueHit>;
+  };
+}
+
+interface SearchItem extends IssueSummary {
+  repo: string;
+}
+
+interface Output {
+  items: SearchItem[];
+  total: number;
+  hasNextPage: boolean;
+  endCursor: string | null;
+}
+
+export function registerIssueSearchTool(
+  register: RegisterToolFn,
+  graphql: GraphqlClient,
+): void {
+  register("gh.issue_search", {
+    description:
+      "Search issues across GitHub via the standard query syntax. " +
+      "Returns paginated results carrying the canonical issue shape " +
+      "plus a `repo` field for cross-repo hits. Total match count " +
+      "is in `total`.",
+    inputSchema,
+    handler: async (raw) => {
+      const args = validate<Input>(inputSchema, raw, "gh.issue_search input");
+      const data = await graphql<Response>("issue/search", {
+        q: args.q,
+        first: args.perPage ?? PER_PAGE_DEFAULT,
+        after: args.after ?? null,
+      });
+      const items: SearchItem[] = [];
+      for (const node of data.search.nodes) {
+        // The `type: ISSUE` filter means non-Issue hits shouldn't
+        // appear, but the GraphQL union type is `SearchResultItem`
+        // and other variants are theoretically possible. Skip them
+        // defensively rather than crashing on a missing field.
+        if (node.__typename !== "Issue") continue;
+        const issue = node as RawSearchHit;
+        items.push({
+          ...summariseIssue(issue),
+          repo: issue.repository.nameWithOwner,
+        });
+      }
+      const out: Output = {
+        items,
+        total: data.search.issueCount,
+        hasNextPage: data.search.pageInfo.hasNextPage,
+        endCursor: data.search.pageInfo.endCursor,
+      };
+      return validate<Output>(outputSchema, out, "gh.issue_search output");
+    },
+  });
+}

--- a/src/tools/issue/view.ts
+++ b/src/tools/issue/view.ts
@@ -58,10 +58,18 @@ export function registerIssueViewTool(
         name: coords.name,
         number: args.number,
       });
-      const issue = data.repository?.issue;
+      // Distinguish "repo missing / no access" from "issue missing"
+      // so a typo in the slug doesn't surface as a misleading
+      // "issue not found" message that points at the wrong axis.
+      if (!data.repository) {
+        throw new Error(
+          `mcp-github: gh.issue_view: repository '${coords.owner}/${coords.name}' not found or token lacks read access`,
+        );
+      }
+      const issue = data.repository.issue;
       if (!issue) {
         throw new Error(
-          `mcp-github: gh.issue_view: ${coords.owner}/${coords.name}#${args.number} not found`,
+          `mcp-github: gh.issue_view: issue ${coords.owner}/${coords.name}#${args.number} not found`,
         );
       }
       const summary = summariseIssue(issue);

--- a/src/tools/issue/view.ts
+++ b/src/tools/issue/view.ts
@@ -1,0 +1,75 @@
+// src/tools/issue/view.ts
+//
+// `gh.issue_view` — fetches a single issue by `repo` + `number`.
+// Returns the canonical IssueSummary shape (see ./_shared.ts), so
+// every consumer of an issue payload across this domain reads the
+// same fields. The mutation tools (create/edit/close) build their
+// response by feeding the GraphQL `Issue` payload through the same
+// `summariseIssue()` helper.
+
+import type { GraphqlClient } from "../../graphql/client.js";
+import type { ToolEntry } from "../../registry.js";
+import { validate } from "../../validation/validator.js";
+import {
+  type IssueSummary,
+  type RawIssue,
+  issueSummarySchema,
+  parseRepoSlug,
+  repoSlugSchema,
+  summariseIssue,
+} from "./_shared.js";
+
+const inputSchema = {
+  type: "object",
+  required: ["repo", "number"],
+  properties: {
+    repo: repoSlugSchema,
+    number: { type: "integer", minimum: 1 },
+  },
+  additionalProperties: false,
+} as const;
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+interface Input {
+  repo: string;
+  number: number;
+}
+
+interface Response {
+  repository: { issue: RawIssue | null } | null;
+}
+
+export function registerIssueViewTool(
+  register: RegisterToolFn,
+  graphql: GraphqlClient,
+): void {
+  register("gh.issue_view", {
+    description:
+      "Fetch a single issue by repository and number. Returns the " +
+      "canonical issue summary (number, url, node_id, title, state, " +
+      "body, labels[], assignees[], author, timestamps).",
+    inputSchema,
+    handler: async (raw) => {
+      const args = validate<Input>(inputSchema, raw, "gh.issue_view input");
+      const coords = parseRepoSlug(args.repo, "gh.issue_view input");
+      const data = await graphql<Response>("issue/view", {
+        owner: coords.owner,
+        name: coords.name,
+        number: args.number,
+      });
+      const issue = data.repository?.issue;
+      if (!issue) {
+        throw new Error(
+          `mcp-github: gh.issue_view: ${coords.owner}/${coords.name}#${args.number} not found`,
+        );
+      }
+      const summary = summariseIssue(issue);
+      return validate<IssueSummary>(
+        issueSummarySchema,
+        summary,
+        "gh.issue_view output",
+      );
+    },
+  });
+}

--- a/src/validation/validator.ts
+++ b/src/validation/validator.ts
@@ -38,10 +38,25 @@ addFormats(ajv);
 // WeakMap key is stable and the cache hits on every subsequent call.
 const compileCache = new WeakMap<object, ValidateFunction>();
 
+// Test-only counter incremented on every cache miss (i.e. every
+// real ajv.compile call). Lets the unit suite assert that a schema
+// passed to validate() multiple times is compiled exactly once,
+// pinning the caching contract instead of just exercising
+// "successive calls succeed" (which would also pass under a broken
+// cache that recompiled every time).
+let compileCount = 0;
+export function _getCompileCount(): number {
+  return compileCount;
+}
+export function _resetCompileCount(): void {
+  compileCount = 0;
+}
+
 function compile(schema: Record<string, unknown>): ValidateFunction {
   let v = compileCache.get(schema);
   if (!v) {
     v = ajv.compile(schema);
+    compileCount += 1;
     compileCache.set(schema, v);
   }
   return v;

--- a/src/validation/validator.ts
+++ b/src/validation/validator.ts
@@ -16,13 +16,22 @@
 // compiled lazily and cached by reference.
 
 import Ajv, { type ErrorObject, type ValidateFunction } from "ajv";
+import addFormats from "ajv-formats";
 
 // One Ajv instance shared across the process. `strict: false` because
 // we use a few non-standard keywords for documentation (`example`,
 // `description` on object fields) that ajv would otherwise warn
 // about. `allErrors: true` collects every violation so the structured
 // error message can list all of them, not just the first one.
+//
+// `addFormats` registers the standard JSON-Schema formats
+// (`date-time`, `email`, `uri`, etc.). Without this call ajv treats
+// unknown formats as no-ops under `strict: false`, so a schema
+// declaring `format: "date-time"` would silently accept any string.
+// We need real format enforcement on inputs like `gh.issue_list`'s
+// `since` field.
 const ajv = new Ajv({ strict: false, allErrors: true });
+addFormats(ajv);
 
 // Cache compiled validators by schema-object identity. Schema objects
 // are usually module-level constants in the tool files, so the

--- a/src/validation/validator.ts
+++ b/src/validation/validator.ts
@@ -1,0 +1,94 @@
+// src/validation/validator.ts
+//
+// Lightweight wrapper around ajv for JSON-Schema validation. Used by
+// every tool handler to gate input/output payloads at the boundary
+// between the MCP transport and the GraphQL client. The MCP SDK does
+// NOT auto-validate `request.params.arguments` against a tool's
+// declared `inputSchema` — we have to do it ourselves, otherwise a
+// malformed input lands in a handler that crashes on
+// `args.someField.someSubfield` rather than returning a clean
+// protocol error.
+//
+// Why ajv: industry-standard, draft-07/2019/2020 support, JIT
+// compiles schemas to functions (so per-call validation is cheap
+// even with the deeply-nested issue/PR/project shapes we'll be
+// validating dozens of times a session). Single-instance, schemas
+// compiled lazily and cached by reference.
+
+import Ajv, { type ErrorObject, type ValidateFunction } from "ajv";
+
+// One Ajv instance shared across the process. `strict: false` because
+// we use a few non-standard keywords for documentation (`example`,
+// `description` on object fields) that ajv would otherwise warn
+// about. `allErrors: true` collects every violation so the structured
+// error message can list all of them, not just the first one.
+const ajv = new Ajv({ strict: false, allErrors: true });
+
+// Cache compiled validators by schema-object identity. Schema objects
+// are usually module-level constants in the tool files, so the
+// WeakMap key is stable and the cache hits on every subsequent call.
+const compileCache = new WeakMap<object, ValidateFunction>();
+
+function compile(schema: Record<string, unknown>): ValidateFunction {
+  let v = compileCache.get(schema);
+  if (!v) {
+    v = ajv.compile(schema);
+    compileCache.set(schema, v);
+  }
+  return v;
+}
+
+export class SchemaValidationError extends Error {
+  override readonly name = "SchemaValidationError";
+  readonly errors: readonly ErrorObject[];
+  readonly where: string;
+  constructor(where: string, errors: readonly ErrorObject[]) {
+    const summary = errors.map(formatError).join("; ");
+    super(`mcp-github: ${where}: ${summary}`);
+    this.errors = errors;
+    this.where = where;
+  }
+}
+
+// Render one ajv error onto a single line. We pull
+// `params.additionalProperty` and `params.allowedValues` into the
+// message text because for `additionalProperties` and `enum`
+// failures the `instancePath` alone is `<root>` / the field path,
+// and the ajv-default `message` ("must NOT have additional
+// properties" / "must be equal to one of the allowed values")
+// doesn't say which property or which values — leaving the
+// message useless without manual cross-referencing.
+function formatError(err: ErrorObject): string {
+  const at = err.instancePath || "<root>";
+  const base = err.message ?? "invalid";
+  const params = err.params as Record<string, unknown>;
+  const extra: string[] = [];
+  if (typeof params["additionalProperty"] === "string") {
+    extra.push(`'${params["additionalProperty"]}'`);
+  }
+  if (Array.isArray(params["allowedValues"])) {
+    extra.push(`allowed: ${(params["allowedValues"] as unknown[]).join(", ")}`);
+  }
+  return extra.length > 0 ? `${at}: ${base} (${extra.join("; ")})` : `${at}: ${base}`;
+}
+
+// Validate `data` against `schema`. On success returns the value
+// (typed as `T` for caller convenience); on failure throws
+// `SchemaValidationError` whose message names the violation site
+// (`<root>`, `/title`, `/labels/0`) and the ajv-supplied reason.
+//
+// `where` is an opaque string included in the error for diagnostics
+// (e.g. `"gh.issue_create input"` or `"gh.issue_view output"`); it
+// flows straight into the error message.
+export function validate<T = unknown>(
+  schema: Record<string, unknown>,
+  data: unknown,
+  where: string,
+): T {
+  const v = compile(schema);
+  const ok = v(data);
+  if (!ok) {
+    throw new SchemaValidationError(where, v.errors ?? []);
+  }
+  return data as T;
+}

--- a/tests/smoke/server-lists-tools.mjs
+++ b/tests/smoke/server-lists-tools.mjs
@@ -25,7 +25,16 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SERVER = resolve(__dirname, "..", "..", "dist", "server.mjs");
 
-const EXPECTED_TOOLS = ["gh.test_connection"];
+const EXPECTED_TOOLS = [
+  "gh.test_connection",
+  "gh.issue_create",
+  "gh.issue_view",
+  "gh.issue_list",
+  "gh.issue_edit",
+  "gh.issue_close",
+  "gh.issue_comment",
+  "gh.issue_search",
+];
 
 function frame(payload) {
   // Newline-delimited JSON-RPC. JSON.stringify cannot emit a literal

--- a/tests/smoke/server-lists-tools.mjs
+++ b/tests/smoke/server-lists-tools.mjs
@@ -3,10 +3,12 @@
 //
 // End-to-end smoke test: spawn the freshly-built dist/server.mjs over
 // stdio, send the MCP `initialize` handshake + `tools/list`, assert
-// the registered tool surface (currently just `gh.test_connection`
-// from MCP-2). Proves the SDK wiring + auth bootstrap + tool
-// registration chain end-to-end without pulling in the unit-test
-// framework.
+// the registered tool surface (the auth probe `gh.test_connection`
+// from MCP-2 plus the seven `gh.issue_*` tools from MCP-4). The
+// `EXPECTED_TOOLS` list below is the source of truth — update it
+// whenever a new domain-tool batch lands. Proves the SDK wiring +
+// auth bootstrap + tool registration chain end-to-end without
+// pulling in the unit-test framework.
 //
 // Wire format: the MCP SDK's StdioServerTransport uses newline-
 // delimited JSON-RPC (one JSON message per `\n`-terminated line),

--- a/tests/unit/tools/issue/_fixtures.ts
+++ b/tests/unit/tools/issue/_fixtures.ts
@@ -1,0 +1,77 @@
+// tests/unit/tools/issue/_fixtures.ts
+//
+// Shared fixtures for the gh.issue_* tool tests. Each test mocks
+// the GraphqlClient by name (the loader's queryName argument), so
+// fixtures here describe the canonical happy-path response shapes
+// for each query the issue tools call.
+
+import type { GraphqlClient } from "../../../../src/graphql/client.ts";
+
+export interface MockedCall {
+  queryName: string;
+  vars: Record<string, unknown>;
+}
+
+// Build a graphql() stub that dispatches by queryName. Each entry
+// in `fixtures` is either a value (returned directly) or a
+// function (called with the vars). Calls outside the fixture map
+// throw — every test must declare every query its handler runs.
+export function stubGraphqlClient(
+  fixtures: Record<
+    string,
+    | unknown
+    | ((vars: Record<string, unknown>) => unknown | Promise<unknown>)
+  >,
+): { graphql: GraphqlClient; calls: MockedCall[] } {
+  const calls: MockedCall[] = [];
+  const graphql = (async (
+    queryName: string,
+    vars: Record<string, unknown> = {},
+  ) => {
+    calls.push({ queryName, vars });
+    if (!(queryName in fixtures)) {
+      throw new Error(
+        `tests: stubGraphqlClient saw unmocked queryName: ${queryName}`,
+      );
+    }
+    const entry = fixtures[queryName];
+    if (typeof entry === "function") {
+      return await (entry as (v: Record<string, unknown>) => unknown)(vars);
+    }
+    return entry;
+  }) as unknown as GraphqlClient;
+  return { graphql, calls };
+}
+
+export const sampleRawIssue = {
+  number: 42,
+  url: "https://github.com/owner/repo/issues/42",
+  id: "I_kwDO_42",
+  title: "Sample title",
+  state: "OPEN" as const,
+  body: "Sample body",
+  labels: { nodes: [{ name: "bug" }, { name: "p1" }] },
+  assignees: { nodes: [{ login: "alice" }] },
+  author: { login: "bob" },
+  createdAt: "2026-04-01T00:00:00Z",
+  updatedAt: "2026-04-02T00:00:00Z",
+  closedAt: null,
+};
+
+export const sampleRepoContextResponse = {
+  repository: {
+    id: "R_kwDO_repo",
+    labels: {
+      nodes: [
+        { id: "LA_bug", name: "bug" },
+        { id: "LA_p1", name: "p1" },
+      ],
+    },
+    assignableUsers: {
+      nodes: [
+        { id: "U_alice", login: "alice" },
+        { id: "U_bob", login: "bob" },
+      ],
+    },
+  },
+};

--- a/tests/unit/tools/issue/_fixtures.ts
+++ b/tests/unit/tools/issue/_fixtures.ts
@@ -50,8 +50,14 @@ export const sampleRawIssue = {
   title: "Sample title",
   state: "OPEN" as const,
   body: "Sample body",
-  labels: { nodes: [{ name: "bug" }, { name: "p1" }] },
-  assignees: { nodes: [{ login: "alice" }] },
+  labels: {
+    pageInfo: { hasNextPage: false },
+    nodes: [{ name: "bug" }, { name: "p1" }],
+  },
+  assignees: {
+    pageInfo: { hasNextPage: false },
+    nodes: [{ login: "alice" }],
+  },
   author: { login: "bob" },
   createdAt: "2026-04-01T00:00:00Z",
   updatedAt: "2026-04-02T00:00:00Z",

--- a/tests/unit/tools/issue/_fixtures.ts
+++ b/tests/unit/tools/issue/_fixtures.ts
@@ -62,12 +62,14 @@ export const sampleRepoContextResponse = {
   repository: {
     id: "R_kwDO_repo",
     labels: {
+      pageInfo: { hasNextPage: false },
       nodes: [
         { id: "LA_bug", name: "bug" },
         { id: "LA_p1", name: "p1" },
       ],
     },
     assignableUsers: {
+      pageInfo: { hasNextPage: false },
       nodes: [
         { id: "U_alice", login: "alice" },
         { id: "U_bob", login: "bob" },

--- a/tests/unit/tools/issue/_shared.test.ts
+++ b/tests/unit/tools/issue/_shared.test.ts
@@ -1,0 +1,104 @@
+// tests/unit/tools/issue/_shared.test.ts
+//
+// Pin the shared helpers used across the seven gh.issue_* tools.
+// These cover the bits that aren't already exercised by the
+// per-tool tests: the parseRepoSlug regex, summariseIssue's
+// truncation warning, and the resolveLabelIds / resolveAssigneeIds
+// error messages.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  parseRepoSlug,
+  resolveAssigneeIds,
+  resolveLabelIds,
+  summariseIssue,
+  type RepoContext,
+} from "../../../../src/tools/issue/_shared.ts";
+import { sampleRawIssue } from "./_fixtures.ts";
+
+test("parseRepoSlug: accepts canonical owner/name and rejects malformed input", () => {
+  assert.deepEqual(parseRepoSlug("owner/repo", "test"), {
+    owner: "owner",
+    name: "repo",
+  });
+  assert.throws(() => parseRepoSlug("no-slash", "test"), /test: invalid repo/);
+  assert.throws(() => parseRepoSlug("a/b/c", "test"), /test: invalid repo/);
+  assert.throws(() => parseRepoSlug(" owner/repo", "test"), /test: invalid repo/);
+});
+
+test("summariseIssue: warns when labels are truncated, lists what was returned", () => {
+  // Truncation is non-fatal — issues with > 100 labels are
+  // vanishingly rare in practice, so we surface a stderr-style
+  // warning rather than failing or paginating. Pin both the
+  // warning content and the fact that the visible labels are
+  // still passed through.
+  const truncated = {
+    ...sampleRawIssue,
+    labels: {
+      pageInfo: { hasNextPage: true },
+      nodes: [{ name: "bug" }, { name: "p1" }],
+    },
+  };
+  const warns: string[] = [];
+  const summary = summariseIssue(truncated, (m) => warns.push(m));
+  assert.deepEqual(summary.labels, ["bug", "p1"]);
+  assert.equal(warns.length, 1);
+  assert.match(warns[0] ?? "", /more than 100 labels/);
+  assert.match(warns[0] ?? "", /truncated to the first page/);
+});
+
+test("summariseIssue: warns when assignees are truncated", () => {
+  const truncated = {
+    ...sampleRawIssue,
+    assignees: {
+      pageInfo: { hasNextPage: true },
+      nodes: [{ login: "alice" }],
+    },
+  };
+  const warns: string[] = [];
+  summariseIssue(truncated, (m) => warns.push(m));
+  assert.equal(warns.length, 1);
+  assert.match(warns[0] ?? "", /more than 100 assignees/);
+});
+
+test("summariseIssue: silent on the common, not-truncated case", () => {
+  const warns: string[] = [];
+  summariseIssue(sampleRawIssue, (m) => warns.push(m));
+  assert.equal(warns.length, 0);
+});
+
+const sampleContext: RepoContext = {
+  repositoryId: "R_kwDO_repo",
+  labelsByName: new Map([
+    ["bug", "LA_bug"],
+    ["p1", "LA_p1"],
+  ]),
+  usersByLogin: new Map([
+    ["alice", "U_alice"],
+    ["bob", "U_bob"],
+  ]),
+};
+
+test("resolveLabelIds: lists every unknown label, not just the first", () => {
+  // The per-tool tests cover the happy path + single-miss case;
+  // this pins the all-misses-aggregated contract so a caller doesn't
+  // have to retry-and-discover one missing label at a time.
+  assert.throws(
+    () => resolveLabelIds(sampleContext, ["bug", "ghost", "phantom"], "test"),
+    /unknown label\(s\): ghost, phantom/,
+  );
+});
+
+test("resolveAssigneeIds: lists every unknown login, not just the first", () => {
+  assert.throws(
+    () =>
+      resolveAssigneeIds(
+        sampleContext,
+        ["alice", "ghost", "phantom"],
+        "test",
+      ),
+    /unknown \/ non-assignable login\(s\): ghost, phantom/,
+  );
+});

--- a/tests/unit/tools/issue/close.test.ts
+++ b/tests/unit/tools/issue/close.test.ts
@@ -1,0 +1,118 @@
+// tests/unit/tools/issue/close.test.ts
+//
+// gh.issue_close: pin the reason mapping (completed → COMPLETED,
+// not_planned → NOT_PLANNED), the optional comment-before-close
+// flow, and the issue-not-found error path.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { registerIssueCloseTool } from "../../../../src/tools/issue/close.ts";
+import type { ToolEntry } from "../../../../src/registry.ts";
+import { sampleRawIssue, stubGraphqlClient } from "./_fixtures.ts";
+
+function captureRegistration() {
+  let entry: ToolEntry | undefined;
+  const register = (name: string, e: ToolEntry) => {
+    if (name !== "gh.issue_close") throw new Error(`unexpected: ${name}`);
+    entry = e;
+  };
+  return {
+    register,
+    get entry(): ToolEntry {
+      if (!entry) throw new Error("not registered");
+      return entry;
+    },
+  };
+}
+
+test("gh.issue_close: maps reason: completed → stateReason: COMPLETED", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "issue/_issue-lookup": { repository: { issue: { id: "I_target" } } },
+    "issue/close": (vars: Record<string, unknown>) => {
+      const input = vars.input as Record<string, unknown>;
+      assert.equal(input.issueId, "I_target");
+      assert.equal(input.stateReason, "COMPLETED");
+      return {
+        closeIssue: {
+          issue: { ...sampleRawIssue, state: "CLOSED", closedAt: "2026-04-29T00:00:00Z" },
+        },
+      };
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueCloseTool(reg.register, graphql);
+  const out = (await reg.entry.handler({
+    repo: "owner/repo",
+    number: 42,
+    reason: "completed",
+  })) as { state: string; closed_at: string | null };
+  assert.equal(out.state, "CLOSED");
+  assert.equal(out.closed_at, "2026-04-29T00:00:00Z");
+  assert.equal(calls.length, 2); // lookup + close (no comment)
+});
+
+test("gh.issue_close: maps reason: not_planned → stateReason: NOT_PLANNED", async () => {
+  const { graphql } = stubGraphqlClient({
+    "issue/_issue-lookup": { repository: { issue: { id: "I_target" } } },
+    "issue/close": (vars: Record<string, unknown>) => {
+      const input = vars.input as Record<string, unknown>;
+      assert.equal(input.stateReason, "NOT_PLANNED");
+      return { closeIssue: { issue: sampleRawIssue } };
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueCloseTool(reg.register, graphql);
+  await reg.entry.handler({
+    repo: "owner/repo",
+    number: 42,
+    reason: "not_planned",
+  });
+});
+
+test("gh.issue_close: posts the comment BEFORE closing when supplied", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "issue/_issue-lookup": { repository: { issue: { id: "I_target" } } },
+    "issue/comment": (vars: Record<string, unknown>) => {
+      const input = vars.input as Record<string, unknown>;
+      assert.equal(input.subjectId, "I_target");
+      assert.equal(input.body, "Closing because foo");
+      return { addComment: { commentEdge: { node: { id: "C_1", url: "u" } } } };
+    },
+    "issue/close": (_vars: Record<string, unknown>) =>
+      ({ closeIssue: { issue: sampleRawIssue } }),
+  });
+  const reg = captureRegistration();
+  registerIssueCloseTool(reg.register, graphql);
+  await reg.entry.handler({
+    repo: "owner/repo",
+    number: 42,
+    reason: "completed",
+    comment: "Closing because foo",
+  });
+  // Order matters: comment before close so watchers see the
+  // rationale alongside the state change in their feed.
+  assert.deepEqual(
+    calls.map((c) => c.queryName),
+    ["issue/_issue-lookup", "issue/comment", "issue/close"],
+  );
+});
+
+test("gh.issue_close: rejects an unknown reason at the input boundary", async () => {
+  const { graphql } = stubGraphqlClient({
+    "issue/_issue-lookup": { repository: { issue: { id: "I_target" } } },
+    "issue/close": () => {
+      throw new Error("must not run");
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueCloseTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      repo: "owner/repo",
+      number: 42,
+      reason: "wontfix",
+    }),
+    /gh\.issue_close input/,
+  );
+});

--- a/tests/unit/tools/issue/comment.test.ts
+++ b/tests/unit/tools/issue/comment.test.ts
@@ -1,0 +1,86 @@
+// tests/unit/tools/issue/comment.test.ts
+//
+// gh.issue_comment: pin the lookup → AddComment two-step plus the
+// missing-issue and empty-body error paths.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { registerIssueCommentTool } from "../../../../src/tools/issue/comment.ts";
+import type { ToolEntry } from "../../../../src/registry.ts";
+import { stubGraphqlClient } from "./_fixtures.ts";
+
+function captureRegistration() {
+  let entry: ToolEntry | undefined;
+  const register = (name: string, e: ToolEntry) => {
+    if (name !== "gh.issue_comment") throw new Error(`unexpected: ${name}`);
+    entry = e;
+  };
+  return {
+    register,
+    get entry(): ToolEntry {
+      if (!entry) throw new Error("not registered");
+      return entry;
+    },
+  };
+}
+
+test("gh.issue_comment: looks up issue id, then posts the comment", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "issue/_issue-lookup": { repository: { issue: { id: "I_42" } } },
+    "issue/comment": (vars: Record<string, unknown>) => {
+      const input = vars.input as Record<string, unknown>;
+      assert.equal(input.subjectId, "I_42");
+      assert.equal(input.body, "hello world");
+      return {
+        addComment: {
+          commentEdge: {
+            node: {
+              id: "IC_kwDO_42",
+              url: "https://github.com/o/r/issues/42#issuecomment-99",
+            },
+          },
+        },
+      };
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueCommentTool(reg.register, graphql);
+  const out = await reg.entry.handler({
+    repo: "owner/repo",
+    number: 42,
+    body: "hello world",
+  });
+  assert.deepEqual(out, {
+    comment_id: "IC_kwDO_42",
+    url: "https://github.com/o/r/issues/42#issuecomment-99",
+  });
+  assert.equal(calls.length, 2);
+});
+
+test("gh.issue_comment: throws when the issue cannot be found", async () => {
+  const { graphql } = stubGraphqlClient({
+    "issue/_issue-lookup": { repository: { issue: null } },
+  });
+  const reg = captureRegistration();
+  registerIssueCommentTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", number: 99, body: "x" }),
+    /owner\/repo#99 not found/,
+  );
+});
+
+test("gh.issue_comment: rejects an empty body at the input boundary", async () => {
+  const { graphql } = stubGraphqlClient({
+    "issue/_issue-lookup": { repository: { issue: { id: "I_42" } } },
+    "issue/comment": () => {
+      throw new Error("must not run");
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueCommentTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", number: 42, body: "" }),
+    /gh\.issue_comment input/,
+  );
+});

--- a/tests/unit/tools/issue/comment.test.ts
+++ b/tests/unit/tools/issue/comment.test.ts
@@ -66,7 +66,7 @@ test("gh.issue_comment: throws when the issue cannot be found", async () => {
   registerIssueCommentTool(reg.register, graphql);
   await assert.rejects(
     reg.entry.handler({ repo: "owner/repo", number: 99, body: "x" }),
-    /owner\/repo#99 not found/,
+    /issue owner\/repo#99 not found/,
   );
 });
 

--- a/tests/unit/tools/issue/create.test.ts
+++ b/tests/unit/tools/issue/create.test.ts
@@ -170,7 +170,7 @@ test("gh.issue_create: throws when the repository is not found", async () => {
   registerIssueCreateTool(reg.register, graphql);
   await assert.rejects(
     reg.entry.handler({ repo: "owner/repo", title: "x" }),
-    /repository 'owner\/repo' not found/,
+    /gh\.issue_create: repository 'owner\/repo' not found/,
   );
 });
 

--- a/tests/unit/tools/issue/create.test.ts
+++ b/tests/unit/tools/issue/create.test.ts
@@ -1,0 +1,151 @@
+// tests/unit/tools/issue/create.test.ts
+//
+// gh.issue_create: pin the two-step name-resolution flow (repo
+// context lookup → mutation) and the error paths for unknown
+// labels / assignees, since those happen BEFORE the mutation runs
+// and produce structured errors rather than GraphQL ones.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { registerIssueCreateTool } from "../../../../src/tools/issue/create.ts";
+import type { ToolEntry } from "../../../../src/registry.ts";
+import {
+  sampleRawIssue,
+  sampleRepoContextResponse,
+  stubGraphqlClient,
+} from "./_fixtures.ts";
+
+function captureRegistration() {
+  let entry: ToolEntry | undefined;
+  const register = (name: string, e: ToolEntry) => {
+    if (name !== "gh.issue_create") {
+      throw new Error(`unexpected tool name: ${name}`);
+    }
+    entry = e;
+  };
+  return {
+    register,
+    get entry(): ToolEntry {
+      if (!entry) throw new Error("handler was not registered");
+      return entry;
+    },
+  };
+}
+
+test("gh.issue_create: resolves label names + assignee logins to IDs, then mutates", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "issue/_repo-context": sampleRepoContextResponse,
+    "issue/create": (vars: Record<string, unknown>) => {
+      // Pin the mutation input shape — this is the contract that
+      // matters for downstream consumers.
+      const input = vars.input as Record<string, unknown>;
+      assert.equal(input.repositoryId, "R_kwDO_repo");
+      assert.equal(input.title, "Hello");
+      assert.equal(input.body, "World");
+      assert.deepEqual(input.labelIds, ["LA_bug"]);
+      assert.deepEqual(input.assigneeIds, ["U_alice"]);
+      return { createIssue: { issue: sampleRawIssue } };
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueCreateTool(reg.register, graphql);
+  const out = await reg.entry.handler({
+    repo: "owner/repo",
+    title: "Hello",
+    body: "World",
+    labels: ["bug"],
+    assignees: ["alice"],
+  });
+  assert.equal((out as { number: number }).number, 42);
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0]?.queryName, "issue/_repo-context");
+  assert.equal(calls[1]?.queryName, "issue/create");
+});
+
+test("gh.issue_create: throws on an unknown label name before mutating", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "issue/_repo-context": sampleRepoContextResponse,
+    "issue/create": () => {
+      throw new Error("mutation must NOT run when label resolution fails");
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueCreateTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      repo: "owner/repo",
+      title: "x",
+      labels: ["bug", "imaginary"],
+    }),
+    /unknown label\(s\): imaginary/,
+  );
+  // We did the prep query but stopped before the mutation.
+  assert.equal(calls.length, 1);
+});
+
+test("gh.issue_create: throws on an unknown assignee login before mutating", async () => {
+  const { graphql } = stubGraphqlClient({
+    "issue/_repo-context": sampleRepoContextResponse,
+    "issue/create": () => {
+      throw new Error("mutation must NOT run when assignee resolution fails");
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueCreateTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      repo: "owner/repo",
+      title: "x",
+      assignees: ["alice", "ghost"],
+    }),
+    /unknown \/ non-assignable login\(s\): ghost/,
+  );
+});
+
+test("gh.issue_create: throws when the repository is not found", async () => {
+  const { graphql } = stubGraphqlClient({
+    "issue/_repo-context": { repository: null },
+    "issue/create": () => {
+      throw new Error("mutation must not run");
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueCreateTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", title: "x" }),
+    /repository 'owner\/repo' not found/,
+  );
+});
+
+test("gh.issue_create: omits unset optional fields from the mutation input", async () => {
+  // GraphQL serialises explicit `undefined` as `null`, which the
+  // CreateIssueInput rejects for fields like `body`. Verify those
+  // fields are absent from the variables when not supplied.
+  const { graphql } = stubGraphqlClient({
+    "issue/_repo-context": sampleRepoContextResponse,
+    "issue/create": (vars: Record<string, unknown>) => {
+      const input = vars.input as Record<string, unknown>;
+      assert.equal("body" in input, false);
+      assert.equal("labelIds" in input, false);
+      assert.equal("assigneeIds" in input, false);
+      return { createIssue: { issue: sampleRawIssue } };
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueCreateTool(reg.register, graphql);
+  await reg.entry.handler({ repo: "owner/repo", title: "minimal" });
+});
+
+test("gh.issue_create: rejects empty title at the input boundary", async () => {
+  const { graphql } = stubGraphqlClient({
+    "issue/_repo-context": sampleRepoContextResponse,
+    "issue/create": () => ({ createIssue: { issue: sampleRawIssue } }),
+  });
+  const reg = captureRegistration();
+  registerIssueCreateTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", title: "" }),
+    /gh\.issue_create input/,
+  );
+});

--- a/tests/unit/tools/issue/create.test.ts
+++ b/tests/unit/tools/issue/create.test.ts
@@ -103,6 +103,62 @@ test("gh.issue_create: throws on an unknown assignee login before mutating", asy
   );
 });
 
+test("gh.issue_create: throws a clear truncation error when repo has >100 labels", async () => {
+  // Pin the v0.1 contract: name-based resolution only works while
+  // the first 100 labels cover the repo. A repo larger than that
+  // would silently false-fail valid label names; instead we throw
+  // an actionable error pointing at the real cause.
+  const truncated = {
+    repository: {
+      ...sampleRepoContextResponse.repository,
+      labels: {
+        pageInfo: { hasNextPage: true },
+        nodes: sampleRepoContextResponse.repository.labels.nodes,
+      },
+    },
+  };
+  const { graphql } = stubGraphqlClient({
+    "issue/_repo-context": truncated,
+    "issue/create": () => {
+      throw new Error("must not run");
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueCreateTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", title: "x", labels: ["bug"] }),
+    /more than 100 labels/,
+  );
+});
+
+test("gh.issue_create: throws a clear truncation error when repo has >100 assignable users", async () => {
+  const truncated = {
+    repository: {
+      ...sampleRepoContextResponse.repository,
+      assignableUsers: {
+        pageInfo: { hasNextPage: true },
+        nodes: sampleRepoContextResponse.repository.assignableUsers.nodes,
+      },
+    },
+  };
+  const { graphql } = stubGraphqlClient({
+    "issue/_repo-context": truncated,
+    "issue/create": () => {
+      throw new Error("must not run");
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueCreateTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      repo: "owner/repo",
+      title: "x",
+      assignees: ["alice"],
+    }),
+    /more than 100 assignable users/,
+  );
+});
+
 test("gh.issue_create: throws when the repository is not found", async () => {
   const { graphql } = stubGraphqlClient({
     "issue/_repo-context": { repository: null },

--- a/tests/unit/tools/issue/edit.test.ts
+++ b/tests/unit/tools/issue/edit.test.ts
@@ -112,6 +112,6 @@ test("gh.issue_edit: throws when the issue cannot be found", async () => {
   registerIssueEditTool(reg.register, graphql);
   await assert.rejects(
     reg.entry.handler({ repo: "owner/repo", number: 99 }),
-    /owner\/repo#99 not found/,
+    /issue owner\/repo#99 not found/,
   );
 });

--- a/tests/unit/tools/issue/edit.test.ts
+++ b/tests/unit/tools/issue/edit.test.ts
@@ -1,0 +1,117 @@
+// tests/unit/tools/issue/edit.test.ts
+//
+// gh.issue_edit: pin the lazy repo-context lookup (only triggered
+// when labels or assignees are passed) and the per-field
+// pass-through to the UpdateIssue mutation input.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { registerIssueEditTool } from "../../../../src/tools/issue/edit.ts";
+import type { ToolEntry } from "../../../../src/registry.ts";
+import {
+  sampleRawIssue,
+  sampleRepoContextResponse,
+  stubGraphqlClient,
+} from "./_fixtures.ts";
+
+function captureRegistration() {
+  let entry: ToolEntry | undefined;
+  const register = (name: string, e: ToolEntry) => {
+    if (name !== "gh.issue_edit") throw new Error(`unexpected: ${name}`);
+    entry = e;
+  };
+  return {
+    register,
+    get entry(): ToolEntry {
+      if (!entry) throw new Error("not registered");
+      return entry;
+    },
+  };
+}
+
+test("gh.issue_edit: title/body-only edits skip the repo-context lookup", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "issue/_issue-lookup": {
+      repository: { issue: { id: "I_target" } },
+    },
+    "issue/edit": (vars: Record<string, unknown>) => {
+      const input = vars.input as Record<string, unknown>;
+      assert.equal(input.id, "I_target");
+      assert.equal(input.title, "New title");
+      assert.equal(input.body, "New body");
+      assert.equal("labelIds" in input, false);
+      assert.equal("assigneeIds" in input, false);
+      return { updateIssue: { issue: sampleRawIssue } };
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueEditTool(reg.register, graphql);
+  await reg.entry.handler({
+    repo: "owner/repo",
+    number: 42,
+    title: "New title",
+    body: "New body",
+  });
+  // Only the issue lookup + the mutation. No repo-context query.
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0]?.queryName, "issue/_issue-lookup");
+  assert.equal(calls[1]?.queryName, "issue/edit");
+});
+
+test("gh.issue_edit: triggers repo-context lookup when labels are passed", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "issue/_issue-lookup": {
+      repository: { issue: { id: "I_target" } },
+    },
+    "issue/_repo-context": sampleRepoContextResponse,
+    "issue/edit": (vars: Record<string, unknown>) => {
+      const input = vars.input as Record<string, unknown>;
+      assert.deepEqual(input.labelIds, ["LA_bug"]);
+      return { updateIssue: { issue: sampleRawIssue } };
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueEditTool(reg.register, graphql);
+  await reg.entry.handler({
+    repo: "owner/repo",
+    number: 42,
+    labels: ["bug"],
+  });
+  assert.equal(calls.length, 3);
+  assert.equal(calls[1]?.queryName, "issue/_repo-context");
+});
+
+test("gh.issue_edit: empty labels array clears the label set", async () => {
+  // Passing labels: [] is the documented "clear" semantics; verify
+  // the mutation input carries an empty labelIds array (not omitted,
+  // not null) so GraphQL applies the clear.
+  const { graphql } = stubGraphqlClient({
+    "issue/_issue-lookup": { repository: { issue: { id: "I_target" } } },
+    "issue/_repo-context": sampleRepoContextResponse,
+    "issue/edit": (vars: Record<string, unknown>) => {
+      const input = vars.input as Record<string, unknown>;
+      assert.deepEqual(input.labelIds, []);
+      return { updateIssue: { issue: sampleRawIssue } };
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueEditTool(reg.register, graphql);
+  await reg.entry.handler({
+    repo: "owner/repo",
+    number: 42,
+    labels: [],
+  });
+});
+
+test("gh.issue_edit: throws when the issue cannot be found", async () => {
+  const { graphql } = stubGraphqlClient({
+    "issue/_issue-lookup": { repository: { issue: null } },
+  });
+  const reg = captureRegistration();
+  registerIssueEditTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", number: 99 }),
+    /owner\/repo#99 not found/,
+  );
+});

--- a/tests/unit/tools/issue/list.test.ts
+++ b/tests/unit/tools/issue/list.test.ts
@@ -76,7 +76,10 @@ test("gh.issue_list: client-side `assignee` filter drops non-matching items", as
     {
       ...sampleRawIssue,
       number: 2,
-      assignees: { nodes: [{ login: "carol" }] },
+      assignees: {
+        pageInfo: { hasNextPage: false },
+        nodes: [{ login: "carol" }],
+      },
     },
   ];
   const { graphql } = stubGraphqlClient({

--- a/tests/unit/tools/issue/list.test.ts
+++ b/tests/unit/tools/issue/list.test.ts
@@ -1,0 +1,147 @@
+// tests/unit/tools/issue/list.test.ts
+//
+// gh.issue_list: pin the page-shape contract (items + hasNextPage
+// + endCursor), the state mapping (OPEN/CLOSED/ALL → GraphQL
+// IssueState), and the post-fetch client-side filter for `assignee`
+// and `since`.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { registerIssueListTool } from "../../../../src/tools/issue/list.ts";
+import type { ToolEntry } from "../../../../src/registry.ts";
+import { sampleRawIssue, stubGraphqlClient } from "./_fixtures.ts";
+
+function captureRegistration() {
+  let entry: ToolEntry | undefined;
+  const register = (name: string, e: ToolEntry) => {
+    if (name !== "gh.issue_list") throw new Error(`unexpected: ${name}`);
+    entry = e;
+  };
+  return {
+    register,
+    get entry(): ToolEntry {
+      if (!entry) throw new Error("not registered");
+      return entry;
+    },
+  };
+}
+
+test("gh.issue_list: returns items + page info, default state filter is OPEN", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "issue/list": {
+      repository: {
+        issues: {
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: [sampleRawIssue],
+        },
+      },
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueListTool(reg.register, graphql);
+  const out = (await reg.entry.handler({ repo: "owner/repo" })) as {
+    items: Array<{ number: number }>;
+    hasNextPage: boolean;
+    endCursor: string | null;
+  };
+  assert.equal(out.items.length, 1);
+  assert.equal(out.items[0]?.number, 42);
+  assert.equal(out.hasNextPage, false);
+  assert.equal(out.endCursor, null);
+  // Default state: OPEN only.
+  assert.deepEqual(calls[0]?.vars.states, ["OPEN"]);
+});
+
+test("gh.issue_list: state=ALL passes a null states filter to GraphQL", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "issue/list": {
+      repository: {
+        issues: {
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: [],
+        },
+      },
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueListTool(reg.register, graphql);
+  await reg.entry.handler({ repo: "owner/repo", state: "ALL" });
+  assert.equal(calls[0]?.vars.states, null);
+});
+
+test("gh.issue_list: client-side `assignee` filter drops non-matching items", async () => {
+  const fixtureIssues = [
+    { ...sampleRawIssue, number: 1 },
+    {
+      ...sampleRawIssue,
+      number: 2,
+      assignees: { nodes: [{ login: "carol" }] },
+    },
+  ];
+  const { graphql } = stubGraphqlClient({
+    "issue/list": {
+      repository: {
+        issues: {
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: fixtureIssues,
+        },
+      },
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueListTool(reg.register, graphql);
+  const out = (await reg.entry.handler({
+    repo: "owner/repo",
+    assignee: "carol",
+  })) as { items: Array<{ number: number }> };
+  assert.equal(out.items.length, 1);
+  assert.equal(out.items[0]?.number, 2);
+});
+
+test("gh.issue_list: client-side `since` filter drops older items", async () => {
+  const fixtureIssues = [
+    {
+      ...sampleRawIssue,
+      number: 1,
+      updatedAt: "2026-04-01T00:00:00Z",
+    },
+    {
+      ...sampleRawIssue,
+      number: 2,
+      updatedAt: "2026-04-15T00:00:00Z",
+    },
+  ];
+  const { graphql } = stubGraphqlClient({
+    "issue/list": {
+      repository: {
+        issues: {
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: fixtureIssues,
+        },
+      },
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueListTool(reg.register, graphql);
+  const out = (await reg.entry.handler({
+    repo: "owner/repo",
+    since: "2026-04-10T00:00:00Z",
+  })) as { items: Array<{ number: number }> };
+  assert.deepEqual(
+    out.items.map((i) => i.number),
+    [2],
+  );
+});
+
+test("gh.issue_list: throws when the repository is not found", async () => {
+  const { graphql } = stubGraphqlClient({
+    "issue/list": { repository: null },
+  });
+  const reg = captureRegistration();
+  registerIssueListTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo" }),
+    /repository 'owner\/repo' not found/,
+  );
+});

--- a/tests/unit/tools/issue/search.test.ts
+++ b/tests/unit/tools/issue/search.test.ts
@@ -1,0 +1,105 @@
+// tests/unit/tools/issue/search.test.ts
+//
+// gh.issue_search: pin the cross-repo `repo` field on each item,
+// the total-count pass-through, and the defensive non-Issue
+// __typename skip.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { registerIssueSearchTool } from "../../../../src/tools/issue/search.ts";
+import type { ToolEntry } from "../../../../src/registry.ts";
+import { sampleRawIssue, stubGraphqlClient } from "./_fixtures.ts";
+
+function captureRegistration() {
+  let entry: ToolEntry | undefined;
+  const register = (name: string, e: ToolEntry) => {
+    if (name !== "gh.issue_search") throw new Error(`unexpected: ${name}`);
+    entry = e;
+  };
+  return {
+    register,
+    get entry(): ToolEntry {
+      if (!entry) throw new Error("not registered");
+      return entry;
+    },
+  };
+}
+
+test("gh.issue_search: returns items with the cross-repo `repo` field", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "issue/search": {
+      search: {
+        issueCount: 7,
+        pageInfo: { hasNextPage: true, endCursor: "C123" },
+        nodes: [
+          {
+            __typename: "Issue",
+            ...sampleRawIssue,
+            repository: { nameWithOwner: "owner/repo" },
+          },
+        ],
+      },
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueSearchTool(reg.register, graphql);
+  const out = (await reg.entry.handler({
+    q: "is:issue is:open repo:owner/repo",
+    perPage: 30,
+  })) as {
+    items: Array<{ number: number; repo: string }>;
+    total: number;
+    hasNextPage: boolean;
+    endCursor: string | null;
+  };
+  assert.equal(out.total, 7);
+  assert.equal(out.hasNextPage, true);
+  assert.equal(out.endCursor, "C123");
+  assert.equal(out.items.length, 1);
+  assert.equal(out.items[0]?.repo, "owner/repo");
+  assert.equal(calls[0]?.vars.first, 30);
+  assert.equal(calls[0]?.vars.q, "is:issue is:open repo:owner/repo");
+});
+
+test("gh.issue_search: skips non-Issue search hits defensively", async () => {
+  // GitHub's search API can in theory return mixed result types
+  // even with `type: ISSUE`; the union schema includes other
+  // variants. Assert we don't crash on a stray PullRequest hit.
+  const { graphql } = stubGraphqlClient({
+    "issue/search": {
+      search: {
+        issueCount: 2,
+        pageInfo: { hasNextPage: false, endCursor: null },
+        nodes: [
+          {
+            __typename: "Issue",
+            ...sampleRawIssue,
+            repository: { nameWithOwner: "owner/repo" },
+          },
+          { __typename: "PullRequest" },
+        ],
+      },
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueSearchTool(reg.register, graphql);
+  const out = (await reg.entry.handler({ q: "anything" })) as {
+    items: unknown[];
+  };
+  assert.equal(out.items.length, 1);
+});
+
+test("gh.issue_search: rejects an empty `q` at the input boundary", async () => {
+  const { graphql } = stubGraphqlClient({
+    "issue/search": () => {
+      throw new Error("must not run");
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueSearchTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ q: "" }),
+    /gh\.issue_search input/,
+  );
+});

--- a/tests/unit/tools/issue/view.test.ts
+++ b/tests/unit/tools/issue/view.test.ts
@@ -1,0 +1,105 @@
+// tests/unit/tools/issue/view.test.ts
+//
+// gh.issue_view: pin the canonical happy-path summary plus the
+// error surface for an unknown issue and bad input.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { registerIssueViewTool } from "../../../../src/tools/issue/view.ts";
+import type { ToolEntry } from "../../../../src/registry.ts";
+import { stubGraphqlClient, sampleRawIssue } from "./_fixtures.ts";
+
+function captureRegistration() {
+  let entry: ToolEntry | undefined;
+  const register = (name: string, e: ToolEntry) => {
+    if (name !== "gh.issue_view") {
+      throw new Error(`unexpected tool name: ${name}`);
+    }
+    entry = e;
+  };
+  return {
+    register,
+    get entry(): ToolEntry {
+      if (!entry) throw new Error("handler was not registered");
+      return entry;
+    },
+  };
+}
+
+test("gh.issue_view: maps the GraphQL response onto the canonical IssueSummary", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "issue/view": { repository: { issue: sampleRawIssue } },
+  });
+  const reg = captureRegistration();
+  registerIssueViewTool(reg.register, graphql);
+  const out = await reg.entry.handler({ repo: "owner/repo", number: 42 });
+  assert.deepEqual(out, {
+    number: 42,
+    url: "https://github.com/owner/repo/issues/42",
+    node_id: "I_kwDO_42",
+    title: "Sample title",
+    state: "OPEN",
+    body: "Sample body",
+    labels: ["bug", "p1"],
+    assignees: ["alice"],
+    author: "bob",
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-02T00:00:00Z",
+    closed_at: null,
+  });
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0]?.vars, {
+    owner: "owner",
+    name: "repo",
+    number: 42,
+  });
+});
+
+test("gh.issue_view: throws a structured error when the issue is missing", async () => {
+  const { graphql } = stubGraphqlClient({
+    "issue/view": { repository: { issue: null } },
+  });
+  const reg = captureRegistration();
+  registerIssueViewTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", number: 99 }),
+    /owner\/repo#99 not found/,
+  );
+});
+
+test("gh.issue_view: rejects malformed repo slugs at the input boundary", async () => {
+  const { graphql } = stubGraphqlClient({
+    "issue/view": { repository: { issue: sampleRawIssue } },
+  });
+  const reg = captureRegistration();
+  registerIssueViewTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ repo: "no-slash", number: 1 }),
+    /gh\.issue_view input/,
+  );
+});
+
+test("gh.issue_view: rejects negative or zero issue numbers", async () => {
+  const { graphql } = stubGraphqlClient({
+    "issue/view": { repository: { issue: sampleRawIssue } },
+  });
+  const reg = captureRegistration();
+  registerIssueViewTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", number: 0 }),
+    /gh\.issue_view input/,
+  );
+});
+
+test("gh.issue_view: rejects unknown additional properties", async () => {
+  const { graphql } = stubGraphqlClient({
+    "issue/view": { repository: { issue: sampleRawIssue } },
+  });
+  const reg = captureRegistration();
+  registerIssueViewTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", number: 1, extra: "boom" }),
+    /extra/,
+  );
+});

--- a/tests/unit/tools/issue/view.test.ts
+++ b/tests/unit/tools/issue/view.test.ts
@@ -56,7 +56,7 @@ test("gh.issue_view: maps the GraphQL response onto the canonical IssueSummary",
   });
 });
 
-test("gh.issue_view: throws a structured error when the issue is missing", async () => {
+test("gh.issue_view: throws an issue-not-found error when the repo exists but the issue doesn't", async () => {
   const { graphql } = stubGraphqlClient({
     "issue/view": { repository: { issue: null } },
   });
@@ -64,7 +64,22 @@ test("gh.issue_view: throws a structured error when the issue is missing", async
   registerIssueViewTool(reg.register, graphql);
   await assert.rejects(
     reg.entry.handler({ repo: "owner/repo", number: 99 }),
-    /owner\/repo#99 not found/,
+    /issue owner\/repo#99 not found/,
+  );
+});
+
+test("gh.issue_view: throws a repo-not-found error when the repository is null", async () => {
+  // The repo-vs-issue distinction matters for the operator: a typo
+  // in the slug should not surface as "issue 99 not found", which
+  // would point them at the wrong axis. Pin the message text.
+  const { graphql } = stubGraphqlClient({
+    "issue/view": { repository: null },
+  });
+  const reg = captureRegistration();
+  registerIssueViewTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", number: 99 }),
+    /repository 'owner\/repo' not found or token lacks read access/,
   );
 });
 

--- a/tests/unit/validation/validator.test.ts
+++ b/tests/unit/validation/validator.test.ts
@@ -11,6 +11,8 @@ import assert from "node:assert/strict";
 import {
   validate,
   SchemaValidationError,
+  _getCompileCount,
+  _resetCompileCount,
 } from "../../../src/validation/validator.ts";
 
 const sampleSchema = {
@@ -75,14 +77,39 @@ test("validate: rejects unknown additional properties", () => {
 });
 
 test("validate: caches compiled validators by schema-object identity", () => {
-  // We can't observe the cache directly, but two consecutive calls
-  // with the same schema reference must succeed identically (and
-  // ajv's compile() throws on a schema it can't compile, so the
-  // first call would have failed if the cache key was unstable).
+  // Pin the actual caching contract via the _getCompileCount() test
+  // hook. Five validate() calls against the same schema reference
+  // must trigger exactly one ajv.compile call; a regression that
+  // breaks the WeakMap key (e.g. cloning the schema before lookup)
+  // would surface here as 5 compiles instead of 1.
+  // Use a fresh schema object so the count is unpolluted by any
+  // earlier validate() in this test file.
+  const freshSchema = {
+    type: "object",
+    required: ["x"],
+    properties: { x: { type: "integer" } },
+    additionalProperties: false,
+  };
+  _resetCompileCount();
   for (let i = 0; i < 5; i++) {
-    assert.deepEqual(
-      validate(sampleSchema, { name: "x", count: i }, "test"),
-      { name: "x", count: i },
-    );
+    assert.deepEqual(validate(freshSchema, { x: i }, "test"), { x: i });
   }
+  assert.equal(
+    _getCompileCount(),
+    1,
+    "ajv.compile must be called exactly once across 5 validate() calls with the same schema",
+  );
+});
+
+test("validate: a different schema reference triggers a fresh compile", () => {
+  // Belt-and-brace: confirm the WeakMap key truly is the schema
+  // object, not e.g. a JSON-stringified copy that would dedupe two
+  // structurally-identical schemas. Two distinct objects must
+  // compile twice even when their contents are equal.
+  const a = { type: "object", properties: {} };
+  const b = { type: "object", properties: {} };
+  _resetCompileCount();
+  validate(a, {}, "test");
+  validate(b, {}, "test");
+  assert.equal(_getCompileCount(), 2);
 });

--- a/tests/unit/validation/validator.test.ts
+++ b/tests/unit/validation/validator.test.ts
@@ -1,0 +1,88 @@
+// tests/unit/validation/validator.test.ts
+//
+// Unit tests for the ajv-backed schema validator. Pin the contract
+// every tool handler depends on: pass-through on valid input,
+// SchemaValidationError on invalid input with a useful message
+// pointing at the offending instance path.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  validate,
+  SchemaValidationError,
+} from "../../../src/validation/validator.ts";
+
+const sampleSchema = {
+  type: "object",
+  required: ["name", "count"],
+  properties: {
+    name: { type: "string", minLength: 1 },
+    count: { type: "integer", minimum: 0 },
+  },
+  additionalProperties: false,
+} as const;
+
+test("validate: returns the data on success", () => {
+  const ok = validate(sampleSchema, { name: "alice", count: 3 }, "test");
+  assert.deepEqual(ok, { name: "alice", count: 3 });
+});
+
+test("validate: throws SchemaValidationError naming the where-string", () => {
+  assert.throws(
+    () => validate(sampleSchema, { name: "", count: 3 }, "gh.issue_create input"),
+    (err: unknown) => {
+      assert.ok(err instanceof SchemaValidationError);
+      assert.equal((err as SchemaValidationError).where, "gh.issue_create input");
+      assert.match((err as SchemaValidationError).message, /gh\.issue_create input/);
+      return true;
+    },
+  );
+});
+
+test("validate: error mentions the offending instance path", () => {
+  assert.throws(
+    () => validate(sampleSchema, { name: "alice", count: -1 }, "test"),
+    (err: unknown) => {
+      assert.match((err as Error).message, /\/count/);
+      return true;
+    },
+  );
+});
+
+test("validate: collects every violation, not just the first", () => {
+  // ajv is configured with allErrors: true so consumers get a
+  // single, actionable error listing every invalid field rather
+  // than a "fix one, retry, fix the next" loop.
+  assert.throws(
+    () => validate(sampleSchema, { count: -1 }, "test"),
+    (err: unknown) => {
+      const e = err as SchemaValidationError;
+      assert.ok(e.errors.length >= 2, `expected ≥2 errors, got ${e.errors.length}`);
+      return true;
+    },
+  );
+});
+
+test("validate: rejects unknown additional properties", () => {
+  assert.throws(
+    () => validate(sampleSchema, { name: "alice", count: 3, extra: 1 }, "test"),
+    (err: unknown) => {
+      assert.match((err as Error).message, /extra/);
+      return true;
+    },
+  );
+});
+
+test("validate: caches compiled validators by schema-object identity", () => {
+  // We can't observe the cache directly, but two consecutive calls
+  // with the same schema reference must succeed identically (and
+  // ajv's compile() throws on a schema it can't compile, so the
+  // first call would have failed if the cache key was unstable).
+  for (let i = 0; i < 5; i++) {
+    assert.deepEqual(
+      validate(sampleSchema, { name: "x", count: i }, "test"),
+      { name: "x", count: i },
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Wraps GitHub's issue CRUD as 7 MCP tools. Every tool's input + output is JSON-Schema-validated at the boundary so a malformed payload surfaces as a clean `SchemaValidationError` before the GraphQL client runs, instead of crashing inside a handler.

### Tools

| Name | Input | Output |
|---|---|---|
| `gh.issue_create` | `{repo, title, body?, labels?[], assignees?[]}` | `IssueSummary` |
| `gh.issue_view` | `{repo, number}` | `IssueSummary` |
| `gh.issue_list` | `{repo, state?, labels?[], assignee?, since?, perPage?, after?}` | `{items[], hasNextPage, endCursor}` |
| `gh.issue_edit` | `{repo, number, title?, body?, state?, labels?[], assignees?[]}` | `IssueSummary` |
| `gh.issue_close` | `{repo, number, reason: completed\|not_planned, comment?}` | `IssueSummary` |
| `gh.issue_comment` | `{repo, number, body}` | `{comment_id, url}` |
| `gh.issue_search` | `{q, perPage?, after?}` | `{items[] (with `repo` field), total, hasNextPage, endCursor}` |

### Behaviour notes worth flagging

- **Name → ID resolution**: `gh.issue_create` and `gh.issue_edit` accept label NAMES + assignee LOGINS (matching `gh` CLI ergonomics), then resolve them to GraphQL IDs via the `issue/_repo-context` prep query. Unknown labels / non-assignable logins fail clean BEFORE the mutation runs.
- **`gh.issue_close` ordering**: the optional `comment` is posted BEFORE the close so watchers see the rationale alongside the state change in their feed.
- **`gh.issue_list` defaults to OPEN**; pass `state: "ALL"` for both. `assignee` + `since` post-filter client-side because `Repository.issues` doesn't index them.
- **`gh.issue_edit` is lazy**: only loads the repo context when `labels` or `assignees` are passed; title/body/state-only edits skip the prep query entirely.

### What ships

- `src/validation/validator.ts` — ajv-backed `validate()` returning typed value on success, throwing `SchemaValidationError` (with instance-path + lifted `additionalProperty` / `allowedValues` params) on failure.
- `src/tools/issue/` — `_shared.ts` (parsers, helpers, canonical IssueSummary shape), 7 tool files, `index.ts` aggregator.
- `src/graphql/queries/issue/` — 9 `.graphql` files (7 main ops + 2 shared prep queries: `_repo-context`, `_issue-lookup`).
- `src/server.ts` — builds the canonical `GraphqlClient` once at startup and hands it to `registerIssueTools()`.
- New dep: `ajv ^8.20.0`.

## Test plan

- [x] `npm run lint` (tsc --noEmit on src + tests configs) clean
- [x] `npm run build` produces `dist/graphql/queries/issue/**.graphql` alongside the compiled `.js` tree
- [x] `npm test` — **94/94 pass** (38 new tests: 6 validator, 5 view, 6 create, 5 list, 4 edit, 4 close, 3 comment, 3 search, plus shared `_fixtures.ts`)
- [x] `node tests/smoke/server-lists-tools.mjs` — now asserts all 8 tools (`gh.test_connection` + 7 issue ops)
- [ ] Live integration probe (real GraphQL calls against a PAT) lands in MCP-12

## Stack

After **MCP-1 (#16, merged) → MCP-2 (#19, merged) → MCP-3 (#20, merged)**. Next siblings: MCP-5 (PR ops), MCP-7 (label ops), MCP-9 (workflow ops), MCP-10 (Project v2 ops). MCP-6's GraphQL `requestReviews(botIds)` work depends on MCP-5.

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)