### PR TITLE
feat: 6 PR-ops tools (MCP-5)

### DIFF
--- a/src/graphql/queries/pr/_pr-lookup.graphql
+++ b/src/graphql/queries/pr/_pr-lookup.graphql
@@ -1,0 +1,7 @@
+query PRLookup($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      id
+    }
+  }
+}

--- a/src/graphql/queries/pr/_ready-for-review.graphql
+++ b/src/graphql/queries/pr/_ready-for-review.graphql
@@ -1,0 +1,90 @@
+mutation PRReadyForReview($input: MarkPullRequestReadyForReviewInput!) {
+  markPullRequestReadyForReview(input: $input) {
+    pullRequest {
+      number
+      url
+      id
+      title
+      state
+      body
+      baseRefName
+      headRefName
+      isDraft
+      mergeable
+      merged
+      mergedAt
+      mergeCommit {
+        oid
+      }
+      labels(first: 100) {
+        pageInfo {
+          hasNextPage
+        }
+        nodes {
+          name
+        }
+      }
+      assignees(first: 100) {
+        pageInfo {
+          hasNextPage
+        }
+        nodes {
+          login
+        }
+      }
+      author {
+        login
+      }
+      createdAt
+      updatedAt
+      closedAt
+      reviews(first: 100) {
+        pageInfo {
+          hasNextPage
+        }
+        nodes {
+          state
+          author {
+            login
+          }
+        }
+      }
+      reviewThreads(first: 100) {
+        pageInfo {
+          hasNextPage
+        }
+        nodes {
+          comments(first: 0) {
+            totalCount
+          }
+        }
+      }
+      commits(last: 1) {
+        nodes {
+          commit {
+            statusCheckRollup {
+              state
+              contexts(first: 100) {
+                pageInfo {
+                  hasNextPage
+                }
+                nodes {
+                  __typename
+                  ... on CheckRun {
+                    name
+                    conclusion
+                    status
+                  }
+                  ... on StatusContext {
+                    context
+                    state
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/graphql/queries/pr/_repo-id.graphql
+++ b/src/graphql/queries/pr/_repo-id.graphql
@@ -1,0 +1,5 @@
+query PRRepoId($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) {
+    id
+  }
+}

--- a/src/graphql/queries/pr/_to-draft.graphql
+++ b/src/graphql/queries/pr/_to-draft.graphql
@@ -1,0 +1,90 @@
+mutation PRToDraft($input: ConvertPullRequestToDraftInput!) {
+  convertPullRequestToDraft(input: $input) {
+    pullRequest {
+      number
+      url
+      id
+      title
+      state
+      body
+      baseRefName
+      headRefName
+      isDraft
+      mergeable
+      merged
+      mergedAt
+      mergeCommit {
+        oid
+      }
+      labels(first: 100) {
+        pageInfo {
+          hasNextPage
+        }
+        nodes {
+          name
+        }
+      }
+      assignees(first: 100) {
+        pageInfo {
+          hasNextPage
+        }
+        nodes {
+          login
+        }
+      }
+      author {
+        login
+      }
+      createdAt
+      updatedAt
+      closedAt
+      reviews(first: 100) {
+        pageInfo {
+          hasNextPage
+        }
+        nodes {
+          state
+          author {
+            login
+          }
+        }
+      }
+      reviewThreads(first: 100) {
+        pageInfo {
+          hasNextPage
+        }
+        nodes {
+          comments(first: 0) {
+            totalCount
+          }
+        }
+      }
+      commits(last: 1) {
+        nodes {
+          commit {
+            statusCheckRollup {
+              state
+              contexts(first: 100) {
+                pageInfo {
+                  hasNextPage
+                }
+                nodes {
+                  __typename
+                  ... on CheckRun {
+                    name
+                    conclusion
+                    status
+                  }
+                  ... on StatusContext {
+                    context
+                    state
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/graphql/queries/pr/comment-reply.graphql
+++ b/src/graphql/queries/pr/comment-reply.graphql
@@ -1,0 +1,8 @@
+mutation PRCommentReply($input: AddPullRequestReviewThreadReplyInput!) {
+  addPullRequestReviewThreadReply(input: $input) {
+    comment {
+      id
+      url
+    }
+  }
+}

--- a/src/graphql/queries/pr/comment.graphql
+++ b/src/graphql/queries/pr/comment.graphql
@@ -1,0 +1,10 @@
+mutation PRComment($input: AddCommentInput!) {
+  addComment(input: $input) {
+    commentEdge {
+      node {
+        id
+        url
+      }
+    }
+  }
+}

--- a/src/graphql/queries/pr/create.graphql
+++ b/src/graphql/queries/pr/create.graphql
@@ -1,0 +1,90 @@
+mutation PRCreate($input: CreatePullRequestInput!) {
+  createPullRequest(input: $input) {
+    pullRequest {
+      number
+      url
+      id
+      title
+      state
+      body
+      baseRefName
+      headRefName
+      isDraft
+      mergeable
+      merged
+      mergedAt
+      mergeCommit {
+        oid
+      }
+      labels(first: 100) {
+        pageInfo {
+          hasNextPage
+        }
+        nodes {
+          name
+        }
+      }
+      assignees(first: 100) {
+        pageInfo {
+          hasNextPage
+        }
+        nodes {
+          login
+        }
+      }
+      author {
+        login
+      }
+      createdAt
+      updatedAt
+      closedAt
+      reviews(first: 100) {
+        pageInfo {
+          hasNextPage
+        }
+        nodes {
+          state
+          author {
+            login
+          }
+        }
+      }
+      reviewThreads(first: 100) {
+        pageInfo {
+          hasNextPage
+        }
+        nodes {
+          comments(first: 0) {
+            totalCount
+          }
+        }
+      }
+      commits(last: 1) {
+        nodes {
+          commit {
+            statusCheckRollup {
+              state
+              contexts(first: 100) {
+                pageInfo {
+                  hasNextPage
+                }
+                nodes {
+                  __typename
+                  ... on CheckRun {
+                    name
+                    conclusion
+                    status
+                  }
+                  ... on StatusContext {
+                    context
+                    state
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/graphql/queries/pr/edit.graphql
+++ b/src/graphql/queries/pr/edit.graphql
@@ -1,0 +1,90 @@
+mutation PREdit($input: UpdatePullRequestInput!) {
+  updatePullRequest(input: $input) {
+    pullRequest {
+      number
+      url
+      id
+      title
+      state
+      body
+      baseRefName
+      headRefName
+      isDraft
+      mergeable
+      merged
+      mergedAt
+      mergeCommit {
+        oid
+      }
+      labels(first: 100) {
+        pageInfo {
+          hasNextPage
+        }
+        nodes {
+          name
+        }
+      }
+      assignees(first: 100) {
+        pageInfo {
+          hasNextPage
+        }
+        nodes {
+          login
+        }
+      }
+      author {
+        login
+      }
+      createdAt
+      updatedAt
+      closedAt
+      reviews(first: 100) {
+        pageInfo {
+          hasNextPage
+        }
+        nodes {
+          state
+          author {
+            login
+          }
+        }
+      }
+      reviewThreads(first: 100) {
+        pageInfo {
+          hasNextPage
+        }
+        nodes {
+          comments(first: 0) {
+            totalCount
+          }
+        }
+      }
+      commits(last: 1) {
+        nodes {
+          commit {
+            statusCheckRollup {
+              state
+              contexts(first: 100) {
+                pageInfo {
+                  hasNextPage
+                }
+                nodes {
+                  __typename
+                  ... on CheckRun {
+                    name
+                    conclusion
+                    status
+                  }
+                  ... on StatusContext {
+                    context
+                    state
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/graphql/queries/pr/list.graphql
+++ b/src/graphql/queries/pr/list.graphql
@@ -1,0 +1,111 @@
+query PRList(
+  $owner: String!
+  $name: String!
+  $states: [PullRequestState!]
+  $headRefName: String
+  $baseRefName: String
+  $first: Int!
+  $after: String
+) {
+  repository(owner: $owner, name: $name) {
+    pullRequests(
+      first: $first
+      after: $after
+      states: $states
+      headRefName: $headRefName
+      baseRefName: $baseRefName
+      orderBy: { field: UPDATED_AT, direction: DESC }
+    ) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        number
+        url
+        id
+        title
+        state
+        body
+        baseRefName
+        headRefName
+        isDraft
+        mergeable
+        merged
+        mergedAt
+        mergeCommit {
+          oid
+        }
+        labels(first: 100) {
+          pageInfo {
+            hasNextPage
+          }
+          nodes {
+            name
+          }
+        }
+        assignees(first: 100) {
+          pageInfo {
+            hasNextPage
+          }
+          nodes {
+            login
+          }
+        }
+        author {
+          login
+        }
+        createdAt
+        updatedAt
+        closedAt
+        reviews(first: 100) {
+          pageInfo {
+            hasNextPage
+          }
+          nodes {
+            state
+            author {
+              login
+            }
+          }
+        }
+        reviewThreads(first: 100) {
+          pageInfo {
+            hasNextPage
+          }
+          nodes {
+            comments(first: 0) {
+              totalCount
+            }
+          }
+        }
+        commits(last: 1) {
+          nodes {
+            commit {
+              statusCheckRollup {
+                state
+                contexts(first: 100) {
+                  pageInfo {
+                    hasNextPage
+                  }
+                  nodes {
+                    __typename
+                    ... on CheckRun {
+                      name
+                      conclusion
+                      status
+                    }
+                    ... on StatusContext {
+                      context
+                      state
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/graphql/queries/pr/merge.graphql
+++ b/src/graphql/queries/pr/merge.graphql
@@ -1,0 +1,12 @@
+mutation PRMerge($input: MergePullRequestInput!) {
+  mergePullRequest(input: $input) {
+    pullRequest {
+      number
+      url
+      merged
+      mergeCommit {
+        oid
+      }
+    }
+  }
+}

--- a/src/graphql/queries/pr/view.graphql
+++ b/src/graphql/queries/pr/view.graphql
@@ -1,0 +1,90 @@
+query PRView($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      number
+      url
+      id
+      title
+      state
+      body
+      baseRefName
+      headRefName
+      isDraft
+      mergeable
+      merged
+      mergedAt
+      mergeCommit {
+        oid
+      }
+      labels(first: 100) {
+        pageInfo {
+          hasNextPage
+        }
+        nodes {
+          name
+        }
+      }
+      assignees(first: 100) {
+        pageInfo {
+          hasNextPage
+        }
+        nodes {
+          login
+        }
+      }
+      author {
+        login
+      }
+      createdAt
+      updatedAt
+      closedAt
+      reviews(first: 100) {
+        pageInfo {
+          hasNextPage
+        }
+        nodes {
+          state
+          author {
+            login
+          }
+        }
+      }
+      reviewThreads(first: 100) {
+        pageInfo {
+          hasNextPage
+        }
+        nodes {
+          comments(first: 0) {
+            totalCount
+          }
+        }
+      }
+      commits(last: 1) {
+        nodes {
+          commit {
+            statusCheckRollup {
+              state
+              contexts(first: 100) {
+                pageInfo {
+                  hasNextPage
+                }
+                nodes {
+                  __typename
+                  ... on CheckRun {
+                    name
+                    conclusion
+                    status
+                  }
+                  ... on StatusContext {
+                    context
+                    state
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,6 +35,7 @@ import {
 } from "./registry.js";
 import { registerTestConnectionTool } from "./tools/auth/test_connection.js";
 import { registerIssueTools } from "./tools/issue/index.js";
+import { registerPRTools } from "./tools/pr/index.js";
 
 // Read the package version from the package.json next to the dist
 // tree at startup, so a single source of truth (package.json) drives
@@ -76,6 +77,7 @@ export async function startServer(): Promise<void> {
   const graphql = createGraphqlClient(authedRequest);
   registerTestConnectionTool(registerTool, authedRequest);
   registerIssueTools(registerTool, graphql);
+  registerPRTools(registerTool, graphql);
 
   const server = new Server(
     {

--- a/src/tools/pr/_shared.ts
+++ b/src/tools/pr/_shared.ts
@@ -1,0 +1,377 @@
+// src/tools/pr/_shared.ts
+//
+// Helpers shared across the six gh.pr_* tools. Mirrors the issue
+// domain's _shared.ts in shape: parse repo slug, look up PR node
+// IDs, summarise the GraphQL response onto a stable `PRSummary`
+// JSON-Schema. The PR shape is heavier than the issue shape
+// because PR-view rolls in reviews, review-comments, and
+// status-checks summaries.
+
+import type { GraphqlClient } from "../../graphql/client.js";
+import { parseRepoSlug as parseIssueRepoSlug, type RepoCoords, repoSlugSchema } from "../issue/_shared.js";
+
+// Re-export the slug parser + JSON-Schema fragment so PR tools
+// don't reach across into the issue domain at the call site. The
+// underlying logic is identical: `owner/name`.
+export type { RepoCoords };
+export { repoSlugSchema };
+export const parseRepoSlug = parseIssueRepoSlug;
+
+// Lookup-by-(repo, number): returns the PR's GraphQL node ID and
+// the headRepository's id (for tools that need to reference the
+// fork repo, e.g. when editing a PR opened from a fork). Used by
+// the three mutations that operate on an existing PR (edit,
+// comment, merge).
+interface PRLookupResponse {
+  repository: {
+    pullRequest: { id: string } | null;
+  } | null;
+}
+
+export async function lookupPRNodeId(
+  graphql: GraphqlClient,
+  coords: RepoCoords,
+  number: number,
+  where: string,
+): Promise<string> {
+  const data = await graphql<PRLookupResponse>("pr/_pr-lookup", {
+    owner: coords.owner,
+    name: coords.name,
+    number,
+  });
+  // Distinguish "repo missing / no access" from "PR missing", same
+  // pattern as the issue domain.
+  if (!data.repository) {
+    throw new Error(
+      `mcp-github: ${where}: repository '${coords.owner}/${coords.name}' not found or token lacks read access`,
+    );
+  }
+  const id = data.repository.pullRequest?.id;
+  if (typeof id !== "string") {
+    throw new Error(
+      `mcp-github: ${where}: PR ${coords.owner}/${coords.name}#${number} not found`,
+    );
+  }
+  return id;
+}
+
+// Repository-context lookup used by gh.pr_create — the
+// CreatePullRequestInput requires `repositoryId`, not the
+// (owner, name) pair.
+interface RepoIdResponse {
+  repository: { id: string } | null;
+}
+
+export async function lookupRepoNodeId(
+  graphql: GraphqlClient,
+  coords: RepoCoords,
+  where: string,
+): Promise<string> {
+  const data = await graphql<RepoIdResponse>("pr/_repo-id", {
+    owner: coords.owner,
+    name: coords.name,
+  });
+  if (!data.repository) {
+    throw new Error(
+      `mcp-github: ${where}: repository '${coords.owner}/${coords.name}' not found or token lacks read access`,
+    );
+  }
+  return data.repository.id;
+}
+
+// JSON-Schema-shaped summary returned by every PR tool that
+// produces a "full PR payload" output (create, view, edit, merge).
+// The list tool returns an array of these.
+export interface ReviewSummary {
+  author: string | null;
+  state: "PENDING" | "COMMENTED" | "APPROVED" | "CHANGES_REQUESTED" | "DISMISSED";
+}
+
+export interface StatusCheck {
+  context: string;
+  state: "EXPECTED" | "ERROR" | "FAILURE" | "PENDING" | "SUCCESS";
+}
+
+export interface PRSummary {
+  number: number;
+  url: string;
+  node_id: string;
+  title: string;
+  state: "OPEN" | "CLOSED" | "MERGED";
+  body: string | null;
+  base: string;
+  head: string;
+  draft: boolean;
+  mergeable: "MERGEABLE" | "CONFLICTING" | "UNKNOWN";
+  merged: boolean;
+  merged_at: string | null;
+  merge_commit_sha: string | null;
+  labels: string[];
+  assignees: string[];
+  author: string | null;
+  created_at: string;
+  updated_at: string;
+  closed_at: string | null;
+  reviews: ReviewSummary[];
+  review_comments_count: number;
+  status_checks_state: "EXPECTED" | "ERROR" | "FAILURE" | "PENDING" | "SUCCESS" | null;
+  status_checks: StatusCheck[];
+}
+
+export const reviewSummarySchema = {
+  type: "object",
+  required: ["author", "state"],
+  properties: {
+    author: { type: ["string", "null"] },
+    state: {
+      type: "string",
+      enum: ["PENDING", "COMMENTED", "APPROVED", "CHANGES_REQUESTED", "DISMISSED"],
+    },
+  },
+  additionalProperties: false,
+} as const;
+
+export const statusCheckSchema = {
+  type: "object",
+  required: ["context", "state"],
+  properties: {
+    context: { type: "string" },
+    state: {
+      type: "string",
+      enum: ["EXPECTED", "ERROR", "FAILURE", "PENDING", "SUCCESS"],
+    },
+  },
+  additionalProperties: false,
+} as const;
+
+export const prSummarySchema = {
+  type: "object",
+  required: [
+    "number",
+    "url",
+    "node_id",
+    "title",
+    "state",
+    "body",
+    "base",
+    "head",
+    "draft",
+    "mergeable",
+    "merged",
+    "merged_at",
+    "merge_commit_sha",
+    "labels",
+    "assignees",
+    "author",
+    "created_at",
+    "updated_at",
+    "closed_at",
+    "reviews",
+    "review_comments_count",
+    "status_checks_state",
+    "status_checks",
+  ],
+  properties: {
+    number: { type: "integer" },
+    url: { type: "string" },
+    node_id: { type: "string" },
+    title: { type: "string" },
+    state: { type: "string", enum: ["OPEN", "CLOSED", "MERGED"] },
+    body: { type: ["string", "null"] },
+    base: { type: "string" },
+    head: { type: "string" },
+    draft: { type: "boolean" },
+    mergeable: { type: "string", enum: ["MERGEABLE", "CONFLICTING", "UNKNOWN"] },
+    merged: { type: "boolean" },
+    merged_at: { type: ["string", "null"] },
+    merge_commit_sha: { type: ["string", "null"] },
+    labels: { type: "array", items: { type: "string" } },
+    assignees: { type: "array", items: { type: "string" } },
+    author: { type: ["string", "null"] },
+    created_at: { type: "string" },
+    updated_at: { type: "string" },
+    closed_at: { type: ["string", "null"] },
+    reviews: { type: "array", items: reviewSummarySchema },
+    review_comments_count: { type: "integer", minimum: 0 },
+    status_checks_state: {
+      type: ["string", "null"],
+      enum: ["EXPECTED", "ERROR", "FAILURE", "PENDING", "SUCCESS", null],
+    },
+    status_checks: { type: "array", items: statusCheckSchema },
+  },
+  additionalProperties: false,
+} as const;
+
+// Shape of a PR returned by GraphQL for the create/view/list/edit
+// queries. The truncation flags on labels/assignees/reviews/
+// reviewThreads/contexts mirror the issue domain's pattern, so a
+// PR with > 100 of any of these surfaces an observable warning
+// rather than a silently-partial array.
+interface PaginatedNodes<T> {
+  pageInfo: { hasNextPage: boolean };
+  nodes: T[];
+}
+
+export interface RawPR {
+  number: number;
+  url: string;
+  id: string;
+  title: string;
+  state: "OPEN" | "CLOSED" | "MERGED";
+  body: string | null;
+  baseRefName: string;
+  headRefName: string;
+  isDraft: boolean;
+  mergeable: "MERGEABLE" | "CONFLICTING" | "UNKNOWN";
+  merged: boolean;
+  mergedAt: string | null;
+  mergeCommit: { oid: string } | null;
+  labels: PaginatedNodes<{ name: string }>;
+  assignees: PaginatedNodes<{ login: string }>;
+  author: { login: string } | null;
+  createdAt: string;
+  updatedAt: string;
+  closedAt: string | null;
+  reviews: PaginatedNodes<{
+    state: ReviewSummary["state"];
+    author: { login: string } | null;
+  }>;
+  reviewThreads: PaginatedNodes<{
+    comments: { totalCount: number };
+  }>;
+  commits: {
+    nodes: Array<{
+      commit: {
+        statusCheckRollup: {
+          state: StatusCheck["state"];
+          contexts: PaginatedNodes<RawCheckOrStatus>;
+        } | null;
+      };
+    }>;
+  };
+}
+
+type RawCheckOrStatus =
+  | {
+      __typename: "CheckRun";
+      name: string;
+      conclusion:
+        | "ACTION_REQUIRED"
+        | "CANCELLED"
+        | "FAILURE"
+        | "NEUTRAL"
+        | "SKIPPED"
+        | "STALE"
+        | "STARTUP_FAILURE"
+        | "SUCCESS"
+        | "TIMED_OUT"
+        | null;
+      status: "QUEUED" | "IN_PROGRESS" | "COMPLETED" | "WAITING" | "PENDING" | "REQUESTED";
+    }
+  | {
+      __typename: "StatusContext";
+      context: string;
+      state: StatusCheck["state"];
+    };
+
+export function summarisePR(
+  raw: RawPR,
+  warn: (msg: string) => void = (msg) =>
+    process.stderr.write(`${msg}\n`),
+): PRSummary {
+  warnIfTruncated(raw, warn);
+  const reviews: ReviewSummary[] = raw.reviews.nodes.map((r) => ({
+    author: r.author?.login ?? null,
+    state: r.state,
+  }));
+  const reviewCommentsCount = raw.reviewThreads.nodes.reduce(
+    (sum, t) => sum + t.comments.totalCount,
+    0,
+  );
+  const rollup = raw.commits.nodes[0]?.commit.statusCheckRollup ?? null;
+  const statusChecks: StatusCheck[] = rollup
+    ? rollup.contexts.nodes.map(normaliseCheckOrStatus)
+    : [];
+  return {
+    number: raw.number,
+    url: raw.url,
+    node_id: raw.id,
+    title: raw.title,
+    state: raw.state,
+    body: raw.body,
+    base: raw.baseRefName,
+    head: raw.headRefName,
+    draft: raw.isDraft,
+    mergeable: raw.mergeable,
+    merged: raw.merged,
+    merged_at: raw.mergedAt,
+    merge_commit_sha: raw.mergeCommit?.oid ?? null,
+    labels: raw.labels.nodes.map((n) => n.name),
+    assignees: raw.assignees.nodes.map((n) => n.login),
+    author: raw.author?.login ?? null,
+    created_at: raw.createdAt,
+    updated_at: raw.updatedAt,
+    closed_at: raw.closedAt,
+    reviews,
+    review_comments_count: reviewCommentsCount,
+    status_checks_state: rollup?.state ?? null,
+    status_checks: statusChecks,
+  };
+}
+
+function warnIfTruncated(raw: RawPR, warn: (msg: string) => void): void {
+  const messages: string[] = [];
+  if (raw.labels.pageInfo.hasNextPage) {
+    messages.push(`labels (>100)`);
+  }
+  if (raw.assignees.pageInfo.hasNextPage) {
+    messages.push(`assignees (>100)`);
+  }
+  if (raw.reviews.pageInfo.hasNextPage) {
+    messages.push(`reviews (>100)`);
+  }
+  if (raw.reviewThreads.pageInfo.hasNextPage) {
+    messages.push(`review threads (>100)`);
+  }
+  const rollup = raw.commits.nodes[0]?.commit.statusCheckRollup;
+  if (rollup?.contexts.pageInfo.hasNextPage) {
+    messages.push(`status checks (>100)`);
+  }
+  if (messages.length > 0) {
+    warn(
+      `mcp-github: PR ${raw.url} has truncated output for: ${messages.join(", ")}; first page only.`,
+    );
+  }
+}
+
+// Map the union shape (CheckRun + StatusContext) onto a flat
+// `{ context, state }` pair so consumers don't have to branch on
+// __typename. CheckRun.conclusion → state via a small lookup
+// table; CheckRun in `IN_PROGRESS` / `QUEUED` etc. without a
+// concluded status maps to "PENDING".
+function normaliseCheckOrStatus(node: RawCheckOrStatus): StatusCheck {
+  if (node.__typename === "CheckRun") {
+    return {
+      context: node.name,
+      state: mapCheckRunConclusion(node.conclusion, node.status),
+    };
+  }
+  return { context: node.context, state: node.state };
+}
+
+function mapCheckRunConclusion(
+  conclusion: Extract<RawCheckOrStatus, { __typename: "CheckRun" }>["conclusion"],
+  status: Extract<RawCheckOrStatus, { __typename: "CheckRun" }>["status"],
+): StatusCheck["state"] {
+  if (conclusion === "SUCCESS") return "SUCCESS";
+  if (conclusion === "NEUTRAL" || conclusion === "SKIPPED") return "SUCCESS";
+  if (conclusion === "FAILURE" || conclusion === "TIMED_OUT" || conclusion === "STARTUP_FAILURE") {
+    return "FAILURE";
+  }
+  if (conclusion === "CANCELLED" || conclusion === "ACTION_REQUIRED" || conclusion === "STALE") {
+    return "ERROR";
+  }
+  // Conclusion is null until the run finishes; fall back to status.
+  if (status === "COMPLETED") return "SUCCESS";
+  return "PENDING";
+}

--- a/src/tools/pr/_shared.ts
+++ b/src/tools/pr/_shared.ts
@@ -17,11 +17,9 @@ export type { RepoCoords };
 export { repoSlugSchema };
 export const parseRepoSlug = parseIssueRepoSlug;
 
-// Lookup-by-(repo, number): returns the PR's GraphQL node ID and
-// the headRepository's id (for tools that need to reference the
-// fork repo, e.g. when editing a PR opened from a fork). Used by
-// the three mutations that operate on an existing PR (edit,
-// comment, merge).
+// Lookup-by-(repo, number): returns the PR's GraphQL node ID.
+// Used by the three mutations that operate on an existing PR
+// (edit, comment, merge).
 interface PRLookupResponse {
   repository: {
     pullRequest: { id: string } | null;

--- a/src/tools/pr/_shared.ts
+++ b/src/tools/pr/_shared.ts
@@ -77,9 +77,13 @@ export async function lookupRepoNodeId(
   return data.repository.id;
 }
 
-// JSON-Schema-shaped summary returned by every PR tool that
-// produces a "full PR payload" output (create, view, edit, merge).
-// The list tool returns an array of these.
+// JSON-Schema-shaped summary returned by the PR tools that
+// produce a "full PR payload" output: create, view, edit. The
+// list tool returns an array of these. gh.pr_merge does NOT
+// return PRSummary — it produces a smaller `{merged, sha, url,
+// number}` shape because the merge mutation's response only
+// guarantees those fields and a full re-fetch would be wasted
+// work.
 export interface ReviewSummary {
   author: string | null;
   state: "PENDING" | "COMMENTED" | "APPROVED" | "CHANGES_REQUESTED" | "DISMISSED";

--- a/src/tools/pr/comment.ts
+++ b/src/tools/pr/comment.ts
@@ -26,9 +26,14 @@ import {
   repoSlugSchema,
 } from "./_shared.js";
 
+// Two valid call shapes; `oneOf` enforces the divide so callers
+// can't pass `repo + number + in_reply_to` together (they'd
+// previously silently flow down the thread-reply path with the
+// repo + number pair ignored, which masks bugs in the caller's
+// thread-ID derivation).
 const inputSchema = {
   type: "object",
-  required: ["repo", "number", "body"],
+  required: ["body"],
   properties: {
     repo: repoSlugSchema,
     number: { type: "integer", minimum: 1 },
@@ -39,14 +44,31 @@ const inputSchema = {
       description:
         "Review-thread node ID (PullRequestReviewThread). When " +
         "supplied, the comment posts as a thread reply rather " +
-        "than an issue-level PR comment. NOTE: v0.1 does not yet " +
-        "expose thread IDs in any of this server's outputs " +
-        "(PRSummary carries only review_comments_count); the " +
-        "caller must source the ID from GitHub directly (e.g. via " +
-        "the REST or raw GraphQL API) until a future tool returns " +
-        "it.",
+        "than an issue-level PR comment, and the call SHAPE " +
+        "differs: omit `repo` and `number` because the thread ID " +
+        "already disambiguates. NOTE: v0.1 does not yet expose " +
+        "thread IDs in any of this server's outputs (PRSummary " +
+        "carries only review_comments_count); the caller must " +
+        "source the ID from GitHub directly until a future tool " +
+        "returns it.",
     },
   },
+  oneOf: [
+    {
+      // Issue-level path: needs repo + number, no in_reply_to.
+      required: ["repo", "number"],
+      not: { required: ["in_reply_to"] },
+    },
+    {
+      // Thread-reply path: needs in_reply_to ONLY. repo + number
+      // are deliberately disallowed here because the thread ID
+      // already carries enough context — accepting them would
+      // create ambiguity if the caller's repo/number didn't
+      // match the thread's parent PR.
+      required: ["in_reply_to"],
+      not: { anyOf: [{ required: ["repo"] }, { required: ["number"] }] },
+    },
+  ],
   additionalProperties: false,
 } as const;
 
@@ -62,12 +84,24 @@ const outputSchema = {
 
 type RegisterToolFn = (name: string, entry: ToolEntry) => void;
 
-interface Input {
-  repo: string;
-  number: number;
-  body: string;
-  in_reply_to?: string;
-}
+// The two call shapes are split into a discriminated union so
+// the handler narrows correctly without re-checking field
+// presence after the runtime validate(). Schema validation
+// enforces the actual shape; this type just helps TypeScript
+// see the same.
+type Input =
+  | {
+      repo: string;
+      number: number;
+      body: string;
+      in_reply_to?: undefined;
+    }
+  | {
+      in_reply_to: string;
+      body: string;
+      repo?: undefined;
+      number?: undefined;
+    };
 
 interface Output {
   comment_id: string;
@@ -90,14 +124,15 @@ export function registerPRCommentTool(
 ): void {
   register("gh.pr_comment", {
     description:
-      "Add a comment on a PR. Without `in_reply_to`, posts an " +
-      "issue-level PR comment. With `in_reply_to` (a review-thread " +
-      "node ID), posts a reply on that thread. Returns the new " +
-      "comment's node ID and HTML url in either case.",
+      "Add a comment on a PR. TWO CALL SHAPES, mutually exclusive: " +
+      "(a) `{repo, number, body}` posts an issue-level PR comment; " +
+      "(b) `{in_reply_to, body}` posts a reply on a review thread " +
+      "by its node ID. Passing `repo`/`number` together with " +
+      "`in_reply_to` is rejected at schema validation. Returns the " +
+      "new comment's node ID and HTML url in either case.",
     inputSchema,
     handler: async (raw) => {
       const args = validate<Input>(inputSchema, raw, "gh.pr_comment input");
-      const coords = parseRepoSlug(args.repo, "gh.pr_comment input");
       let result: Output;
       if (args.in_reply_to !== undefined) {
         const data = await graphql<ReplyResponse>("pr/comment-reply", {
@@ -111,6 +146,9 @@ export function registerPRCommentTool(
           url: data.addPullRequestReviewThreadReply.comment.url,
         };
       } else {
+        // Schema's oneOf guarantees repo + number are present on
+        // this branch, so the parse + lookup never see undefined.
+        const coords = parseRepoSlug(args.repo, "gh.pr_comment input");
         const prId = await lookupPRNodeId(
           graphql,
           coords,

--- a/src/tools/pr/comment.ts
+++ b/src/tools/pr/comment.ts
@@ -1,0 +1,124 @@
+// src/tools/pr/comment.ts
+//
+// `gh.pr_comment` — adds a comment on a PR. Two paths:
+//
+//   1. Without `in_reply_to`: posts an issue-level comment on the
+//      PR (the same surface as `gh pr comment`). Uses AddComment
+//      with the PR's GraphQL node ID as the subjectId.
+//   2. With `in_reply_to`: posts a reply on a specific review
+//      thread. Uses AddPullRequestReviewThreadReply with the
+//      thread's node ID; the caller is expected to have looked up
+//      the thread ID via the PR-view payload (review threads
+//      become accessible there in a later MCP-* PR).
+//
+// The two paths are different mutations because GitHub treats
+// "issue comments" and "review comments" as distinct objects with
+// separate node-ID namespaces. The output shape is identical.
+
+import type { GraphqlClient } from "../../graphql/client.js";
+import type { ToolEntry } from "../../registry.js";
+import { validate } from "../../validation/validator.js";
+import {
+  lookupPRNodeId,
+  parseRepoSlug,
+  repoSlugSchema,
+} from "./_shared.js";
+
+const inputSchema = {
+  type: "object",
+  required: ["repo", "number", "body"],
+  properties: {
+    repo: repoSlugSchema,
+    number: { type: "integer", minimum: 1 },
+    body: { type: "string", minLength: 1 },
+    in_reply_to: {
+      type: "string",
+      minLength: 1,
+      description:
+        "Review-thread node ID (PullRequestReviewThread). When " +
+        "supplied, the comment posts as a thread reply rather " +
+        "than an issue-level PR comment.",
+    },
+  },
+  additionalProperties: false,
+} as const;
+
+const outputSchema = {
+  type: "object",
+  required: ["comment_id", "url"],
+  properties: {
+    comment_id: { type: "string" },
+    url: { type: "string" },
+  },
+  additionalProperties: false,
+} as const;
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+interface Input {
+  repo: string;
+  number: number;
+  body: string;
+  in_reply_to?: string;
+}
+
+interface Output {
+  comment_id: string;
+  url: string;
+}
+
+interface IssueCommentResponse {
+  addComment: { commentEdge: { node: { id: string; url: string } } };
+}
+
+interface ReplyResponse {
+  addPullRequestReviewThreadReply: {
+    comment: { id: string; url: string };
+  };
+}
+
+export function registerPRCommentTool(
+  register: RegisterToolFn,
+  graphql: GraphqlClient,
+): void {
+  register("gh.pr_comment", {
+    description:
+      "Add a comment on a PR. Without `in_reply_to`, posts an " +
+      "issue-level PR comment. With `in_reply_to` (a review-thread " +
+      "node ID), posts a reply on that thread. Returns the new " +
+      "comment's node ID and HTML url in either case.",
+    inputSchema,
+    handler: async (raw) => {
+      const args = validate<Input>(inputSchema, raw, "gh.pr_comment input");
+      const coords = parseRepoSlug(args.repo, "gh.pr_comment input");
+      let result: Output;
+      if (args.in_reply_to !== undefined) {
+        const data = await graphql<ReplyResponse>("pr/comment-reply", {
+          input: {
+            pullRequestReviewThreadId: args.in_reply_to,
+            body: args.body,
+          },
+        });
+        result = {
+          comment_id: data.addPullRequestReviewThreadReply.comment.id,
+          url: data.addPullRequestReviewThreadReply.comment.url,
+        };
+      } else {
+        const prId = await lookupPRNodeId(
+          graphql,
+          coords,
+          args.number,
+          "gh.pr_comment",
+        );
+        const data = await graphql<IssueCommentResponse>("pr/comment", {
+          input: { subjectId: prId, body: args.body },
+        });
+        result = {
+          comment_id: data.addComment.commentEdge.node.id,
+          url: data.addComment.commentEdge.node.url,
+        };
+      }
+      return validate<Output>(outputSchema, result, "gh.pr_comment output");
+    },
+  });
+}

--- a/src/tools/pr/comment.ts
+++ b/src/tools/pr/comment.ts
@@ -7,9 +7,11 @@
 //      with the PR's GraphQL node ID as the subjectId.
 //   2. With `in_reply_to`: posts a reply on a specific review
 //      thread. Uses AddPullRequestReviewThreadReply with the
-//      thread's node ID; the caller is expected to have looked up
-//      the thread ID via the PR-view payload (review threads
-//      become accessible there in a later MCP-* PR).
+//      thread's node ID. v0.1 does not yet surface thread IDs in
+//      any of this server's outputs (PRSummary carries only a
+//      review_comments_count integer), so the caller must source
+//      the thread ID from GitHub directly until a future tool
+//      returns it. See input-schema description for details.
 //
 // The two paths are different mutations because GitHub treats
 // "issue comments" and "review comments" as distinct objects with
@@ -37,7 +39,12 @@ const inputSchema = {
       description:
         "Review-thread node ID (PullRequestReviewThread). When " +
         "supplied, the comment posts as a thread reply rather " +
-        "than an issue-level PR comment.",
+        "than an issue-level PR comment. NOTE: v0.1 does not yet " +
+        "expose thread IDs in any of this server's outputs " +
+        "(PRSummary carries only review_comments_count); the " +
+        "caller must source the ID from GitHub directly (e.g. via " +
+        "the REST or raw GraphQL API) until a future tool returns " +
+        "it.",
     },
   },
   additionalProperties: false,

--- a/src/tools/pr/create.ts
+++ b/src/tools/pr/create.ts
@@ -1,0 +1,83 @@
+// src/tools/pr/create.ts
+//
+// `gh.pr_create` — opens a PR. CreatePullRequestInput needs the
+// repository's GraphQL node ID (not the owner/name pair), so we
+// run a small `_repo-id` lookup first. Branch refs are passed
+// straight through; cross-repo head refs (e.g. forks) use the
+// `owner:branch` form on `headRefName`, same as `gh pr create`.
+
+import type { GraphqlClient } from "../../graphql/client.js";
+import type { ToolEntry } from "../../registry.js";
+import { validate } from "../../validation/validator.js";
+import {
+  type PRSummary,
+  type RawPR,
+  lookupRepoNodeId,
+  parseRepoSlug,
+  prSummarySchema,
+  repoSlugSchema,
+  summarisePR,
+} from "./_shared.js";
+
+const inputSchema = {
+  type: "object",
+  required: ["repo", "base", "head", "title"],
+  properties: {
+    repo: repoSlugSchema,
+    base: { type: "string", minLength: 1 },
+    head: {
+      type: "string",
+      minLength: 1,
+      description: "Head ref. Cross-repo: `owner:branch`. Same-repo: `branch`.",
+    },
+    title: { type: "string", minLength: 1 },
+    body: { type: "string" },
+    draft: { type: "boolean" },
+  },
+  additionalProperties: false,
+} as const;
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+interface Input {
+  repo: string;
+  base: string;
+  head: string;
+  title: string;
+  body?: string;
+  draft?: boolean;
+}
+
+interface CreateResponse {
+  createPullRequest: { pullRequest: RawPR };
+}
+
+export function registerPRCreateTool(
+  register: RegisterToolFn,
+  graphql: GraphqlClient,
+): void {
+  register("gh.pr_create", {
+    description:
+      "Open a PR. `head` accepts `branch` for same-repo PRs and " +
+      "`owner:branch` for cross-repo (fork-based). Returns the " +
+      "canonical PRSummary including the new PR's number, url, " +
+      "and node_id.",
+    inputSchema,
+    handler: async (raw) => {
+      const args = validate<Input>(inputSchema, raw, "gh.pr_create input");
+      const coords = parseRepoSlug(args.repo, "gh.pr_create input");
+      const repositoryId = await lookupRepoNodeId(graphql, coords, "gh.pr_create");
+      const input: Record<string, unknown> = {
+        repositoryId,
+        baseRefName: args.base,
+        headRefName: args.head,
+        title: args.title,
+      };
+      if (args.body !== undefined) input.body = args.body;
+      if (args.draft !== undefined) input.draft = args.draft;
+      const data = await graphql<CreateResponse>("pr/create", { input });
+      const summary = summarisePR(data.createPullRequest.pullRequest);
+      return validate<PRSummary>(prSummarySchema, summary, "gh.pr_create output");
+    },
+  });
+}

--- a/src/tools/pr/edit.ts
+++ b/src/tools/pr/edit.ts
@@ -3,9 +3,15 @@
 // `gh.pr_edit` — updates fields on an existing PR. Two-step:
 // look up the PR's GraphQL node ID, then run UpdatePullRequest
 // with only the fields that were supplied. Omitting a field
-// leaves it unchanged; passing `null` is rejected by the input
-// schema (we don't accept it as a "clear" sentinel because the
-// underlying mutation has no concept of clearing title/body).
+// leaves it unchanged. Sentinels:
+//
+//   - title cannot be cleared (the schema requires minLength: 1
+//     on the way in, and GitHub rejects empty-title PRs anyway).
+//   - body CAN be cleared by passing the empty string `""` —
+//     UpdatePullRequest accepts that and stores no body.
+//   - `null` is intentionally rejected at the schema level for
+//     both fields; if you want to clear the body, pass `""`
+//     explicitly so the intent is unambiguous in the call shape.
 
 import type { GraphqlClient } from "../../graphql/client.js";
 import type { ToolEntry } from "../../registry.js";

--- a/src/tools/pr/edit.ts
+++ b/src/tools/pr/edit.ts
@@ -95,27 +95,23 @@ export function registerPREditTool(
 }
 
 // When the caller supplies `draft`, we run the title/body/base
-// edit (if any of those fields were also set) AND the
-// draft-toggle mutation. The draft toggle is intentionally
-// applied AFTER the field edits so the final returned PR carries
-// the draft state the caller asked for, rather than the
-// pre-toggle one.
+// edit first (if any of those fields were also set) AND the
+// draft-toggle mutation second. Order matters: the toggle's
+// pullRequest payload becomes the response, so a same-call
+// `title + draft` edit returns a PR carrying both the new title
+// AND the new draft state. The pr/edit response is intentionally
+// discarded.
 async function applyEditWithDraftToggle(
   graphql: GraphqlClient,
   pullRequestId: string,
   input: Record<string, unknown>,
   draft: boolean,
 ): Promise<EditResponse> {
-  // If the caller only changed `draft`, the input has just
-  // `pullRequestId` — skip the no-op pr/edit call.
-  let result: EditResponse;
+  // Only run pr/edit when the caller changed fields besides
+  // `draft`. The input always carries `pullRequestId`, so a
+  // length of 1 means draft-only and we skip the no-op call.
   if (Object.keys(input).length > 1) {
-    result = await graphql<EditResponse>("pr/edit", { input });
-  } else {
-    // Synthesize a "no-op edit" result that matches the toggle
-    // mutation's pullRequest payload shape so the caller below
-    // can read it uniformly. Replaced with the toggle response.
-    result = { updatePullRequest: { pullRequest: {} as RawPR } };
+    await graphql<EditResponse>("pr/edit", { input });
   }
   const toggleQuery = draft ? "pr/_to-draft" : "pr/_ready-for-review";
   const toggleResp = await graphql<{

--- a/src/tools/pr/edit.ts
+++ b/src/tools/pr/edit.ts
@@ -1,0 +1,134 @@
+// src/tools/pr/edit.ts
+//
+// `gh.pr_edit` — updates fields on an existing PR. Two-step:
+// look up the PR's GraphQL node ID, then run UpdatePullRequest
+// with only the fields that were supplied. Omitting a field
+// leaves it unchanged; passing `null` is rejected by the input
+// schema (we don't accept it as a "clear" sentinel because the
+// underlying mutation has no concept of clearing title/body).
+
+import type { GraphqlClient } from "../../graphql/client.js";
+import type { ToolEntry } from "../../registry.js";
+import { validate } from "../../validation/validator.js";
+import {
+  type PRSummary,
+  type RawPR,
+  lookupPRNodeId,
+  parseRepoSlug,
+  prSummarySchema,
+  repoSlugSchema,
+  summarisePR,
+} from "./_shared.js";
+
+const inputSchema = {
+  type: "object",
+  required: ["repo", "number"],
+  properties: {
+    repo: repoSlugSchema,
+    number: { type: "integer", minimum: 1 },
+    title: { type: "string", minLength: 1 },
+    body: { type: "string" },
+    base: { type: "string", minLength: 1 },
+    draft: { type: "boolean" },
+  },
+  additionalProperties: false,
+} as const;
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+interface Input {
+  repo: string;
+  number: number;
+  title?: string;
+  body?: string;
+  base?: string;
+  draft?: boolean;
+}
+
+interface EditResponse {
+  updatePullRequest: { pullRequest: RawPR };
+}
+
+export function registerPREditTool(
+  register: RegisterToolFn,
+  graphql: GraphqlClient,
+): void {
+  register("gh.pr_edit", {
+    description:
+      "Update fields on an existing PR. Each field is independent " +
+      "and optional; omitting a field leaves it unchanged. " +
+      "`base` retargets the PR; `draft: true|false` toggles the " +
+      "draft state. Returns the updated PRSummary.",
+    inputSchema,
+    handler: async (raw) => {
+      const args = validate<Input>(inputSchema, raw, "gh.pr_edit input");
+      const coords = parseRepoSlug(args.repo, "gh.pr_edit input");
+      const pullRequestId = await lookupPRNodeId(
+        graphql,
+        coords,
+        args.number,
+        "gh.pr_edit",
+      );
+      const input: Record<string, unknown> = { pullRequestId };
+      if (args.title !== undefined) input.title = args.title;
+      if (args.body !== undefined) input.body = args.body;
+      if (args.base !== undefined) input.baseRefName = args.base;
+      // The GraphQL `UpdatePullRequestInput` accepts `state` for
+      // open/close, not `draft`. Toggling draft uses a separate
+      // mutation pair (markPullRequestReadyForReview /
+      // convertPullRequestToDraft). We expose `draft` here as a
+      // single-direction signal: if supplied, it routes to
+      // whichever sibling mutation matches. Implemented below.
+      const data =
+        args.draft === undefined
+          ? await graphql<EditResponse>("pr/edit", { input })
+          : await applyEditWithDraftToggle(
+              graphql,
+              pullRequestId,
+              input,
+              args.draft,
+            );
+      const summary = summarisePR(data.updatePullRequest.pullRequest);
+      return validate<PRSummary>(prSummarySchema, summary, "gh.pr_edit output");
+    },
+  });
+}
+
+// When the caller supplies `draft`, we run the title/body/base
+// edit (if any of those fields were also set) AND the
+// draft-toggle mutation. The draft toggle is intentionally
+// applied AFTER the field edits so the final returned PR carries
+// the draft state the caller asked for, rather than the
+// pre-toggle one.
+async function applyEditWithDraftToggle(
+  graphql: GraphqlClient,
+  pullRequestId: string,
+  input: Record<string, unknown>,
+  draft: boolean,
+): Promise<EditResponse> {
+  // If the caller only changed `draft`, the input has just
+  // `pullRequestId` — skip the no-op pr/edit call.
+  let result: EditResponse;
+  if (Object.keys(input).length > 1) {
+    result = await graphql<EditResponse>("pr/edit", { input });
+  } else {
+    // Synthesize a "no-op edit" result that matches the toggle
+    // mutation's pullRequest payload shape so the caller below
+    // can read it uniformly. Replaced with the toggle response.
+    result = { updatePullRequest: { pullRequest: {} as RawPR } };
+  }
+  const toggleQuery = draft ? "pr/_to-draft" : "pr/_ready-for-review";
+  const toggleResp = await graphql<{
+    convertPullRequestToDraft?: { pullRequest: RawPR };
+    markPullRequestReadyForReview?: { pullRequest: RawPR };
+  }>(toggleQuery, { input: { pullRequestId } });
+  const pr =
+    toggleResp.convertPullRequestToDraft?.pullRequest ??
+    toggleResp.markPullRequestReadyForReview?.pullRequest;
+  if (!pr) {
+    throw new Error(
+      `mcp-github: gh.pr_edit: draft-toggle mutation returned no pullRequest payload`,
+    );
+  }
+  return { updatePullRequest: { pullRequest: pr } };
+}

--- a/src/tools/pr/index.ts
+++ b/src/tools/pr/index.ts
@@ -1,0 +1,28 @@
+// src/tools/pr/index.ts
+//
+// Aggregator for the six gh.pr_* tools. Imported by
+// `src/server.ts`'s startServer() and called once at boot to
+// register every PR-domain tool against the registry.
+
+import type { GraphqlClient } from "../../graphql/client.js";
+import type { ToolEntry } from "../../registry.js";
+import { registerPRCommentTool } from "./comment.js";
+import { registerPRCreateTool } from "./create.js";
+import { registerPREditTool } from "./edit.js";
+import { registerPRListTool } from "./list.js";
+import { registerPRMergeTool } from "./merge.js";
+import { registerPRViewTool } from "./view.js";
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+export function registerPRTools(
+  register: RegisterToolFn,
+  graphql: GraphqlClient,
+): void {
+  registerPRCreateTool(register, graphql);
+  registerPRViewTool(register, graphql);
+  registerPRListTool(register, graphql);
+  registerPREditTool(register, graphql);
+  registerPRCommentTool(register, graphql);
+  registerPRMergeTool(register, graphql);
+}

--- a/src/tools/pr/list.ts
+++ b/src/tools/pr/list.ts
@@ -116,16 +116,13 @@ export function registerPRListTool(
       const states = mapStateFilter(args.state);
       // Strip an optional `owner:` prefix on `head` so the gh-CLI
       // shape (`--head owner:branch`) keeps working. GraphQL's
-      // `headRefName` filter is the bare branch name. Validate
-      // post-strip too: `head: "owner:"` and `head: ":branch"`
-      // (in the second the prefix is empty) would otherwise send
-      // an empty filter that matches nothing.
-      const head = args.head ? stripOwnerPrefix(args.head) : null;
-      if (head !== null && head.length === 0) {
-        throw new Error(
-          `mcp-github: gh.pr_list input: head must contain a branch name after the optional 'owner:' prefix, got '${args.head}'`,
-        );
-      }
+      // `headRefName` filter is the bare branch name. The
+      // helper rejects `":branch"` and `"owner:"` (and any
+      // single-colon shape with an empty half) before stripping,
+      // so the GraphQL call never sees an empty filter.
+      const head = args.head
+        ? stripOwnerPrefix(args.head, "gh.pr_list input")
+        : null;
       const data = await graphql<Response>("pr/list", {
         owner: coords.owner,
         name: coords.name,
@@ -175,9 +172,25 @@ function mapStateFilter(
 // `Repository.pullRequests.headRefName` filter is the branch
 // name only. We strip rather than reject so the gh-CLI shape
 // keeps working without the caller knowing about this
-// boundary. A name with no colon passes through unchanged.
-function stripOwnerPrefix(head: string): string {
+// boundary.
+//
+// We reject malformed shapes BEFORE stripping so the caller sees
+// the bad input rather than a "no results" mystery later:
+//
+//   - leading colon (`":branch"`) → empty owner; almost
+//     certainly a typo / mis-concatenation upstream, not the
+//     intent.
+//   - trailing colon (`"owner:"`) → empty branch; same.
+//   - no colon at all → unchanged.
+//
+// Returns the bare branch name on success; throws otherwise.
+function stripOwnerPrefix(head: string, where: string): string {
   const colon = head.indexOf(":");
   if (colon === -1) return head;
+  if (colon === 0 || colon === head.length - 1) {
+    throw new Error(
+      `mcp-github: ${where}: head '${head}' is malformed; expected 'owner:branch' with both halves non-empty`,
+    );
+  }
   return head.slice(colon + 1);
 }

--- a/src/tools/pr/list.ts
+++ b/src/tools/pr/list.ts
@@ -177,19 +177,24 @@ function mapStateFilter(
 // We reject malformed shapes BEFORE stripping so the caller sees
 // the bad input rather than a "no results" mystery later:
 //
-//   - leading colon (`":branch"`) → empty owner; almost
-//     certainly a typo / mis-concatenation upstream, not the
-//     intent.
-//   - trailing colon (`"owner:"`) → empty branch; same.
+//   - leading colon (`":branch"`) → empty owner.
+//   - trailing colon (`"owner:"`) → empty branch.
+//   - more than one colon (`"a:b:c"`) → not a valid
+//     `owner:branch` shape; the unstripped tail (`"b:c"`) would
+//     silently match nothing on GraphQL.
 //   - no colon at all → unchanged.
 //
 // Returns the bare branch name on success; throws otherwise.
 function stripOwnerPrefix(head: string, where: string): string {
   const colon = head.indexOf(":");
   if (colon === -1) return head;
-  if (colon === 0 || colon === head.length - 1) {
+  const malformed =
+    colon === 0 ||
+    colon === head.length - 1 ||
+    head.indexOf(":", colon + 1) !== -1;
+  if (malformed) {
     throw new Error(
-      `mcp-github: ${where}: head '${head}' is malformed; expected 'owner:branch' with both halves non-empty`,
+      `mcp-github: ${where}: head '${head}' is malformed; expected 'owner:branch' with both halves non-empty and exactly one colon`,
     );
   }
   return head.slice(colon + 1);

--- a/src/tools/pr/list.ts
+++ b/src/tools/pr/list.ts
@@ -1,0 +1,154 @@
+// src/tools/pr/list.ts
+//
+// `gh.pr_list` — paginated PR list, optionally filtered by state,
+// head ref, base ref, or author. `author` is post-filtered
+// client-side because GraphQL `Repository.pullRequests` doesn't
+// have an `author` filter; same trade-off as gh.issue_list's
+// `assignee`/`since` filters.
+
+import type { GraphqlClient } from "../../graphql/client.js";
+import type { ToolEntry } from "../../registry.js";
+import { validate } from "../../validation/validator.js";
+import {
+  type PRSummary,
+  type RawPR,
+  parseRepoSlug,
+  prSummarySchema,
+  repoSlugSchema,
+  summarisePR,
+} from "./_shared.js";
+
+const PER_PAGE_DEFAULT = 30;
+const PER_PAGE_MAX = 100;
+
+const inputSchema = {
+  type: "object",
+  required: ["repo"],
+  properties: {
+    repo: repoSlugSchema,
+    state: {
+      type: "string",
+      enum: ["OPEN", "CLOSED", "MERGED", "ALL"],
+      description: "Defaults to OPEN.",
+    },
+    head: {
+      type: "string",
+      minLength: 1,
+      description: "Filter by head ref name (e.g. `owner:branch` or just `branch`).",
+    },
+    base: {
+      type: "string",
+      minLength: 1,
+      description: "Filter by base ref name.",
+    },
+    author: {
+      type: "string",
+      minLength: 1,
+      description: "Filter to PRs opened by this login (post-filter, client-side).",
+    },
+    perPage: { type: "integer", minimum: 1, maximum: PER_PAGE_MAX },
+    after: {
+      type: "string",
+      minLength: 1,
+      description: "Opaque cursor from a previous page's endCursor.",
+    },
+  },
+  additionalProperties: false,
+} as const;
+
+const outputSchema = {
+  type: "object",
+  required: ["items", "hasNextPage", "endCursor"],
+  properties: {
+    items: { type: "array", items: prSummarySchema },
+    hasNextPage: { type: "boolean" },
+    endCursor: { type: ["string", "null"] },
+  },
+  additionalProperties: false,
+} as const;
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+interface Input {
+  repo: string;
+  state?: "OPEN" | "CLOSED" | "MERGED" | "ALL";
+  head?: string;
+  base?: string;
+  author?: string;
+  perPage?: number;
+  after?: string;
+}
+
+interface Output {
+  items: PRSummary[];
+  hasNextPage: boolean;
+  endCursor: string | null;
+}
+
+interface Response {
+  repository: {
+    pullRequests: {
+      pageInfo: { hasNextPage: boolean; endCursor: string | null };
+      nodes: RawPR[];
+    };
+  } | null;
+}
+
+export function registerPRListTool(
+  register: RegisterToolFn,
+  graphql: GraphqlClient,
+): void {
+  register("gh.pr_list", {
+    description:
+      "List PRs in a repo with optional state / head / base / " +
+      "author filters. Returns one page; advance via the returned " +
+      "`endCursor`. `author` is post-filtered client-side because " +
+      "GraphQL Repository.pullRequests doesn't index it.",
+    inputSchema,
+    handler: async (raw) => {
+      const args = validate<Input>(inputSchema, raw, "gh.pr_list input");
+      const coords = parseRepoSlug(args.repo, "gh.pr_list input");
+      const states = mapStateFilter(args.state);
+      const data = await graphql<Response>("pr/list", {
+        owner: coords.owner,
+        name: coords.name,
+        states,
+        headRefName: args.head ?? null,
+        baseRefName: args.base ?? null,
+        first: args.perPage ?? PER_PAGE_DEFAULT,
+        after: args.after ?? null,
+      });
+      if (!data.repository) {
+        throw new Error(
+          `mcp-github: gh.pr_list: repository '${coords.owner}/${coords.name}' not found or token lacks read access`,
+        );
+      }
+      // Filter raw nodes BEFORE summarising. summarisePR builds
+      // multiple arrays + walks the status-check rollup, so doing
+      // it for items that will be dropped by the author predicate
+      // wastes work proportional to the page size.
+      const filtered: PRSummary[] = [];
+      for (const pr of data.repository.pullRequests.nodes) {
+        if (args.author && pr.author?.login !== args.author) continue;
+        filtered.push(summarisePR(pr));
+      }
+      const out: Output = {
+        items: filtered,
+        hasNextPage: data.repository.pullRequests.pageInfo.hasNextPage,
+        endCursor: data.repository.pullRequests.pageInfo.endCursor,
+      };
+      return validate<Output>(outputSchema, out, "gh.pr_list output");
+    },
+  });
+}
+
+// `ALL` translates to "no filter" (null). Unset defaults to OPEN
+// to match `gh pr list` ergonomics; callers who want everything
+// pass `state: "ALL"` explicitly.
+function mapStateFilter(
+  state: Input["state"],
+): Array<"OPEN" | "CLOSED" | "MERGED"> | null {
+  if (state === "ALL") return null;
+  if (state === undefined) return ["OPEN"];
+  return [state];
+}

--- a/src/tools/pr/list.ts
+++ b/src/tools/pr/list.ts
@@ -114,16 +114,23 @@ export function registerPRListTool(
       const args = validate<Input>(inputSchema, raw, "gh.pr_list input");
       const coords = parseRepoSlug(args.repo, "gh.pr_list input");
       const states = mapStateFilter(args.state);
+      // Strip an optional `owner:` prefix on `head` so the gh-CLI
+      // shape (`--head owner:branch`) keeps working. GraphQL's
+      // `headRefName` filter is the bare branch name. Validate
+      // post-strip too: `head: "owner:"` and `head: ":branch"`
+      // (in the second the prefix is empty) would otherwise send
+      // an empty filter that matches nothing.
+      const head = args.head ? stripOwnerPrefix(args.head) : null;
+      if (head !== null && head.length === 0) {
+        throw new Error(
+          `mcp-github: gh.pr_list input: head must contain a branch name after the optional 'owner:' prefix, got '${args.head}'`,
+        );
+      }
       const data = await graphql<Response>("pr/list", {
         owner: coords.owner,
         name: coords.name,
         states,
-        // Strip an optional `owner:` prefix on `head` so the
-        // gh-CLI shape (`--head owner:branch`) keeps working.
-        // GraphQL's `headRefName` filter is the bare branch name,
-        // and the unstripped form would match nothing on a
-        // cross-repo (fork) PR.
-        headRefName: args.head ? stripOwnerPrefix(args.head) : null,
+        headRefName: head,
         baseRefName: args.base ?? null,
         first: args.perPage ?? PER_PAGE_DEFAULT,
         after: args.after ?? null,

--- a/src/tools/pr/list.ts
+++ b/src/tools/pr/list.ts
@@ -34,7 +34,12 @@ const inputSchema = {
     head: {
       type: "string",
       minLength: 1,
-      description: "Filter by head ref name (e.g. `owner:branch` or just `branch`).",
+      description:
+        "Filter by head ref name. Branch name only (e.g. `feat/x`); " +
+        "if you pass `owner:branch` (the `gh pr list --head` form), " +
+        "the `owner:` prefix is stripped before sending to GraphQL " +
+        "because Repository.pullRequests.headRefName matches the " +
+        "ref name without an owner qualifier.",
     },
     base: {
       type: "string",
@@ -113,7 +118,12 @@ export function registerPRListTool(
         owner: coords.owner,
         name: coords.name,
         states,
-        headRefName: args.head ?? null,
+        // Strip an optional `owner:` prefix on `head` so the
+        // gh-CLI shape (`--head owner:branch`) keeps working.
+        // GraphQL's `headRefName` filter is the bare branch name,
+        // and the unstripped form would match nothing on a
+        // cross-repo (fork) PR.
+        headRefName: args.head ? stripOwnerPrefix(args.head) : null,
         baseRefName: args.base ?? null,
         first: args.perPage ?? PER_PAGE_DEFAULT,
         after: args.after ?? null,
@@ -151,4 +161,16 @@ function mapStateFilter(
   if (state === "ALL") return null;
   if (state === undefined) return ["OPEN"];
   return [state];
+}
+
+// Drop an `owner:` prefix from a head-ref name. `gh pr list`'s
+// `--head` accepts `owner:branch` for fork PRs; GraphQL's
+// `Repository.pullRequests.headRefName` filter is the branch
+// name only. We strip rather than reject so the gh-CLI shape
+// keeps working without the caller knowing about this
+// boundary. A name with no colon passes through unchanged.
+function stripOwnerPrefix(head: string): string {
+  const colon = head.indexOf(":");
+  if (colon === -1) return head;
+  return head.slice(colon + 1);
 }

--- a/src/tools/pr/merge.ts
+++ b/src/tools/pr/merge.ts
@@ -1,0 +1,134 @@
+// src/tools/pr/merge.ts
+//
+// `gh.pr_merge` — merges a PR using one of three methods (merge,
+// squash, rebase). Branch-protection failures, mergeability
+// blocks, and conflicts come back from GitHub as GraphQL errors;
+// `client.ts`'s mapper turns them into structured `GraphqlError`
+// instances so the caller sees the rejection reason rather than
+// a generic crash.
+
+import type { GraphqlClient } from "../../graphql/client.js";
+import type { ToolEntry } from "../../registry.js";
+import { validate } from "../../validation/validator.js";
+import {
+  lookupPRNodeId,
+  parseRepoSlug,
+  repoSlugSchema,
+} from "./_shared.js";
+
+const inputSchema = {
+  type: "object",
+  required: ["repo", "number", "method"],
+  properties: {
+    repo: repoSlugSchema,
+    number: { type: "integer", minimum: 1 },
+    method: { type: "string", enum: ["merge", "squash", "rebase"] },
+    commit_title: {
+      type: "string",
+      minLength: 1,
+      description: "Override the merge-commit subject (merge / squash only).",
+    },
+    commit_message: {
+      type: "string",
+      description:
+        "Override the merge-commit body (merge / squash only). Pass " +
+        "empty string to clear; omit to keep GitHub's default.",
+    },
+  },
+  additionalProperties: false,
+} as const;
+
+const outputSchema = {
+  type: "object",
+  required: ["merged", "url"],
+  properties: {
+    merged: { type: "boolean" },
+    sha: { type: ["string", "null"] },
+    url: { type: "string" },
+    number: { type: "integer" },
+  },
+  additionalProperties: false,
+} as const;
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+interface Input {
+  repo: string;
+  number: number;
+  method: "merge" | "squash" | "rebase";
+  commit_title?: string;
+  commit_message?: string;
+}
+
+interface Output {
+  merged: boolean;
+  sha: string | null;
+  url: string;
+  number: number;
+}
+
+interface MergeResponse {
+  mergePullRequest: {
+    pullRequest: {
+      number: number;
+      url: string;
+      merged: boolean;
+      mergeCommit: { oid: string } | null;
+    };
+  };
+}
+
+const METHOD_GRAPHQL: Record<Input["method"], "MERGE" | "SQUASH" | "REBASE"> = {
+  merge: "MERGE",
+  squash: "SQUASH",
+  rebase: "REBASE",
+};
+
+export function registerPRMergeTool(
+  register: RegisterToolFn,
+  graphql: GraphqlClient,
+): void {
+  register("gh.pr_merge", {
+    description:
+      "Merge a PR via merge | squash | rebase. Branch-protection " +
+      "failures and mergeability blocks come back as structured " +
+      "GraphqlError. Returns `{merged, sha, url, number}`.",
+    inputSchema,
+    handler: async (raw) => {
+      const args = validate<Input>(inputSchema, raw, "gh.pr_merge input");
+      const coords = parseRepoSlug(args.repo, "gh.pr_merge input");
+      const pullRequestId = await lookupPRNodeId(
+        graphql,
+        coords,
+        args.number,
+        "gh.pr_merge",
+      );
+      const input: Record<string, unknown> = {
+        pullRequestId,
+        mergeMethod: METHOD_GRAPHQL[args.method],
+      };
+      if (args.method !== "rebase") {
+        // Rebase merges have no merge commit, so commit_title /
+        // commit_message are ignored — GitHub returns an error if
+        // they're set with REBASE. Drop them silently for the
+        // rebase path; users who passed them probably meant the
+        // commit body that ends up on the rebased commits, which
+        // we don't control here.
+        if (args.commit_title !== undefined) {
+          input.commitHeadline = args.commit_title;
+        }
+        if (args.commit_message !== undefined) {
+          input.commitBody = args.commit_message;
+        }
+      }
+      const data = await graphql<MergeResponse>("pr/merge", { input });
+      const out: Output = {
+        merged: data.mergePullRequest.pullRequest.merged,
+        sha: data.mergePullRequest.pullRequest.mergeCommit?.oid ?? null,
+        url: data.mergePullRequest.pullRequest.url,
+        number: data.mergePullRequest.pullRequest.number,
+      };
+      return validate<Output>(outputSchema, out, "gh.pr_merge output");
+    },
+  });
+}

--- a/src/tools/pr/merge.ts
+++ b/src/tools/pr/merge.ts
@@ -40,7 +40,14 @@ const inputSchema = {
 
 const outputSchema = {
   type: "object",
-  required: ["merged", "url"],
+  // sha + number are documented contract: the handler always
+  // emits them (sha is null only when GitHub returns no
+  // mergeCommit, e.g. for rebase merges). Listing them in
+  // `required` means an accidental omission (e.g. a future
+  // refactor that drops a field from the GraphQL response) trips
+  // output validation here rather than landing on consumers as a
+  // partial payload.
+  required: ["merged", "sha", "url", "number"],
   properties: {
     merged: { type: "boolean" },
     sha: { type: ["string", "null"] },

--- a/src/tools/pr/view.ts
+++ b/src/tools/pr/view.ts
@@ -1,9 +1,13 @@
 // src/tools/pr/view.ts
 //
 // `gh.pr_view` — fetches a PR with reviews + review-comment count
-// + status-checks rolled in. The single output shape (`PRSummary`)
-// is shared with create/edit/list/merge so consumers see the same
-// fields regardless of how they got the PR payload.
+// + status-checks rolled in. The output shape (`PRSummary`) is
+// shared with create/edit (and list, which returns an array of
+// these), so consumers see the same fields regardless of how
+// they got the PR payload. gh.pr_merge has its own smaller
+// `{merged, sha, url, number}` shape because the merge mutation
+// only guarantees those fields and a full re-fetch would be
+// wasted work.
 
 import type { GraphqlClient } from "../../graphql/client.js";
 import type { ToolEntry } from "../../registry.js";

--- a/src/tools/pr/view.ts
+++ b/src/tools/pr/view.ts
@@ -1,0 +1,77 @@
+// src/tools/pr/view.ts
+//
+// `gh.pr_view` — fetches a PR with reviews + review-comment count
+// + status-checks rolled in. The single output shape (`PRSummary`)
+// is shared with create/edit/list/merge so consumers see the same
+// fields regardless of how they got the PR payload.
+
+import type { GraphqlClient } from "../../graphql/client.js";
+import type { ToolEntry } from "../../registry.js";
+import { validate } from "../../validation/validator.js";
+import {
+  type PRSummary,
+  type RawPR,
+  parseRepoSlug,
+  prSummarySchema,
+  repoSlugSchema,
+  summarisePR,
+} from "./_shared.js";
+
+const inputSchema = {
+  type: "object",
+  required: ["repo", "number"],
+  properties: {
+    repo: repoSlugSchema,
+    number: { type: "integer", minimum: 1 },
+  },
+  additionalProperties: false,
+} as const;
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+interface Input {
+  repo: string;
+  number: number;
+}
+
+interface Response {
+  repository: { pullRequest: RawPR | null } | null;
+}
+
+export function registerPRViewTool(
+  register: RegisterToolFn,
+  graphql: GraphqlClient,
+): void {
+  register("gh.pr_view", {
+    description:
+      "Fetch a PR with reviews, review-comment count, and " +
+      "status-checks summary. Returns the canonical PRSummary " +
+      "shape used by every PR tool that produces a full payload.",
+    inputSchema,
+    handler: async (raw) => {
+      const args = validate<Input>(inputSchema, raw, "gh.pr_view input");
+      const coords = parseRepoSlug(args.repo, "gh.pr_view input");
+      const data = await graphql<Response>("pr/view", {
+        owner: coords.owner,
+        name: coords.name,
+        number: args.number,
+      });
+      // Distinguish "repo missing / no access" from "PR missing" so
+      // a typo in the slug doesn't surface as a misleading
+      // "PR not found" message.
+      if (!data.repository) {
+        throw new Error(
+          `mcp-github: gh.pr_view: repository '${coords.owner}/${coords.name}' not found or token lacks read access`,
+        );
+      }
+      const pr = data.repository.pullRequest;
+      if (!pr) {
+        throw new Error(
+          `mcp-github: gh.pr_view: PR ${coords.owner}/${coords.name}#${args.number} not found`,
+        );
+      }
+      const summary = summarisePR(pr);
+      return validate<PRSummary>(prSummarySchema, summary, "gh.pr_view output");
+    },
+  });
+}

--- a/tests/smoke/server-lists-tools.mjs
+++ b/tests/smoke/server-lists-tools.mjs
@@ -36,6 +36,12 @@ const EXPECTED_TOOLS = [
   "gh.issue_close",
   "gh.issue_comment",
   "gh.issue_search",
+  "gh.pr_create",
+  "gh.pr_view",
+  "gh.pr_list",
+  "gh.pr_edit",
+  "gh.pr_comment",
+  "gh.pr_merge",
 ];
 
 function frame(payload) {

--- a/tests/unit/tools/pr/_fixtures.ts
+++ b/tests/unit/tools/pr/_fixtures.ts
@@ -1,0 +1,107 @@
+// tests/unit/tools/pr/_fixtures.ts
+//
+// Shared fixtures + stub-graphql helpers for the gh.pr_* tool
+// tests. Mirrors the issue-domain fixtures in shape; the only
+// material differences are the heavier per-PR payload (reviews,
+// reviewThreads totalCount, statusCheckRollup).
+
+import type { GraphqlClient } from "../../../../src/graphql/client.ts";
+
+export interface MockedCall {
+  queryName: string;
+  vars: Record<string, unknown>;
+}
+
+export function stubGraphqlClient(
+  fixtures: Record<
+    string,
+    | unknown
+    | ((vars: Record<string, unknown>) => unknown | Promise<unknown>)
+  >,
+): { graphql: GraphqlClient; calls: MockedCall[] } {
+  const calls: MockedCall[] = [];
+  const graphql = (async (
+    queryName: string,
+    vars: Record<string, unknown> = {},
+  ) => {
+    calls.push({ queryName, vars });
+    if (!(queryName in fixtures)) {
+      throw new Error(
+        `tests: stubGraphqlClient saw unmocked queryName: ${queryName}`,
+      );
+    }
+    const entry = fixtures[queryName];
+    if (typeof entry === "function") {
+      return await (entry as (v: Record<string, unknown>) => unknown)(vars);
+    }
+    return entry;
+  }) as unknown as GraphqlClient;
+  return { graphql, calls };
+}
+
+// Canonical RawPR shape used across the per-tool tests. Tests
+// override fields case-by-case via spread.
+export const sampleRawPR = {
+  number: 7,
+  url: "https://github.com/owner/repo/pull/7",
+  id: "PR_kwDO_7",
+  title: "Sample PR",
+  state: "OPEN" as const,
+  body: "Sample body",
+  baseRefName: "main",
+  headRefName: "feat/x",
+  isDraft: false,
+  mergeable: "MERGEABLE" as const,
+  merged: false,
+  mergedAt: null,
+  mergeCommit: null,
+  labels: {
+    pageInfo: { hasNextPage: false },
+    nodes: [{ name: "enhancement" }],
+  },
+  assignees: {
+    pageInfo: { hasNextPage: false },
+    nodes: [{ login: "alice" }],
+  },
+  author: { login: "bob" },
+  createdAt: "2026-04-01T00:00:00Z",
+  updatedAt: "2026-04-02T00:00:00Z",
+  closedAt: null,
+  reviews: {
+    pageInfo: { hasNextPage: false },
+    nodes: [
+      { state: "APPROVED" as const, author: { login: "carol" } },
+    ],
+  },
+  reviewThreads: {
+    pageInfo: { hasNextPage: false },
+    nodes: [{ comments: { totalCount: 3 } }, { comments: { totalCount: 0 } }],
+  },
+  commits: {
+    nodes: [
+      {
+        commit: {
+          statusCheckRollup: {
+            state: "SUCCESS" as const,
+            contexts: {
+              pageInfo: { hasNextPage: false },
+              nodes: [
+                {
+                  __typename: "CheckRun",
+                  name: "ci/build",
+                  conclusion: "SUCCESS" as const,
+                  status: "COMPLETED" as const,
+                },
+                {
+                  __typename: "StatusContext",
+                  context: "ci/legacy",
+                  state: "SUCCESS" as const,
+                },
+              ],
+            },
+          },
+        },
+      },
+    ],
+  },
+};

--- a/tests/unit/tools/pr/_fixtures.ts
+++ b/tests/unit/tools/pr/_fixtures.ts
@@ -87,13 +87,13 @@ export const sampleRawPR = {
               pageInfo: { hasNextPage: false },
               nodes: [
                 {
-                  __typename: "CheckRun",
+                  __typename: "CheckRun" as const,
                   name: "ci/build",
                   conclusion: "SUCCESS" as const,
                   status: "COMPLETED" as const,
                 },
                 {
-                  __typename: "StatusContext",
+                  __typename: "StatusContext" as const,
                   context: "ci/legacy",
                   state: "SUCCESS" as const,
                 },

--- a/tests/unit/tools/pr/_shared.test.ts
+++ b/tests/unit/tools/pr/_shared.test.ts
@@ -1,0 +1,107 @@
+// tests/unit/tools/pr/_shared.test.ts
+//
+// Pin the truncation-warning paths in `summarisePR()`. The issue
+// domain has the analogous test at
+// `tests/unit/tools/issue/_shared.test.ts`; we mirror the
+// coverage here so each truncation flag (labels, assignees,
+// reviews, reviewThreads, status-check contexts) surfaces a
+// stderr-style warning rather than silently emitting a partial
+// payload.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { summarisePR } from "../../../../src/tools/pr/_shared.ts";
+import { sampleRawPR } from "./_fixtures.ts";
+
+test("summarisePR: silent on the common, not-truncated case", () => {
+  const warns: string[] = [];
+  summarisePR(sampleRawPR, (m) => warns.push(m));
+  assert.equal(warns.length, 0);
+});
+
+test("summarisePR: warns when labels are truncated", () => {
+  const truncated = {
+    ...sampleRawPR,
+    labels: { ...sampleRawPR.labels, pageInfo: { hasNextPage: true } },
+  };
+  const warns: string[] = [];
+  summarisePR(truncated, (m) => warns.push(m));
+  assert.equal(warns.length, 1);
+  assert.match(warns[0] ?? "", /labels \(>100\)/);
+});
+
+test("summarisePR: warns when assignees are truncated", () => {
+  const truncated = {
+    ...sampleRawPR,
+    assignees: { ...sampleRawPR.assignees, pageInfo: { hasNextPage: true } },
+  };
+  const warns: string[] = [];
+  summarisePR(truncated, (m) => warns.push(m));
+  assert.equal(warns.length, 1);
+  assert.match(warns[0] ?? "", /assignees \(>100\)/);
+});
+
+test("summarisePR: warns when reviews are truncated", () => {
+  const truncated = {
+    ...sampleRawPR,
+    reviews: { ...sampleRawPR.reviews, pageInfo: { hasNextPage: true } },
+  };
+  const warns: string[] = [];
+  summarisePR(truncated, (m) => warns.push(m));
+  assert.match(warns[0] ?? "", /reviews \(>100\)/);
+});
+
+test("summarisePR: warns when review threads are truncated", () => {
+  const truncated = {
+    ...sampleRawPR,
+    reviewThreads: {
+      ...sampleRawPR.reviewThreads,
+      pageInfo: { hasNextPage: true },
+    },
+  };
+  const warns: string[] = [];
+  summarisePR(truncated, (m) => warns.push(m));
+  assert.match(warns[0] ?? "", /review threads \(>100\)/);
+});
+
+test("summarisePR: warns when status-check contexts are truncated", () => {
+  // The status-check rollup has its own contexts connection; its
+  // pageInfo is nested two levels deep, which makes it the
+  // easiest one to forget when adding new fields. Pin it.
+  const rollup = sampleRawPR.commits.nodes[0]?.commit.statusCheckRollup;
+  if (!rollup) throw new Error("fixture missing rollup");
+  const truncated = {
+    ...sampleRawPR,
+    commits: {
+      nodes: [
+        {
+          commit: {
+            statusCheckRollup: {
+              ...rollup,
+              contexts: { ...rollup.contexts, pageInfo: { hasNextPage: true } },
+            },
+          },
+        },
+      ],
+    },
+  };
+  const warns: string[] = [];
+  summarisePR(truncated, (m) => warns.push(m));
+  assert.match(warns[0] ?? "", /status checks \(>100\)/);
+});
+
+test("summarisePR: collapses multiple truncations into a single warning line", () => {
+  // Issues with > 100 of multiple things are vanishingly rare,
+  // but a single line listing every truncated connection is
+  // easier to grep for in CI logs than five separate warnings.
+  const truncated = {
+    ...sampleRawPR,
+    labels: { ...sampleRawPR.labels, pageInfo: { hasNextPage: true } },
+    reviews: { ...sampleRawPR.reviews, pageInfo: { hasNextPage: true } },
+  };
+  const warns: string[] = [];
+  summarisePR(truncated, (m) => warns.push(m));
+  assert.equal(warns.length, 1);
+  assert.match(warns[0] ?? "", /labels \(>100\), reviews \(>100\)/);
+});

--- a/tests/unit/tools/pr/comment.test.ts
+++ b/tests/unit/tools/pr/comment.test.ts
@@ -1,0 +1,99 @@
+// tests/unit/tools/pr/comment.test.ts
+//
+// gh.pr_comment: pin both the issue-level path (no in_reply_to)
+// and the review-thread reply path (in_reply_to set). Different
+// mutations under the hood, identical output shape.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { registerPRCommentTool } from "../../../../src/tools/pr/comment.ts";
+import type { ToolEntry } from "../../../../src/registry.ts";
+import { stubGraphqlClient } from "./_fixtures.ts";
+
+function captureRegistration() {
+  let entry: ToolEntry | undefined;
+  const register = (name: string, e: ToolEntry) => {
+    if (name !== "gh.pr_comment") throw new Error(`unexpected: ${name}`);
+    entry = e;
+  };
+  return {
+    register,
+    get entry(): ToolEntry {
+      if (!entry) throw new Error("not registered");
+      return entry;
+    },
+  };
+}
+
+test("gh.pr_comment: without in_reply_to, looks up the PR and runs AddComment", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "pr/_pr-lookup": { repository: { pullRequest: { id: "PR_7" } } },
+    "pr/comment": (vars: Record<string, unknown>) => {
+      const input = vars.input as Record<string, unknown>;
+      assert.equal(input.subjectId, "PR_7");
+      assert.equal(input.body, "looks good");
+      return {
+        addComment: {
+          commentEdge: { node: { id: "C_1", url: "https://example/u" } },
+        },
+      };
+    },
+  });
+  const reg = captureRegistration();
+  registerPRCommentTool(reg.register, graphql);
+  const out = await reg.entry.handler({
+    repo: "owner/repo",
+    number: 7,
+    body: "looks good",
+  });
+  assert.deepEqual(out, { comment_id: "C_1", url: "https://example/u" });
+  assert.deepEqual(
+    calls.map((c) => c.queryName),
+    ["pr/_pr-lookup", "pr/comment"],
+  );
+});
+
+test("gh.pr_comment: with in_reply_to, skips the PR lookup and uses the reply mutation", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "pr/comment-reply": (vars: Record<string, unknown>) => {
+      const input = vars.input as Record<string, unknown>;
+      assert.equal(input.pullRequestReviewThreadId, "PRRT_thread");
+      assert.equal(input.body, "thread reply");
+      return {
+        addPullRequestReviewThreadReply: {
+          comment: { id: "RC_2", url: "https://example/u2" },
+        },
+      };
+    },
+  });
+  const reg = captureRegistration();
+  registerPRCommentTool(reg.register, graphql);
+  const out = await reg.entry.handler({
+    repo: "owner/repo",
+    number: 7,
+    body: "thread reply",
+    in_reply_to: "PRRT_thread",
+  });
+  assert.deepEqual(out, { comment_id: "RC_2", url: "https://example/u2" });
+  // No PR lookup needed when we have the thread ID.
+  assert.deepEqual(
+    calls.map((c) => c.queryName),
+    ["pr/comment-reply"],
+  );
+});
+
+test("gh.pr_comment: rejects empty body at the input boundary", async () => {
+  const { graphql } = stubGraphqlClient({
+    "pr/_pr-lookup": { repository: { pullRequest: { id: "PR_7" } } },
+    "pr/comment": () => {
+      throw new Error("must not run");
+    },
+  });
+  const reg = captureRegistration();
+  registerPRCommentTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", number: 7, body: "" }),
+    /gh\.pr_comment input/,
+  );
+});

--- a/tests/unit/tools/pr/comment.test.ts
+++ b/tests/unit/tools/pr/comment.test.ts
@@ -69,9 +69,11 @@ test("gh.pr_comment: with in_reply_to, skips the PR lookup and uses the reply mu
   });
   const reg = captureRegistration();
   registerPRCommentTool(reg.register, graphql);
+  // Thread-reply shape: in_reply_to + body only, no repo/number.
+  // The schema's oneOf disallows the four-field combo so callers
+  // can't accidentally mismatch the thread's parent PR with a
+  // wrong (repo, number) pair that would silently be ignored.
   const out = await reg.entry.handler({
-    repo: "owner/repo",
-    number: 7,
     body: "thread reply",
     in_reply_to: "PRRT_thread",
   });
@@ -80,6 +82,39 @@ test("gh.pr_comment: with in_reply_to, skips the PR lookup and uses the reply mu
   assert.deepEqual(
     calls.map((c) => c.queryName),
     ["pr/comment-reply"],
+  );
+});
+
+test("gh.pr_comment: rejects mixing in_reply_to with repo/number", async () => {
+  const { graphql } = stubGraphqlClient({
+    "pr/comment-reply": () => {
+      throw new Error("must not run when input shape is invalid");
+    },
+  });
+  const reg = captureRegistration();
+  registerPRCommentTool(reg.register, graphql);
+  // Schema's oneOf must reject this combo. The previous shape
+  // happily ignored repo + number on the thread-reply path,
+  // which masked thread-ID-derivation bugs in the caller.
+  await assert.rejects(
+    reg.entry.handler({
+      repo: "owner/repo",
+      number: 7,
+      body: "x",
+      in_reply_to: "PRRT_thread",
+    }),
+    /gh\.pr_comment input/,
+  );
+});
+
+test("gh.pr_comment: rejects bare body without repo/number or in_reply_to", async () => {
+  const { graphql } = stubGraphqlClient({});
+  const reg = captureRegistration();
+  registerPRCommentTool(reg.register, graphql);
+  // body alone matches neither oneOf branch — schema rejects.
+  await assert.rejects(
+    reg.entry.handler({ body: "x" }),
+    /gh\.pr_comment input/,
   );
 });
 

--- a/tests/unit/tools/pr/create.test.ts
+++ b/tests/unit/tools/pr/create.test.ts
@@ -1,0 +1,114 @@
+// tests/unit/tools/pr/create.test.ts
+//
+// gh.pr_create: pin the repo-id lookup → mutation flow, the
+// optional body/draft pass-through, and the input-validation
+// boundary.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { registerPRCreateTool } from "../../../../src/tools/pr/create.ts";
+import type { ToolEntry } from "../../../../src/registry.ts";
+import { sampleRawPR, stubGraphqlClient } from "./_fixtures.ts";
+
+function captureRegistration() {
+  let entry: ToolEntry | undefined;
+  const register = (name: string, e: ToolEntry) => {
+    if (name !== "gh.pr_create") throw new Error(`unexpected: ${name}`);
+    entry = e;
+  };
+  return {
+    register,
+    get entry(): ToolEntry {
+      if (!entry) throw new Error("not registered");
+      return entry;
+    },
+  };
+}
+
+test("gh.pr_create: looks up repo id, then runs CreatePullRequest", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "pr/_repo-id": { repository: { id: "R_kwDO_repo" } },
+    "pr/create": (vars: Record<string, unknown>) => {
+      const input = vars.input as Record<string, unknown>;
+      assert.equal(input.repositoryId, "R_kwDO_repo");
+      assert.equal(input.baseRefName, "main");
+      assert.equal(input.headRefName, "feat/x");
+      assert.equal(input.title, "Add x");
+      assert.equal(input.body, "Body of x");
+      assert.equal(input.draft, true);
+      return { createPullRequest: { pullRequest: sampleRawPR } };
+    },
+  });
+  const reg = captureRegistration();
+  registerPRCreateTool(reg.register, graphql);
+  const out = (await reg.entry.handler({
+    repo: "owner/repo",
+    base: "main",
+    head: "feat/x",
+    title: "Add x",
+    body: "Body of x",
+    draft: true,
+  })) as { number: number };
+  assert.equal(out.number, 7);
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0]?.queryName, "pr/_repo-id");
+});
+
+test("gh.pr_create: omits body and draft when not supplied", async () => {
+  const { graphql } = stubGraphqlClient({
+    "pr/_repo-id": { repository: { id: "R_kwDO_repo" } },
+    "pr/create": (vars: Record<string, unknown>) => {
+      const input = vars.input as Record<string, unknown>;
+      assert.equal("body" in input, false);
+      assert.equal("draft" in input, false);
+      return { createPullRequest: { pullRequest: sampleRawPR } };
+    },
+  });
+  const reg = captureRegistration();
+  registerPRCreateTool(reg.register, graphql);
+  await reg.entry.handler({
+    repo: "owner/repo",
+    base: "main",
+    head: "feat/x",
+    title: "Minimal",
+  });
+});
+
+test("gh.pr_create: throws when the repository is not found", async () => {
+  const { graphql } = stubGraphqlClient({
+    "pr/_repo-id": { repository: null },
+    "pr/create": () => {
+      throw new Error("must not run");
+    },
+  });
+  const reg = captureRegistration();
+  registerPRCreateTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      repo: "owner/repo",
+      base: "main",
+      head: "feat/x",
+      title: "x",
+    }),
+    /gh\.pr_create: repository 'owner\/repo' not found/,
+  );
+});
+
+test("gh.pr_create: rejects empty title at the input boundary", async () => {
+  const { graphql } = stubGraphqlClient({
+    "pr/_repo-id": { repository: { id: "R_kwDO_repo" } },
+    "pr/create": () => ({ createPullRequest: { pullRequest: sampleRawPR } }),
+  });
+  const reg = captureRegistration();
+  registerPRCreateTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      repo: "owner/repo",
+      base: "main",
+      head: "feat/x",
+      title: "",
+    }),
+    /gh\.pr_create input/,
+  );
+});

--- a/tests/unit/tools/pr/edit.test.ts
+++ b/tests/unit/tools/pr/edit.test.ts
@@ -1,0 +1,147 @@
+// tests/unit/tools/pr/edit.test.ts
+//
+// gh.pr_edit: pin the field-edit pass-through plus the
+// draft-toggle two-mutation flow (the underlying GraphQL
+// surfaces draft state via two distinct mutations rather than
+// UpdatePullRequestInput).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { registerPREditTool } from "../../../../src/tools/pr/edit.ts";
+import type { ToolEntry } from "../../../../src/registry.ts";
+import { sampleRawPR, stubGraphqlClient } from "./_fixtures.ts";
+
+function captureRegistration() {
+  let entry: ToolEntry | undefined;
+  const register = (name: string, e: ToolEntry) => {
+    if (name !== "gh.pr_edit") throw new Error(`unexpected: ${name}`);
+    entry = e;
+  };
+  return {
+    register,
+    get entry(): ToolEntry {
+      if (!entry) throw new Error("not registered");
+      return entry;
+    },
+  };
+}
+
+test("gh.pr_edit: title/body/base-only edits run a single UpdatePullRequest", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "pr/_pr-lookup": { repository: { pullRequest: { id: "PR_target" } } },
+    "pr/edit": (vars: Record<string, unknown>) => {
+      const input = vars.input as Record<string, unknown>;
+      assert.equal(input.pullRequestId, "PR_target");
+      assert.equal(input.title, "New title");
+      assert.equal(input.body, "New body");
+      assert.equal(input.baseRefName, "develop");
+      assert.equal("draft" in input, false);
+      return { updatePullRequest: { pullRequest: sampleRawPR } };
+    },
+  });
+  const reg = captureRegistration();
+  registerPREditTool(reg.register, graphql);
+  await reg.entry.handler({
+    repo: "owner/repo",
+    number: 7,
+    title: "New title",
+    body: "New body",
+    base: "develop",
+  });
+  // Lookup + edit; no draft-toggle.
+  assert.equal(calls.length, 2);
+  assert.equal(calls[1]?.queryName, "pr/edit");
+});
+
+test("gh.pr_edit: draft: true routes through convertPullRequestToDraft", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "pr/_pr-lookup": { repository: { pullRequest: { id: "PR_target" } } },
+    "pr/_to-draft": (vars: Record<string, unknown>) => {
+      const input = vars.input as Record<string, unknown>;
+      assert.equal(input.pullRequestId, "PR_target");
+      return {
+        convertPullRequestToDraft: {
+          pullRequest: { ...sampleRawPR, isDraft: true },
+        },
+      };
+    },
+  });
+  const reg = captureRegistration();
+  registerPREditTool(reg.register, graphql);
+  const out = (await reg.entry.handler({
+    repo: "owner/repo",
+    number: 7,
+    draft: true,
+  })) as { draft: boolean };
+  assert.equal(out.draft, true);
+  // Draft-only edit: lookup + toggle, no pr/edit call.
+  assert.deepEqual(
+    calls.map((c) => c.queryName),
+    ["pr/_pr-lookup", "pr/_to-draft"],
+  );
+});
+
+test("gh.pr_edit: draft: false routes through markPullRequestReadyForReview", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "pr/_pr-lookup": { repository: { pullRequest: { id: "PR_target" } } },
+    "pr/_ready-for-review": {
+      markPullRequestReadyForReview: {
+        pullRequest: { ...sampleRawPR, isDraft: false },
+      },
+    },
+  });
+  const reg = captureRegistration();
+  registerPREditTool(reg.register, graphql);
+  const out = (await reg.entry.handler({
+    repo: "owner/repo",
+    number: 7,
+    draft: false,
+  })) as { draft: boolean };
+  assert.equal(out.draft, false);
+  assert.equal(calls.length, 2);
+  assert.equal(calls[1]?.queryName, "pr/_ready-for-review");
+});
+
+test("gh.pr_edit: title + draft true runs both edit AND draft-toggle", async () => {
+  // The composite case: caller wants to edit the title AND mark
+  // as draft. We run pr/edit first (so the title change persists
+  // even if the draft-toggle later fails), then the toggle. The
+  // returned PR is the one from the toggle response — its title
+  // already reflects the prior edit.
+  const { graphql, calls } = stubGraphqlClient({
+    "pr/_pr-lookup": { repository: { pullRequest: { id: "PR_target" } } },
+    "pr/edit": { updatePullRequest: { pullRequest: sampleRawPR } },
+    "pr/_to-draft": {
+      convertPullRequestToDraft: {
+        pullRequest: { ...sampleRawPR, title: "New title", isDraft: true },
+      },
+    },
+  });
+  const reg = captureRegistration();
+  registerPREditTool(reg.register, graphql);
+  const out = (await reg.entry.handler({
+    repo: "owner/repo",
+    number: 7,
+    title: "New title",
+    draft: true,
+  })) as { title: string; draft: boolean };
+  assert.equal(out.title, "New title");
+  assert.equal(out.draft, true);
+  assert.deepEqual(
+    calls.map((c) => c.queryName),
+    ["pr/_pr-lookup", "pr/edit", "pr/_to-draft"],
+  );
+});
+
+test("gh.pr_edit: throws when the PR cannot be found", async () => {
+  const { graphql } = stubGraphqlClient({
+    "pr/_pr-lookup": { repository: { pullRequest: null } },
+  });
+  const reg = captureRegistration();
+  registerPREditTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", number: 99, title: "x" }),
+    /PR owner\/repo#99 not found/,
+  );
+});

--- a/tests/unit/tools/pr/list.test.ts
+++ b/tests/unit/tools/pr/list.test.ts
@@ -113,6 +113,24 @@ test("gh.pr_list: strips `owner:` prefix from head before forwarding to GraphQL"
   assert.equal(calls[0]?.vars.headRefName, "feat/x");
 });
 
+test("gh.pr_list: rejects head that strips down to an empty branch name", async () => {
+  // Inputs like `head: "owner:"` or `head: ":branch"` would
+  // either become `""` (the first case) or have an empty owner
+  // and a real branch (the second). Both are user errors that
+  // would silently send nothing useful to GraphQL — fail loudly.
+  const { graphql } = stubGraphqlClient({
+    "pr/list": () => {
+      throw new Error("must not run when head is malformed");
+    },
+  });
+  const reg = captureRegistration();
+  registerPRListTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", head: "owner:" }),
+    /head must contain a branch name/,
+  );
+});
+
 test("gh.pr_list: author filter is post-filtered client-side", async () => {
   const others = {
     ...sampleRawPR,

--- a/tests/unit/tools/pr/list.test.ts
+++ b/tests/unit/tools/pr/list.test.ts
@@ -148,6 +148,23 @@ test("gh.pr_list: rejects head with empty owner (`:branch`)", async () => {
   );
 });
 
+test("gh.pr_list: rejects head with more than one colon (`a:b:c`)", async () => {
+  // Multi-colon shapes don't match `owner:branch`; the strip
+  // would forward "b:c" as the branch filter, which GraphQL
+  // would silently fail to match. Reject upfront.
+  const { graphql } = stubGraphqlClient({
+    "pr/list": () => {
+      throw new Error("must not run when head is malformed");
+    },
+  });
+  const reg = captureRegistration();
+  registerPRListTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", head: "a:b:c" }),
+    /head 'a:b:c' is malformed/,
+  );
+});
+
 test("gh.pr_list: author filter is post-filtered client-side", async () => {
   const others = {
     ...sampleRawPR,

--- a/tests/unit/tools/pr/list.test.ts
+++ b/tests/unit/tools/pr/list.test.ts
@@ -89,6 +89,30 @@ test("gh.pr_list: head + base filters pass through to GraphQL vars", async () =>
   assert.equal(calls[0]?.vars.baseRefName, "main");
 });
 
+test("gh.pr_list: strips `owner:` prefix from head before forwarding to GraphQL", async () => {
+  // `gh pr list --head owner:branch` is the canonical fork-PR
+  // shape, but GraphQL's headRefName filter is the bare branch
+  // name. Without stripping, fork PRs would silently match
+  // nothing.
+  const { graphql, calls } = stubGraphqlClient({
+    "pr/list": {
+      repository: {
+        pullRequests: {
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: [],
+        },
+      },
+    },
+  });
+  const reg = captureRegistration();
+  registerPRListTool(reg.register, graphql);
+  await reg.entry.handler({
+    repo: "owner/repo",
+    head: "fork-owner:feat/x",
+  });
+  assert.equal(calls[0]?.vars.headRefName, "feat/x");
+});
+
 test("gh.pr_list: author filter is post-filtered client-side", async () => {
   const others = {
     ...sampleRawPR,

--- a/tests/unit/tools/pr/list.test.ts
+++ b/tests/unit/tools/pr/list.test.ts
@@ -113,11 +113,10 @@ test("gh.pr_list: strips `owner:` prefix from head before forwarding to GraphQL"
   assert.equal(calls[0]?.vars.headRefName, "feat/x");
 });
 
-test("gh.pr_list: rejects head that strips down to an empty branch name", async () => {
-  // Inputs like `head: "owner:"` or `head: ":branch"` would
-  // either become `""` (the first case) or have an empty owner
-  // and a real branch (the second). Both are user errors that
-  // would silently send nothing useful to GraphQL — fail loudly.
+test("gh.pr_list: rejects head with empty branch (`owner:`)", async () => {
+  // A trailing colon means an empty branch name. Without explicit
+  // rejection the strip would leave \`""\` and silently match
+  // nothing on GraphQL.
   const { graphql } = stubGraphqlClient({
     "pr/list": () => {
       throw new Error("must not run when head is malformed");
@@ -127,7 +126,25 @@ test("gh.pr_list: rejects head that strips down to an empty branch name", async 
   registerPRListTool(reg.register, graphql);
   await assert.rejects(
     reg.entry.handler({ repo: "owner/repo", head: "owner:" }),
-    /head must contain a branch name/,
+    /head 'owner:' is malformed/,
+  );
+});
+
+test("gh.pr_list: rejects head with empty owner (`:branch`)", async () => {
+  // Symmetric case: a leading colon means an empty owner. The
+  // strip would happily return "branch" as if `:branch` were
+  // valid, silently broadening the filter on a typo. Reject
+  // explicitly so the caller sees the malformed input.
+  const { graphql } = stubGraphqlClient({
+    "pr/list": () => {
+      throw new Error("must not run when head is malformed");
+    },
+  });
+  const reg = captureRegistration();
+  registerPRListTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", head: ":branch" }),
+    /head ':branch' is malformed/,
   );
 });
 

--- a/tests/unit/tools/pr/list.test.ts
+++ b/tests/unit/tools/pr/list.test.ts
@@ -1,0 +1,128 @@
+// tests/unit/tools/pr/list.test.ts
+//
+// gh.pr_list: pin the default-state filter, the head/base/author
+// filters, and the cross-repo author client-side post-filter.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { registerPRListTool } from "../../../../src/tools/pr/list.ts";
+import type { ToolEntry } from "../../../../src/registry.ts";
+import { sampleRawPR, stubGraphqlClient } from "./_fixtures.ts";
+
+function captureRegistration() {
+  let entry: ToolEntry | undefined;
+  const register = (name: string, e: ToolEntry) => {
+    if (name !== "gh.pr_list") throw new Error(`unexpected: ${name}`);
+    entry = e;
+  };
+  return {
+    register,
+    get entry(): ToolEntry {
+      if (!entry) throw new Error("not registered");
+      return entry;
+    },
+  };
+}
+
+test("gh.pr_list: defaults to OPEN, returns one page with pageInfo", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "pr/list": {
+      repository: {
+        pullRequests: {
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: [sampleRawPR],
+        },
+      },
+    },
+  });
+  const reg = captureRegistration();
+  registerPRListTool(reg.register, graphql);
+  const out = (await reg.entry.handler({ repo: "owner/repo" })) as {
+    items: Array<{ number: number }>;
+    hasNextPage: boolean;
+    endCursor: string | null;
+  };
+  assert.equal(out.items.length, 1);
+  assert.equal(out.items[0]?.number, 7);
+  assert.deepEqual(calls[0]?.vars.states, ["OPEN"]);
+  assert.equal(calls[0]?.vars.headRefName, null);
+  assert.equal(calls[0]?.vars.baseRefName, null);
+});
+
+test("gh.pr_list: state=ALL passes a null states filter to GraphQL", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "pr/list": {
+      repository: {
+        pullRequests: {
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: [],
+        },
+      },
+    },
+  });
+  const reg = captureRegistration();
+  registerPRListTool(reg.register, graphql);
+  await reg.entry.handler({ repo: "owner/repo", state: "ALL" });
+  assert.equal(calls[0]?.vars.states, null);
+});
+
+test("gh.pr_list: head + base filters pass through to GraphQL vars", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "pr/list": {
+      repository: {
+        pullRequests: {
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: [],
+        },
+      },
+    },
+  });
+  const reg = captureRegistration();
+  registerPRListTool(reg.register, graphql);
+  await reg.entry.handler({
+    repo: "owner/repo",
+    head: "feat/x",
+    base: "main",
+  });
+  assert.equal(calls[0]?.vars.headRefName, "feat/x");
+  assert.equal(calls[0]?.vars.baseRefName, "main");
+});
+
+test("gh.pr_list: author filter is post-filtered client-side", async () => {
+  const others = {
+    ...sampleRawPR,
+    number: 8,
+    author: { login: "carol" },
+  };
+  const { graphql } = stubGraphqlClient({
+    "pr/list": {
+      repository: {
+        pullRequests: {
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: [sampleRawPR, others],
+        },
+      },
+    },
+  });
+  const reg = captureRegistration();
+  registerPRListTool(reg.register, graphql);
+  const out = (await reg.entry.handler({
+    repo: "owner/repo",
+    author: "bob",
+  })) as { items: Array<{ number: number; author: string | null }> };
+  assert.equal(out.items.length, 1);
+  assert.equal(out.items[0]?.number, 7);
+});
+
+test("gh.pr_list: throws when the repository is not found", async () => {
+  const { graphql } = stubGraphqlClient({
+    "pr/list": { repository: null },
+  });
+  const reg = captureRegistration();
+  registerPRListTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo" }),
+    /repository 'owner\/repo' not found/,
+  );
+});

--- a/tests/unit/tools/pr/merge.test.ts
+++ b/tests/unit/tools/pr/merge.test.ts
@@ -1,0 +1,135 @@
+// tests/unit/tools/pr/merge.test.ts
+//
+// gh.pr_merge: pin the method mapping (merge|squash|rebase →
+// MERGE|SQUASH|REBASE), the commit_title/commit_message
+// pass-through (only for merge / squash, not rebase), and the
+// happy-path output shape.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { registerPRMergeTool } from "../../../../src/tools/pr/merge.ts";
+import type { ToolEntry } from "../../../../src/registry.ts";
+import { stubGraphqlClient } from "./_fixtures.ts";
+
+function captureRegistration() {
+  let entry: ToolEntry | undefined;
+  const register = (name: string, e: ToolEntry) => {
+    if (name !== "gh.pr_merge") throw new Error(`unexpected: ${name}`);
+    entry = e;
+  };
+  return {
+    register,
+    get entry(): ToolEntry {
+      if (!entry) throw new Error("not registered");
+      return entry;
+    },
+  };
+}
+
+const sampleMerged = {
+  number: 7,
+  url: "https://github.com/owner/repo/pull/7",
+  merged: true,
+  mergeCommit: { oid: "deadbeef" },
+};
+
+test("gh.pr_merge: method=merge maps to MERGE and passes commit_title/message", async () => {
+  const { graphql } = stubGraphqlClient({
+    "pr/_pr-lookup": { repository: { pullRequest: { id: "PR_7" } } },
+    "pr/merge": (vars: Record<string, unknown>) => {
+      const input = vars.input as Record<string, unknown>;
+      assert.equal(input.pullRequestId, "PR_7");
+      assert.equal(input.mergeMethod, "MERGE");
+      assert.equal(input.commitHeadline, "feat: subject");
+      assert.equal(input.commitBody, "Body of the commit");
+      return { mergePullRequest: { pullRequest: sampleMerged } };
+    },
+  });
+  const reg = captureRegistration();
+  registerPRMergeTool(reg.register, graphql);
+  const out = await reg.entry.handler({
+    repo: "owner/repo",
+    number: 7,
+    method: "merge",
+    commit_title: "feat: subject",
+    commit_message: "Body of the commit",
+  });
+  assert.deepEqual(out, {
+    merged: true,
+    sha: "deadbeef",
+    url: "https://github.com/owner/repo/pull/7",
+    number: 7,
+  });
+});
+
+test("gh.pr_merge: method=squash maps to SQUASH", async () => {
+  const { graphql } = stubGraphqlClient({
+    "pr/_pr-lookup": { repository: { pullRequest: { id: "PR_7" } } },
+    "pr/merge": (vars: Record<string, unknown>) => {
+      assert.equal(
+        (vars.input as Record<string, unknown>).mergeMethod,
+        "SQUASH",
+      );
+      return { mergePullRequest: { pullRequest: sampleMerged } };
+    },
+  });
+  const reg = captureRegistration();
+  registerPRMergeTool(reg.register, graphql);
+  await reg.entry.handler({
+    repo: "owner/repo",
+    number: 7,
+    method: "squash",
+  });
+});
+
+test("gh.pr_merge: method=rebase silently drops commit_title/commit_message", async () => {
+  // GitHub rejects MergePullRequest with REBASE + commitHeadline.
+  // The tool spec lets the caller pass them anyway (matching `gh
+  // pr merge`'s ergonomics) but we don't forward them — the
+  // rebased commit subjects come from the source branch, not from
+  // a merge-commit override that doesn't exist.
+  const { graphql } = stubGraphqlClient({
+    "pr/_pr-lookup": { repository: { pullRequest: { id: "PR_7" } } },
+    "pr/merge": (vars: Record<string, unknown>) => {
+      const input = vars.input as Record<string, unknown>;
+      assert.equal(input.mergeMethod, "REBASE");
+      assert.equal("commitHeadline" in input, false);
+      assert.equal("commitBody" in input, false);
+      return {
+        mergePullRequest: {
+          pullRequest: { ...sampleMerged, mergeCommit: null },
+        },
+      };
+    },
+  });
+  const reg = captureRegistration();
+  registerPRMergeTool(reg.register, graphql);
+  const out = (await reg.entry.handler({
+    repo: "owner/repo",
+    number: 7,
+    method: "rebase",
+    commit_title: "ignored on rebase",
+    commit_message: "also ignored",
+  })) as { sha: string | null };
+  assert.equal(out.sha, null);
+});
+
+test("gh.pr_merge: rejects unknown method at the input boundary", async () => {
+  const { graphql } = stubGraphqlClient({
+    "pr/_pr-lookup": { repository: { pullRequest: { id: "PR_7" } } },
+    "pr/merge": () => {
+      throw new Error("must not run");
+    },
+  });
+  const reg = captureRegistration();
+  registerPRMergeTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      repo: "owner/repo",
+      number: 7,
+      method: "auto",
+    }),
+    /gh\.pr_merge input/,
+  );
+});

--- a/tests/unit/tools/pr/view.test.ts
+++ b/tests/unit/tools/pr/view.test.ts
@@ -1,0 +1,155 @@
+// tests/unit/tools/pr/view.test.ts
+//
+// gh.pr_view: pin the canonical PRSummary shape (heavier than
+// IssueSummary because it rolls in reviews + review-comment count
+// + status-check rollup) plus the repo-vs-PR error distinction.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { registerPRViewTool } from "../../../../src/tools/pr/view.ts";
+import type { ToolEntry } from "../../../../src/registry.ts";
+import { sampleRawPR, stubGraphqlClient } from "./_fixtures.ts";
+
+function captureRegistration() {
+  let entry: ToolEntry | undefined;
+  const register = (name: string, e: ToolEntry) => {
+    if (name !== "gh.pr_view") throw new Error(`unexpected: ${name}`);
+    entry = e;
+  };
+  return {
+    register,
+    get entry(): ToolEntry {
+      if (!entry) throw new Error("not registered");
+      return entry;
+    },
+  };
+}
+
+test("gh.pr_view: maps a full GraphQL response onto the canonical PRSummary", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "pr/view": { repository: { pullRequest: sampleRawPR } },
+  });
+  const reg = captureRegistration();
+  registerPRViewTool(reg.register, graphql);
+  const out = (await reg.entry.handler({ repo: "owner/repo", number: 7 })) as {
+    number: number;
+    base: string;
+    head: string;
+    review_comments_count: number;
+    status_checks_state: string | null;
+    status_checks: Array<{ context: string; state: string }>;
+    reviews: Array<{ author: string | null; state: string }>;
+  };
+  assert.equal(out.number, 7);
+  assert.equal(out.base, "main");
+  assert.equal(out.head, "feat/x");
+  // 3 + 0 = 3 review-comments across two threads.
+  assert.equal(out.review_comments_count, 3);
+  assert.equal(out.status_checks_state, "SUCCESS");
+  assert.deepEqual(
+    out.status_checks.map((c) => c.context),
+    ["ci/build", "ci/legacy"],
+  );
+  assert.deepEqual(out.reviews, [{ author: "carol", state: "APPROVED" }]);
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0]?.vars, {
+    owner: "owner",
+    name: "repo",
+    number: 7,
+  });
+});
+
+test("gh.pr_view: distinguishes repo-not-found from PR-not-found", async () => {
+  const { graphql } = stubGraphqlClient({
+    "pr/view": { repository: null },
+  });
+  const reg = captureRegistration();
+  registerPRViewTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", number: 7 }),
+    /repository 'owner\/repo' not found or token lacks read access/,
+  );
+});
+
+test("gh.pr_view: throws PR-not-found when repo exists but PR doesn't", async () => {
+  const { graphql } = stubGraphqlClient({
+    "pr/view": { repository: { pullRequest: null } },
+  });
+  const reg = captureRegistration();
+  registerPRViewTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", number: 99 }),
+    /PR owner\/repo#99 not found/,
+  );
+});
+
+test("gh.pr_view: maps CheckRun + StatusContext onto the unified status_checks shape", async () => {
+  // CheckRun.conclusion="FAILURE" → state: "FAILURE"; an
+  // in-progress CheckRun with null conclusion + status="QUEUED"
+  // maps to "PENDING" so consumers don't have to branch on
+  // __typename + status independently.
+  const customPR = {
+    ...sampleRawPR,
+    commits: {
+      nodes: [
+        {
+          commit: {
+            statusCheckRollup: {
+              state: "PENDING" as const,
+              contexts: {
+                pageInfo: { hasNextPage: false },
+                nodes: [
+                  {
+                    __typename: "CheckRun",
+                    name: "ci/lint",
+                    conclusion: "FAILURE" as const,
+                    status: "COMPLETED" as const,
+                  },
+                  {
+                    __typename: "CheckRun",
+                    name: "ci/test",
+                    conclusion: null,
+                    status: "QUEUED" as const,
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ],
+    },
+  };
+  const { graphql } = stubGraphqlClient({
+    "pr/view": { repository: { pullRequest: customPR } },
+  });
+  const reg = captureRegistration();
+  registerPRViewTool(reg.register, graphql);
+  const out = (await reg.entry.handler({ repo: "owner/repo", number: 7 })) as {
+    status_checks: Array<{ context: string; state: string }>;
+  };
+  assert.deepEqual(out.status_checks, [
+    { context: "ci/lint", state: "FAILURE" },
+    { context: "ci/test", state: "PENDING" },
+  ]);
+});
+
+test("gh.pr_view: status_checks_state is null when there's no rollup", async () => {
+  // Brand-new PRs without commits, or PRs against a base with no
+  // CI configured, return statusCheckRollup: null.
+  const customPR = {
+    ...sampleRawPR,
+    commits: { nodes: [{ commit: { statusCheckRollup: null } }] },
+  };
+  const { graphql } = stubGraphqlClient({
+    "pr/view": { repository: { pullRequest: customPR } },
+  });
+  const reg = captureRegistration();
+  registerPRViewTool(reg.register, graphql);
+  const out = (await reg.entry.handler({ repo: "owner/repo", number: 7 })) as {
+    status_checks_state: string | null;
+    status_checks: Array<unknown>;
+  };
+  assert.equal(out.status_checks_state, null);
+  assert.deepEqual(out.status_checks, []);
+});


### PR DESCRIPTION
## Summary

Wraps GitHub's pull-request CRUD as 6 MCP tools. Reviewer-request via the GraphQL `requestReviews(botIds)` path stays out of scope here — it lands in MCP-6 on its own — so this PR is the foundational PR surface that MCP-6 will then extend.

| Tool | Input | Output |
|---|---|---|
| `gh.pr_create` | `{repo, base, head, title, body?, draft?}` | `PRSummary` |
| `gh.pr_view` | `{repo, number}` | `PRSummary` |
| `gh.pr_list` | `{repo, state?, head?, base?, author?, perPage?, after?}` | `{items[], hasNextPage, endCursor}` |
| `gh.pr_edit` | `{repo, number, title?, body?, base?, draft?}` | `PRSummary` |
| `gh.pr_comment` | **mutually exclusive shapes — see below** | `{comment_id, url}` |
| `gh.pr_merge` | `{repo, number, method: merge\|squash\|rebase, commit_title?, commit_message?}` | `{merged, sha, url, number}` |

### `gh.pr_comment` two-shape input

The schema enforces a `oneOf` so callers can't accidentally mix the two paths:

- **Issue-level PR comment:** `{repo, number, body}` — `in_reply_to` is rejected here.
- **Review-thread reply:** `{in_reply_to, body}` — `repo` and `number` are rejected here (the thread ID already disambiguates, and accepting a non-matching pair would silently land the comment on the wrong PR).

### Design notes worth flagging

- **`PRSummary` is heavier than `IssueSummary`.** It rolls in `reviews` (state + author per review), `review_comments_count` (sum across review threads), and `status_checks_state` + `status_checks` (CheckRun + StatusContext flattened to a unified `{context, state}` pair via `mapCheckRunConclusion`). Truncation on labels / assignees / reviews / review-threads / status-contexts surfaces as a stderr warn, same pattern as the issue domain.
- **`gh.pr_edit` draft-toggle is a two-mutation flow.** GraphQL exposes draft state via `convertPullRequestToDraft` / `markPullRequestReadyForReview`, not via `UpdatePullRequestInput`. When the caller passes both an edit and a draft toggle, the edit runs first and the toggle runs second so the returned PR carries the final state.
- **`gh.pr_list` head filter strips `owner:` prefix.** GraphQL's `headRefName` is the bare branch name; the gh-CLI shape (`--head owner:branch`) is supported via a small strip helper that rejects the malformed `:branch` / `owner:` shapes loudly.
- **`gh.pr_merge` drops `commit_title` / `commit_message` on rebase.** The underlying mutation rejects them with `REBASE`; we silently drop rather than relay GitHub's error so the caller's `gh pr merge`-style ergonomics keep working.
- **Branch-protection failures, mergeability blocks, and conflicts** come back from GitHub as GraphQL errors, which `client.ts`'s mapper turns into structured `GraphqlError` instances. No special handling needed at the tool layer.

### Files

- `src/tools/pr/` — `_shared.ts` (parsers + `summarisePR` + canonical schema), 6 tool files, `index.ts` aggregator.
- `src/graphql/queries/pr/` — 11 `.graphql` files (3 lookup/prep + 6 main ops + 2 draft-toggle siblings). The canonical PR-payload selection is duplicated across mutation responses because the current `loadQuery` contract is one operation per file (cross-file fragments aren't supported).
- `src/server.ts` — wires `registerPRTools()` alongside the existing issue + auth registrations.
- Smoke test now asserts 14 tools (test_connection + 7 issue + 6 PR).

## Test plan

- [x] `npm run lint` (tsc --noEmit on src + tests configs) clean
- [x] `npm run build` produces `dist/graphql/queries/pr/**.graphql` alongside the compiled `.js` tree
- [x] `npm test` — 142/142 pass (after multiple Copilot review rounds, including new tests for the oneOf input enforcement on `pr_comment`, `head`-prefix strip + leading/trailing colon rejection on `pr_list`, and truncation-warn paths on `summarisePR`)
- [x] `node tests/smoke/server-lists-tools.mjs` — 14 tools listed
- [ ] Live integration probe (real PR ops against a PAT) lands in MCP-12

## Stack

After **MCP-1/2/3 (merged) → MCP-4 (#21, merged)**. Sibling PRs that don't depend on this one: MCP-7 (#23, label ops), MCP-9 (workflow ops), MCP-10 (Project v2). MCP-6's `requestReviews(botIds)` work is the direct dependent.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)