### PR TITLE
feat: gh.pr_request_reviews via GraphQL botIds (MCP-6)

### DIFF
--- a/src/graphql/queries/pr/_bot-id.graphql
+++ b/src/graphql/queries/pr/_bot-id.graphql
@@ -1,3 +1,13 @@
+# NOTE on `loginNames`: despite the plural field name, GitHub's
+# GraphQL schema declares this argument as `String` (single value),
+# not `[String]`. Verified by introspection on Repository.fields:
+#
+#   {"name":"loginNames","type":{"kind":"SCALAR","name":"String","ofType":null}}
+#
+# Passing a list literal (e.g. `loginNames: ["x"]`) returns
+# "argumentLiteralsIncompatible: Expected type 'String'". So we
+# call once per bot login from the handler rather than batching.
+
 query PRBotId($owner: String!, $name: String!, $login: String!) {
   repository(owner: $owner, name: $name) {
     suggestedActors(capabilities: [CAN_BE_ASSIGNED], first: 5, loginNames: $login) {

--- a/src/graphql/queries/pr/_bot-id.graphql
+++ b/src/graphql/queries/pr/_bot-id.graphql
@@ -1,0 +1,16 @@
+query PRBotId($owner: String!, $name: String!, $login: String!) {
+  repository(owner: $owner, name: $name) {
+    suggestedActors(capabilities: [CAN_BE_ASSIGNED], first: 5, loginNames: $login) {
+      nodes {
+        __typename
+        ... on Bot {
+          id
+          login
+        }
+        ... on User {
+          login
+        }
+      }
+    }
+  }
+}

--- a/src/graphql/queries/pr/_team-id.graphql
+++ b/src/graphql/queries/pr/_team-id.graphql
@@ -1,0 +1,7 @@
+query PRTeamId($org: String!, $slug: String!) {
+  organization(login: $org) {
+    team(slug: $slug) {
+      id
+    }
+  }
+}

--- a/src/graphql/queries/pr/_user-id.graphql
+++ b/src/graphql/queries/pr/_user-id.graphql
@@ -1,0 +1,6 @@
+query PRUserId($login: String!) {
+  user(login: $login) {
+    id
+    __typename
+  }
+}

--- a/src/graphql/queries/pr/request_reviews.graphql
+++ b/src/graphql/queries/pr/request_reviews.graphql
@@ -1,0 +1,28 @@
+mutation PRRequestReviews($input: RequestReviewsInput!) {
+  requestReviews(input: $input) {
+    pullRequest {
+      reviewRequests(first: 100) {
+        pageInfo {
+          hasNextPage
+        }
+        nodes {
+          requestedReviewer {
+            __typename
+            ... on User {
+              login
+            }
+            ... on Bot {
+              login
+            }
+            ... on Team {
+              slug
+            }
+            ... on Mannequin {
+              login
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/tools/pr/index.ts
+++ b/src/tools/pr/index.ts
@@ -1,6 +1,6 @@
 // src/tools/pr/index.ts
 //
-// Aggregator for the six gh.pr_* tools. Imported by
+// Aggregator for the seven gh.pr_* tools. Imported by
 // `src/server.ts`'s startServer() and called once at boot to
 // register every PR-domain tool against the registry.
 
@@ -11,6 +11,7 @@ import { registerPRCreateTool } from "./create.js";
 import { registerPREditTool } from "./edit.js";
 import { registerPRListTool } from "./list.js";
 import { registerPRMergeTool } from "./merge.js";
+import { registerPRRequestReviewsTool } from "./request_reviews.js";
 import { registerPRViewTool } from "./view.js";
 
 type RegisterToolFn = (name: string, entry: ToolEntry) => void;
@@ -25,4 +26,5 @@ export function registerPRTools(
   registerPREditTool(register, graphql);
   registerPRCommentTool(register, graphql);
   registerPRMergeTool(register, graphql);
+  registerPRRequestReviewsTool(register, graphql);
 }

--- a/src/tools/pr/request_reviews.ts
+++ b/src/tools/pr/request_reviews.ts
@@ -55,11 +55,17 @@ const inputSchema = {
     },
     team_slugs: {
       type: "array",
-      items: { type: "string", minLength: 1 },
+      // Disallow forward slashes at the schema boundary so an
+      // `org/slug` form (a common mis-passing) fails fast with
+      // a schema-validation error rather than producing a
+      // confusing "team 'owner/org/slug' not found" later. The
+      // org is derived from the repo's owner; slugs are bare.
+      items: { type: "string", minLength: 1, pattern: "^[^/]+$" },
       description:
         "Team slugs (slug only, no `org/` prefix — the org is " +
         "derived from the repo's owner). Only meaningful on " +
-        "org-owned repos.",
+        "org-owned repos. A slug containing `/` is rejected at " +
+        "the input boundary.",
     },
     bot_logins: {
       type: "array",
@@ -263,10 +269,18 @@ async function resolveUserIds(
           const upstream = err.errors
             .map((e) => e.message ?? "unknown")
             .join("; ");
-          const looksLikeBot = /could not resolve to a user/i.test(upstream);
+          // GitHub returns the same "Could not resolve to a User"
+          // message for both bot logins AND misspelled / deleted
+          // humans, so we can't tell which one happened from the
+          // upstream text alone. Surface BOTH possibilities in
+          // the rethrow rather than asserting one — the caller
+          // knows which login they intended and can pick the
+          // correct fix.
+          const isResolutionFailure =
+            /could not resolve to a user/i.test(upstream);
           throw new Error(
-            looksLikeBot
-              ? `mcp-github: gh.pr_request_reviews: '${login}' could not be resolved as a User (upstream: ${upstream}); use bot_logins for bot accounts`
+            isResolutionFailure
+              ? `mcp-github: gh.pr_request_reviews: '${login}' could not be resolved as a User (upstream: ${upstream}); if this is a bot account, use bot_logins; otherwise verify the spelling and that the account still exists`
               : `mcp-github: gh.pr_request_reviews: failed to resolve user '${login}' (upstream: ${upstream})`,
           );
         }

--- a/src/tools/pr/request_reviews.ts
+++ b/src/tools/pr/request_reviews.ts
@@ -29,6 +29,7 @@
 //      return it as the canonical output.
 
 import type { GraphqlClient } from "../../graphql/client.js";
+import { GraphqlError } from "../../graphql/errors.js";
 import type { ToolEntry } from "../../registry.js";
 import { validate } from "../../validation/validator.js";
 import {
@@ -88,7 +89,13 @@ const outputSchema = {
     requested_reviewers: {
       type: "array",
       items: { type: "string" },
-      description: "Logins of human reviewers currently requested on the PR.",
+      description:
+        "Logins of human-shaped reviewers currently requested on " +
+        "the PR. Includes both `User` and `Mannequin` (the GHE " +
+        "migration placeholder for former contributors); the two " +
+        "share a login-shaped identifier and the same review " +
+        "semantics, so they're bucketed together rather than " +
+        "split into separate output fields.",
     },
     requested_teams: {
       type: "array",
@@ -227,14 +234,20 @@ export function registerPRRequestReviewsTool(
   });
 }
 
-// Resolve human logins → GraphQL User IDs. The `user(login)`
-// query throws when the login doesn't exist; client.ts will
-// surface that as a `GraphqlError`. We additionally check
-// `__typename === "User"` because GitHub's GraphQL has been
-// known to return `null` for some special cases (deleted
-// accounts) without erroring; treating a non-User response as
-// a bot-vs-human routing error gives the caller a clearer
-// signal than a generic GraphQL error would.
+// Resolve human logins → GraphQL User IDs. Three failure shapes
+// are possible from `user(login)`:
+//
+//   1. GraphQL errors[] surfaces as `GraphqlError` from
+//      client.ts. Most common for bot logins, where the API
+//      returns "Could not resolve to a User with the login of
+//      '...'". We catch it and rethrow with a tool-scoped
+//      message that hints at `bot_logins` so the caller's next
+//      attempt is correct.
+//   2. Response is `{ user: null }`. Less common (deleted
+//      accounts) but treated as "user not found".
+//   3. Response is non-null but `__typename` isn't "User".
+//      Defensive — GitHub's GraphQL has been known to deviate
+//      here for some special cases.
 async function resolveUserIds(
   graphql: GraphqlClient,
   logins: readonly string[],
@@ -242,7 +255,23 @@ async function resolveUserIds(
   if (logins.length === 0) return [];
   const ids = await Promise.all(
     logins.map(async (login) => {
-      const data = await graphql<UserIdResponse>("pr/_user-id", { login });
+      let data: UserIdResponse;
+      try {
+        data = await graphql<UserIdResponse>("pr/_user-id", { login });
+      } catch (err) {
+        if (err instanceof GraphqlError) {
+          const upstream = err.errors
+            .map((e) => e.message ?? "unknown")
+            .join("; ");
+          const looksLikeBot = /could not resolve to a user/i.test(upstream);
+          throw new Error(
+            looksLikeBot
+              ? `mcp-github: gh.pr_request_reviews: '${login}' could not be resolved as a User (upstream: ${upstream}); use bot_logins for bot accounts`
+              : `mcp-github: gh.pr_request_reviews: failed to resolve user '${login}' (upstream: ${upstream})`,
+          );
+        }
+        throw err;
+      }
       if (!data.user) {
         throw new Error(
           `mcp-github: gh.pr_request_reviews: user '${login}' not found`,
@@ -379,6 +408,13 @@ export function _readReviewRequestsOff(
     if (!r) continue; // null is possible per GraphQL nullability
     switch (r.__typename) {
       case "User":
+      // Mannequin is the GitHub Enterprise migration placeholder
+      // for a former contributor whose account no longer exists.
+      // It carries a login like a User and has the same review-
+      // request semantics, so we bucket it alongside human
+      // reviewers rather than inventing a separate output field
+      // that nearly every consumer would have to ignore. The
+      // schema description spells this out for callers.
       case "Mannequin":
         requested_reviewers.push(r.login);
         break;

--- a/src/tools/pr/request_reviews.ts
+++ b/src/tools/pr/request_reviews.ts
@@ -190,7 +190,7 @@ export function registerPRRequestReviewsTool(
         botLogins.length === 0
       ) {
         throw new Error(
-          `mcp-github: gh.pr_request_reviews input: at least one of user_logins, team_logins, bot_logins must be non-empty`,
+          `mcp-github: gh.pr_request_reviews input: at least one of user_logins, team_slugs, bot_logins must be non-empty`,
         );
       }
       const coords = parseRepoSlug(args.repo, "gh.pr_request_reviews input");
@@ -301,6 +301,11 @@ async function resolveTeamIds(
 // search (humans appear in the same suggestedActors list) but
 // would fail the typename check and produce a clean "use
 // user_logins" message.
+//
+// Note: despite its plural name, `loginNames` is declared
+// `String` (single) in GitHub's schema — see the comment in
+// `_bot-id.graphql`. So we call once per supplied bot login
+// rather than batching them all in one query.
 async function resolveBotIds(
   graphql: GraphqlClient,
   coords: RepoCoords,

--- a/src/tools/pr/request_reviews.ts
+++ b/src/tools/pr/request_reviews.ts
@@ -164,8 +164,9 @@ export function registerPRRequestReviewsTool(
 ): void {
   register("gh.pr_request_reviews", {
     description:
-      "Request reviews on a PR via GraphQL `requestReviews(botIds: " +
-      "[...])`. Unlike the REST `RequestReviewers` endpoint, this " +
+      "Request reviews on a PR via the GraphQL `requestReviews(" +
+      "input: { pullRequestId, userIds, teamIds, botIds, union })` " +
+      "mutation. Unlike the REST `RequestReviewers` endpoint, this " +
       "actually requests reviews from BOT accounts (Copilot, " +
       "Dependabot, custom apps); REST silently no-ops for bots, " +
       "which is the original reason this server exists. Logins " +

--- a/src/tools/pr/request_reviews.ts
+++ b/src/tools/pr/request_reviews.ts
@@ -1,0 +1,374 @@
+// src/tools/pr/request_reviews.ts
+//
+// `gh.pr_request_reviews` — THE marquee tool. Requests reviews on
+// a PR via GraphQL `requestReviews(input: { ..., botIds })` so
+// Copilot, Dependabot, and other custom-app bots are actually
+// requested. The REST endpoint
+// `POST /repos/:o/:r/pulls/:n/requested_reviewers` silently
+// no-ops for bots; that bug is the original reason this whole
+// server exists (see `agent-staff-engineer#34`).
+//
+// Implementation:
+//
+//   1. Resolve the PR's GraphQL node ID by (repo, number).
+//   2. Resolve the supplied logins/slugs to GraphQL node IDs in
+//      parallel:
+//        - users via `user(login: $l)` — must come back with
+//          `__typename: User`, otherwise reject (caller passed
+//          a bot login in the wrong slot).
+//        - teams via `organization(login: $org).team(slug: $s)`
+//          — org is derived from the repo's owner.
+//        - bots via `repository.suggestedActors(loginNames: $l,
+//          capabilities: [CAN_BE_ASSIGNED])` — must return a
+//          node with `__typename: Bot` matching the login,
+//          otherwise reject (caller passed a human login in
+//          the wrong slot).
+//   3. Run the `requestReviews` mutation with the resolved
+//      userIds / teamIds / botIds and the `union` flag.
+//   4. Read the new review-request set off the response and
+//      return it as the canonical output.
+
+import type { GraphqlClient } from "../../graphql/client.js";
+import type { ToolEntry } from "../../registry.js";
+import { validate } from "../../validation/validator.js";
+import {
+  lookupPRNodeId,
+  parseRepoSlug,
+  type RepoCoords,
+  repoSlugSchema,
+} from "./_shared.js";
+
+const inputSchema = {
+  type: "object",
+  required: ["repo", "number"],
+  properties: {
+    repo: repoSlugSchema,
+    number: { type: "integer", minimum: 1 },
+    user_logins: {
+      type: "array",
+      items: { type: "string", minLength: 1 },
+      description:
+        "Human reviewer logins. Resolved via `user(login)`; a " +
+        "login that resolves to a non-User type is rejected with " +
+        "a structured error pointing at `bot_logins` instead.",
+    },
+    team_slugs: {
+      type: "array",
+      items: { type: "string", minLength: 1 },
+      description:
+        "Team slugs (slug only, no `org/` prefix — the org is " +
+        "derived from the repo's owner). Only meaningful on " +
+        "org-owned repos.",
+    },
+    bot_logins: {
+      type: "array",
+      items: { type: "string", minLength: 1 },
+      description:
+        "Bot logins (e.g. `copilot-pull-request-reviewer`, " +
+        "`dependabot`). Resolved via `repository.suggestedActors` " +
+        "and verified to be a `Bot` type — a human login here is " +
+        "rejected because the GraphQL `requestReviews` mutation " +
+        "would otherwise reject the call as a type mismatch.",
+    },
+    union: {
+      type: "boolean",
+      description:
+        "false (default): replace the PR's existing requested " +
+        "reviewers with this set. true: ADD to the existing set " +
+        "without removing any.",
+    },
+  },
+  additionalProperties: false,
+} as const;
+
+const outputSchema = {
+  type: "object",
+  required: ["requested_reviewers", "requested_teams", "requested_bots"],
+  properties: {
+    requested_reviewers: {
+      type: "array",
+      items: { type: "string" },
+      description: "Logins of human reviewers currently requested on the PR.",
+    },
+    requested_teams: {
+      type: "array",
+      items: { type: "string" },
+      description: "Slugs of team reviewers currently requested on the PR.",
+    },
+    requested_bots: {
+      type: "array",
+      items: { type: "string" },
+      description: "Logins of bot reviewers currently requested on the PR.",
+    },
+  },
+  additionalProperties: false,
+} as const;
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+interface Input {
+  repo: string;
+  number: number;
+  user_logins?: string[];
+  team_slugs?: string[];
+  bot_logins?: string[];
+  union?: boolean;
+}
+
+interface Output {
+  requested_reviewers: string[];
+  requested_teams: string[];
+  requested_bots: string[];
+}
+
+interface UserIdResponse {
+  user: { id: string; __typename: string } | null;
+}
+
+interface TeamIdResponse {
+  organization: { team: { id: string } | null } | null;
+}
+
+interface BotIdResponse {
+  repository: {
+    suggestedActors: {
+      nodes: Array<
+        | { __typename: "Bot"; id: string; login: string }
+        | { __typename: "User"; login: string }
+      >;
+    };
+  } | null;
+}
+
+interface RequestReviewsResponse {
+  requestReviews: {
+    pullRequest: {
+      reviewRequests: {
+        pageInfo: { hasNextPage: boolean };
+        nodes: Array<{
+          requestedReviewer:
+            | { __typename: "User"; login: string }
+            | { __typename: "Bot"; login: string }
+            | { __typename: "Team"; slug: string }
+            | { __typename: "Mannequin"; login: string }
+            | null;
+        }>;
+      };
+    };
+  };
+}
+
+export function registerPRRequestReviewsTool(
+  register: RegisterToolFn,
+  graphql: GraphqlClient,
+): void {
+  register("gh.pr_request_reviews", {
+    description:
+      "Request reviews on a PR via GraphQL `requestReviews(botIds: " +
+      "[...])`. Unlike the REST `RequestReviewers` endpoint, this " +
+      "actually requests reviews from BOT accounts (Copilot, " +
+      "Dependabot, custom apps); REST silently no-ops for bots, " +
+      "which is the original reason this server exists. Logins " +
+      "are split into human / team / bot inputs because GraphQL " +
+      "resolves each to a different node type and the mutation " +
+      "rejects type mismatches. `union: false` (default) replaces " +
+      "the existing reviewer set; `true` adds without removing.",
+    inputSchema,
+    handler: async (raw) => {
+      const args = validate<Input>(inputSchema, raw, "gh.pr_request_reviews input");
+      const userLogins = args.user_logins ?? [];
+      const teamSlugs = args.team_slugs ?? [];
+      const botLogins = args.bot_logins ?? [];
+      // Refuse a no-op call upfront. The mutation accepts empty
+      // inputs but the result is ambiguous (in `union: false`
+      // mode it would clear all existing reviewers, which the
+      // caller almost certainly didn't intend if they reached
+      // this tool with no logins).
+      if (
+        userLogins.length === 0 &&
+        teamSlugs.length === 0 &&
+        botLogins.length === 0
+      ) {
+        throw new Error(
+          `mcp-github: gh.pr_request_reviews input: at least one of user_logins, team_logins, bot_logins must be non-empty`,
+        );
+      }
+      const coords = parseRepoSlug(args.repo, "gh.pr_request_reviews input");
+      // Run the PR lookup + every ID resolution in parallel.
+      // The lookups are independent so this halves the
+      // wall-clock cost when reviewing a typical 1-or-2-bot,
+      // 1-or-2-human request.
+      const [pullRequestId, userIds, teamIds, botIds] = await Promise.all([
+        lookupPRNodeId(graphql, coords, args.number, "gh.pr_request_reviews"),
+        resolveUserIds(graphql, userLogins),
+        resolveTeamIds(graphql, coords.owner, teamSlugs),
+        resolveBotIds(graphql, coords, botLogins),
+      ]);
+      // Build the mutation input incrementally — the GraphQL
+      // schema treats a present-but-empty array as "clear", so
+      // we omit categories the caller didn't ask about.
+      const input: Record<string, unknown> = { pullRequestId };
+      if (userIds.length > 0) input.userIds = userIds;
+      if (teamIds.length > 0) input.teamIds = teamIds;
+      if (botIds.length > 0) input.botIds = botIds;
+      input.union = args.union ?? false;
+      const data = await graphql<RequestReviewsResponse>(
+        "pr/request_reviews",
+        { input },
+      );
+      const out = readReviewRequestsOff(data);
+      return validate<Output>(
+        outputSchema,
+        out,
+        "gh.pr_request_reviews output",
+      );
+    },
+  });
+}
+
+// Resolve human logins → GraphQL User IDs. The `user(login)`
+// query throws when the login doesn't exist; client.ts will
+// surface that as a `GraphqlError`. We additionally check
+// `__typename === "User"` because GitHub's GraphQL has been
+// known to return `null` for some special cases (deleted
+// accounts) without erroring; treating a non-User response as
+// a bot-vs-human routing error gives the caller a clearer
+// signal than a generic GraphQL error would.
+async function resolveUserIds(
+  graphql: GraphqlClient,
+  logins: readonly string[],
+): Promise<string[]> {
+  if (logins.length === 0) return [];
+  const ids = await Promise.all(
+    logins.map(async (login) => {
+      const data = await graphql<UserIdResponse>("pr/_user-id", { login });
+      if (!data.user) {
+        throw new Error(
+          `mcp-github: gh.pr_request_reviews: user '${login}' not found`,
+        );
+      }
+      if (data.user.__typename !== "User") {
+        throw new Error(
+          `mcp-github: gh.pr_request_reviews: '${login}' is not a User (resolved to ${data.user.__typename}); use bot_logins for bot accounts`,
+        );
+      }
+      return data.user.id;
+    }),
+  );
+  return ids;
+}
+
+// Resolve team slugs → GraphQL Team IDs. The org is the repo's
+// owner. We don't accept `org/slug` form here because team
+// slugs are scoped to the repo's owning org by design — a team
+// from a different org couldn't review a PR on this repo
+// anyway.
+async function resolveTeamIds(
+  graphql: GraphqlClient,
+  org: string,
+  slugs: readonly string[],
+): Promise<string[]> {
+  if (slugs.length === 0) return [];
+  const ids = await Promise.all(
+    slugs.map(async (slug) => {
+      const data = await graphql<TeamIdResponse>("pr/_team-id", { org, slug });
+      if (!data.organization) {
+        throw new Error(
+          `mcp-github: gh.pr_request_reviews: organization '${org}' not found (or repo is user-owned, in which case team_slugs is not applicable)`,
+        );
+      }
+      if (!data.organization.team) {
+        throw new Error(
+          `mcp-github: gh.pr_request_reviews: team '${org}/${slug}' not found`,
+        );
+      }
+      return data.organization.team.id;
+    }),
+  );
+  return ids;
+}
+
+// Resolve bot logins → GraphQL Bot IDs via
+// `repository.suggestedActors`. This is the only practical
+// path: `Query.user(login)` errors out for bots (returns "Could
+// not resolve to a User"). suggestedActors with the
+// CAN_BE_ASSIGNED capability lists every actor that can be
+// associated with the repo, including Copilot / Dependabot /
+// custom apps installed on the repo.
+//
+// We verify `__typename === "Bot"` AND a login match; passing a
+// human login here would be silently accepted by the Apollo
+// search (humans appear in the same suggestedActors list) but
+// would fail the typename check and produce a clean "use
+// user_logins" message.
+async function resolveBotIds(
+  graphql: GraphqlClient,
+  coords: RepoCoords,
+  logins: readonly string[],
+): Promise<string[]> {
+  if (logins.length === 0) return [];
+  const ids = await Promise.all(
+    logins.map(async (login) => {
+      const data = await graphql<BotIdResponse>("pr/_bot-id", {
+        owner: coords.owner,
+        name: coords.name,
+        login,
+      });
+      if (!data.repository) {
+        throw new Error(
+          `mcp-github: gh.pr_request_reviews: repository '${coords.owner}/${coords.name}' not found or token lacks read access`,
+        );
+      }
+      const bot = data.repository.suggestedActors.nodes.find(
+        (n): n is { __typename: "Bot"; id: string; login: string } =>
+          n.__typename === "Bot" && n.login === login,
+      );
+      if (!bot) {
+        // Distinguish "not found at all" from "found but it's a
+        // human" so the caller knows which input slot to use.
+        const human = data.repository.suggestedActors.nodes.find(
+          (n) => n.__typename === "User" && n.login === login,
+        );
+        if (human) {
+          throw new Error(
+            `mcp-github: gh.pr_request_reviews: '${login}' is a User, not a Bot — use user_logins for human reviewers`,
+          );
+        }
+        throw new Error(
+          `mcp-github: gh.pr_request_reviews: bot '${login}' not found among assignable actors on '${coords.owner}/${coords.name}'`,
+        );
+      }
+      return bot.id;
+    }),
+  );
+  return ids;
+}
+
+// Read the post-mutation reviewer state off the response. We
+// echo back the actual GitHub-reported set rather than the
+// inputs because under `union: false` the response shows the
+// post-replace state (which only contains the just-supplied
+// reviewers) and under `union: true` it shows the merged set
+// (which can include reviewers from BEFORE this call).
+function readReviewRequestsOff(data: RequestReviewsResponse): Output {
+  const requested_reviewers: string[] = [];
+  const requested_teams: string[] = [];
+  const requested_bots: string[] = [];
+  for (const node of data.requestReviews.pullRequest.reviewRequests.nodes) {
+    const r = node.requestedReviewer;
+    if (!r) continue; // null is possible per GraphQL nullability
+    switch (r.__typename) {
+      case "User":
+      case "Mannequin":
+        requested_reviewers.push(r.login);
+        break;
+      case "Bot":
+        requested_bots.push(r.login);
+        break;
+      case "Team":
+        requested_teams.push(r.slug);
+        break;
+    }
+  }
+  return { requested_reviewers, requested_teams, requested_bots };
+}

--- a/src/tools/pr/request_reviews.ts
+++ b/src/tools/pr/request_reviews.ts
@@ -216,7 +216,7 @@ export function registerPRRequestReviewsTool(
         "pr/request_reviews",
         { input },
       );
-      const out = readReviewRequestsOff(data);
+      const out = _readReviewRequestsOff(data);
       return validate<Output>(
         outputSchema,
         out,
@@ -355,7 +355,21 @@ async function resolveBotIds(
 // post-replace state (which only contains the just-supplied
 // reviewers) and under `union: true` it shows the merged set
 // (which can include reviewers from BEFORE this call).
-function readReviewRequestsOff(data: RequestReviewsResponse): Output {
+//
+// `warn` is parameterised so unit tests can capture the
+// truncation message without hijacking stderr. Defaults to
+// `process.stderr.write`, matching the pattern in
+// `summarisePR()`.
+//
+// Exported for the unit suite under the `_` prefix so the
+// truncation-warn behaviour can be pinned without spinning up
+// the full handler. Not part of the package's public API
+// surface — tests reach in via a direct relative import.
+export function _readReviewRequestsOff(
+  data: RequestReviewsResponse,
+  warn: (msg: string) => void = (msg) =>
+    process.stderr.write(`${msg}\n`),
+): Output {
   const requested_reviewers: string[] = [];
   const requested_teams: string[] = [];
   const requested_bots: string[] = [];
@@ -374,6 +388,19 @@ function readReviewRequestsOff(data: RequestReviewsResponse): Output {
         requested_teams.push(r.slug);
         break;
     }
+  }
+  // The mutation response fetches `reviewRequests(first: 100)`.
+  // Under `union: true` on a PR that already had > 100 pending
+  // reviewers, the readback would silently drop the tail —
+  // surface a warning so the caller sees the partial result is
+  // intentional rather than a missed reviewer. PRs with > 100
+  // pending review-requests are vanishingly rare in practice
+  // (GitHub's UI doesn't even paginate the list), so we warn
+  // rather than throw.
+  if (data.requestReviews.pullRequest.reviewRequests.pageInfo.hasNextPage) {
+    warn(
+      `mcp-github: gh.pr_request_reviews: PR has more than 100 pending review requests; output is truncated to the first page.`,
+    );
   }
   return { requested_reviewers, requested_teams, requested_bots };
 }

--- a/tests/smoke/server-lists-tools.mjs
+++ b/tests/smoke/server-lists-tools.mjs
@@ -1,14 +1,17 @@
 #!/usr/bin/env node
 // tests/smoke/server-lists-tools.mjs
 //
-// End-to-end smoke test: spawn the freshly-built dist/server.mjs over
-// stdio, send the MCP `initialize` handshake + `tools/list`, assert
-// the registered tool surface (the auth probe `gh.test_connection`
-// from MCP-2 plus the seven `gh.issue_*` tools from MCP-4). The
-// `EXPECTED_TOOLS` list below is the source of truth — update it
-// whenever a new domain-tool batch lands. Proves the SDK wiring +
-// auth bootstrap + tool registration chain end-to-end without
-// pulling in the unit-test framework.
+// End-to-end smoke test: spawn the freshly-built dist/server.mjs
+// over stdio, send the MCP `initialize` handshake + `tools/list`,
+// assert the registered tool surface. The `EXPECTED_TOOLS` list
+// below is the source of truth — update it whenever a new
+// domain-tool batch lands. Proves the SDK wiring + auth bootstrap
+// + tool registration chain end-to-end without pulling in the
+// unit-test framework.
+//
+// Current surface: 1 auth probe (`gh.test_connection` from MCP-2)
+// + 7 issue tools (MCP-4) + 4 label tools (MCP-7) + 7 PR tools
+// (MCP-5 + MCP-6, the latter adding `gh.pr_request_reviews`).
 //
 // Wire format: the MCP SDK's StdioServerTransport uses newline-
 // delimited JSON-RPC (one JSON message per `\n`-terminated line),

--- a/tests/smoke/server-lists-tools.mjs
+++ b/tests/smoke/server-lists-tools.mjs
@@ -46,6 +46,7 @@ const EXPECTED_TOOLS = [
   "gh.pr_edit",
   "gh.pr_comment",
   "gh.pr_merge",
+  "gh.pr_request_reviews",
 ];
 
 function frame(payload) {

--- a/tests/unit/tools/pr/request_reviews.test.ts
+++ b/tests/unit/tools/pr/request_reviews.test.ts
@@ -12,7 +12,10 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { registerPRRequestReviewsTool } from "../../../../src/tools/pr/request_reviews.ts";
+import {
+  registerPRRequestReviewsTool,
+  _readReviewRequestsOff,
+} from "../../../../src/tools/pr/request_reviews.ts";
 import type { ToolEntry } from "../../../../src/registry.ts";
 import { stubGraphqlClient } from "./_fixtures.ts";
 
@@ -380,6 +383,60 @@ test("gh.pr_request_reviews: surfaces clear error when team_slugs are passed on 
     }),
     /team_slugs is not applicable/,
   );
+});
+
+test("_readReviewRequestsOff: warns when reviewRequests page is truncated", async () => {
+  // The mutation response fetches reviewRequests(first: 100).
+  // PRs with > 100 pending review requests are vanishingly rare,
+  // but if a `union: true` call lands on one the readback would
+  // silently drop the tail. Pin the warn-not-throw contract.
+  const truncated = {
+    requestReviews: {
+      pullRequest: {
+        reviewRequests: {
+          pageInfo: { hasNextPage: true },
+          nodes: [
+            {
+              requestedReviewer: {
+                __typename: "User" as const,
+                login: "alice",
+              },
+            },
+          ],
+        },
+      },
+    },
+  };
+  const warns: string[] = [];
+  const out = _readReviewRequestsOff(truncated, (m) => warns.push(m));
+  // Output is still emitted (we warn rather than throw); the
+  // observable signal lives on stderr.
+  assert.deepEqual(out.requested_reviewers, ["alice"]);
+  assert.equal(warns.length, 1);
+  assert.match(warns[0] ?? "", /more than 100 pending review requests/);
+});
+
+test("_readReviewRequestsOff: silent on the common, not-truncated case", async () => {
+  const normal = {
+    requestReviews: {
+      pullRequest: {
+        reviewRequests: {
+          pageInfo: { hasNextPage: false },
+          nodes: [
+            {
+              requestedReviewer: {
+                __typename: "Bot" as const,
+                login: "copilot",
+              },
+            },
+          ],
+        },
+      },
+    },
+  };
+  const warns: string[] = [];
+  _readReviewRequestsOff(normal, (m) => warns.push(m));
+  assert.equal(warns.length, 0);
 });
 
 test("gh.pr_request_reviews: rejects malformed repo slug at the input boundary", async () => {

--- a/tests/unit/tools/pr/request_reviews.test.ts
+++ b/tests/unit/tools/pr/request_reviews.test.ts
@@ -1,0 +1,397 @@
+// tests/unit/tools/pr/request_reviews.test.ts
+//
+// gh.pr_request_reviews — the marquee tool. The single-most-
+// important assertion in this file is that the tool calls the
+// GraphQL `pr/request_reviews` mutation with `botIds` populated.
+// REST `POST /repos/.../requested_reviewers` would silently
+// no-op for bots; if a future regression accidentally routed
+// bot logins through the REST path or dropped them from the
+// GraphQL input, every test here that asserts botIds presence
+// would fail.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { registerPRRequestReviewsTool } from "../../../../src/tools/pr/request_reviews.ts";
+import type { ToolEntry } from "../../../../src/registry.ts";
+import { stubGraphqlClient } from "./_fixtures.ts";
+
+function captureRegistration() {
+  let entry: ToolEntry | undefined;
+  const register = (name: string, e: ToolEntry) => {
+    if (name !== "gh.pr_request_reviews") throw new Error(`unexpected: ${name}`);
+    entry = e;
+  };
+  return {
+    register,
+    get entry(): ToolEntry {
+      if (!entry) throw new Error("not registered");
+      return entry;
+    },
+  };
+}
+
+// Canonical mutation response: a PR with one of each reviewer
+// type so the readback path is exercised end-to-end. Override
+// per-test by spreading.
+const sampleMutationResponse = {
+  requestReviews: {
+    pullRequest: {
+      reviewRequests: {
+        pageInfo: { hasNextPage: false },
+        nodes: [
+          {
+            requestedReviewer: {
+              __typename: "User" as const,
+              login: "alice",
+            },
+          },
+          {
+            requestedReviewer: {
+              __typename: "Bot" as const,
+              login: "copilot-pull-request-reviewer",
+            },
+          },
+          {
+            requestedReviewer: {
+              __typename: "Team" as const,
+              slug: "platform",
+            },
+          },
+        ],
+      },
+    },
+  },
+};
+
+test("gh.pr_request_reviews: routes bot logins through GraphQL botIds (the marquee path)", async () => {
+  // The whole point of MCP-6: bot reviewers MUST go through the
+  // GraphQL mutation's `botIds` input. The earlier path under
+  // `@github/mcp-server-github` used the REST endpoint, which
+  // silently no-ops for bots. Pin that:
+  //
+  //   - the resolved bot ID flows into mutation input as botIds
+  //   - userIds and teamIds stay empty when only bots are
+  //     supplied, so the call shape is unambiguous
+  let mutationInput: Record<string, unknown> | undefined;
+  const { graphql, calls } = stubGraphqlClient({
+    "pr/_pr-lookup": { repository: { pullRequest: { id: "PR_target" } } },
+    "pr/_bot-id": (vars: Record<string, unknown>) => {
+      assert.equal(vars.login, "copilot-pull-request-reviewer");
+      return {
+        repository: {
+          suggestedActors: {
+            nodes: [
+              {
+                __typename: "Bot",
+                id: "BOT_copilot",
+                login: "copilot-pull-request-reviewer",
+              },
+            ],
+          },
+        },
+      };
+    },
+    "pr/request_reviews": (vars: Record<string, unknown>) => {
+      mutationInput = vars.input as Record<string, unknown>;
+      return sampleMutationResponse;
+    },
+  });
+  const reg = captureRegistration();
+  registerPRRequestReviewsTool(reg.register, graphql);
+  const out = (await reg.entry.handler({
+    repo: "owner/repo",
+    number: 42,
+    bot_logins: ["copilot-pull-request-reviewer"],
+  })) as { requested_bots: string[] };
+  assert.deepEqual(mutationInput, {
+    pullRequestId: "PR_target",
+    botIds: ["BOT_copilot"],
+    union: false,
+  });
+  assert.deepEqual(out.requested_bots, ["copilot-pull-request-reviewer"]);
+  // The mutation MUST be `pr/request_reviews`, not anything
+  // resembling a REST path. (The stub already enforces this by
+  // throwing on unmocked queries, but the assertion makes the
+  // intent visible in the test name.)
+  assert.ok(
+    calls.some((c) => c.queryName === "pr/request_reviews"),
+    "MUST call the GraphQL pr/request_reviews mutation, not REST",
+  );
+});
+
+test("gh.pr_request_reviews: resolves human + team + bot in parallel, splits the readback", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "pr/_pr-lookup": { repository: { pullRequest: { id: "PR_target" } } },
+    "pr/_user-id": (vars: Record<string, unknown>) => {
+      assert.equal(vars.login, "alice");
+      return { user: { id: "U_alice", __typename: "User" } };
+    },
+    "pr/_team-id": (vars: Record<string, unknown>) => {
+      assert.equal(vars.org, "owner");
+      assert.equal(vars.slug, "platform");
+      return { organization: { team: { id: "T_platform" } } };
+    },
+    "pr/_bot-id": () => ({
+      repository: {
+        suggestedActors: {
+          nodes: [
+            {
+              __typename: "Bot",
+              id: "BOT_copilot",
+              login: "copilot-pull-request-reviewer",
+            },
+          ],
+        },
+      },
+    }),
+    "pr/request_reviews": (vars: Record<string, unknown>) => {
+      const input = vars.input as Record<string, unknown>;
+      assert.deepEqual(input.userIds, ["U_alice"]);
+      assert.deepEqual(input.teamIds, ["T_platform"]);
+      assert.deepEqual(input.botIds, ["BOT_copilot"]);
+      return sampleMutationResponse;
+    },
+  });
+  const reg = captureRegistration();
+  registerPRRequestReviewsTool(reg.register, graphql);
+  const out = (await reg.entry.handler({
+    repo: "owner/repo",
+    number: 42,
+    user_logins: ["alice"],
+    team_slugs: ["platform"],
+    bot_logins: ["copilot-pull-request-reviewer"],
+  })) as {
+    requested_reviewers: string[];
+    requested_teams: string[];
+    requested_bots: string[];
+  };
+  assert.deepEqual(out, {
+    requested_reviewers: ["alice"],
+    requested_teams: ["platform"],
+    requested_bots: ["copilot-pull-request-reviewer"],
+  });
+  // Resolution order is non-deterministic (Promise.all) but
+  // every required query must have run.
+  const queries = calls.map((c) => c.queryName).sort();
+  assert.deepEqual(queries, [
+    "pr/_bot-id",
+    "pr/_pr-lookup",
+    "pr/_team-id",
+    "pr/_user-id",
+    "pr/request_reviews",
+  ]);
+});
+
+test("gh.pr_request_reviews: rejects a human login passed in bot_logins", async () => {
+  // Crucial routing check. A caller who puts `octocat` in
+  // bot_logins must see a clear "use user_logins" error rather
+  // than a confusing "Bot not found" or — worse — a silent
+  // no-op once the request hits the mutation.
+  const { graphql } = stubGraphqlClient({
+    "pr/_pr-lookup": { repository: { pullRequest: { id: "PR_target" } } },
+    "pr/_bot-id": () => ({
+      repository: {
+        suggestedActors: {
+          nodes: [
+            { __typename: "User", login: "octocat" },
+          ],
+        },
+      },
+    }),
+    "pr/request_reviews": () => {
+      throw new Error("mutation must NOT run when bot resolution fails");
+    },
+  });
+  const reg = captureRegistration();
+  registerPRRequestReviewsTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      repo: "owner/repo",
+      number: 42,
+      bot_logins: ["octocat"],
+    }),
+    /'octocat' is a User, not a Bot — use user_logins/,
+  );
+});
+
+test("gh.pr_request_reviews: rejects a bot login passed in user_logins", async () => {
+  // Symmetric routing check. user(login) errors out for bots
+  // but we also defensively check __typename in case GitHub's
+  // API ever returns null instead of erroring.
+  const { graphql } = stubGraphqlClient({
+    "pr/_pr-lookup": { repository: { pullRequest: { id: "PR_target" } } },
+    "pr/_user-id": () => ({ user: null }),
+    "pr/request_reviews": () => {
+      throw new Error("mutation must NOT run when user resolution fails");
+    },
+  });
+  const reg = captureRegistration();
+  registerPRRequestReviewsTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      repo: "owner/repo",
+      number: 42,
+      user_logins: ["dependabot"],
+    }),
+    /user 'dependabot' not found/,
+  );
+});
+
+test("gh.pr_request_reviews: union: true forwards to mutation input", async () => {
+  let mutationInput: Record<string, unknown> | undefined;
+  const { graphql } = stubGraphqlClient({
+    "pr/_pr-lookup": { repository: { pullRequest: { id: "PR_target" } } },
+    "pr/_user-id": () => ({ user: { id: "U_alice", __typename: "User" } }),
+    "pr/request_reviews": (vars: Record<string, unknown>) => {
+      mutationInput = vars.input as Record<string, unknown>;
+      return sampleMutationResponse;
+    },
+  });
+  const reg = captureRegistration();
+  registerPRRequestReviewsTool(reg.register, graphql);
+  await reg.entry.handler({
+    repo: "owner/repo",
+    number: 42,
+    user_logins: ["alice"],
+    union: true,
+  });
+  assert.equal(mutationInput?.union, true);
+});
+
+test("gh.pr_request_reviews: union defaults to false (replace existing reviewers)", async () => {
+  let mutationInput: Record<string, unknown> | undefined;
+  const { graphql } = stubGraphqlClient({
+    "pr/_pr-lookup": { repository: { pullRequest: { id: "PR_target" } } },
+    "pr/_user-id": () => ({ user: { id: "U_alice", __typename: "User" } }),
+    "pr/request_reviews": (vars: Record<string, unknown>) => {
+      mutationInput = vars.input as Record<string, unknown>;
+      return sampleMutationResponse;
+    },
+  });
+  const reg = captureRegistration();
+  registerPRRequestReviewsTool(reg.register, graphql);
+  await reg.entry.handler({
+    repo: "owner/repo",
+    number: 42,
+    user_logins: ["alice"],
+  });
+  assert.equal(mutationInput?.union, false);
+});
+
+test("gh.pr_request_reviews: refuses a no-op call where every reviewer slot is empty", async () => {
+  // Without this guard, `union: false` + no inputs would
+  // CLEAR the existing reviewers — almost certainly not what
+  // the caller meant if they reached this tool empty-handed.
+  const { graphql } = stubGraphqlClient({
+    "pr/_pr-lookup": () => {
+      throw new Error("must not run when input is empty");
+    },
+    "pr/request_reviews": () => {
+      throw new Error("must not run when input is empty");
+    },
+  });
+  const reg = captureRegistration();
+  registerPRRequestReviewsTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", number: 42 }),
+    /at least one of user_logins, team_logins, bot_logins must be non-empty/,
+  );
+});
+
+test("gh.pr_request_reviews: skips empty arrays in the mutation input", async () => {
+  // GraphQL's RequestReviewsInput treats present-but-empty
+  // arrays as "clear that category". When the caller only
+  // supplies bots, userIds and teamIds must be ABSENT (not
+  // present and empty) so the mutation doesn't accidentally
+  // wipe pre-existing human or team reviewers.
+  let mutationInput: Record<string, unknown> | undefined;
+  const { graphql } = stubGraphqlClient({
+    "pr/_pr-lookup": { repository: { pullRequest: { id: "PR_target" } } },
+    "pr/_bot-id": () => ({
+      repository: {
+        suggestedActors: {
+          nodes: [
+            {
+              __typename: "Bot",
+              id: "BOT_copilot",
+              login: "copilot",
+            },
+          ],
+        },
+      },
+    }),
+    "pr/request_reviews": (vars: Record<string, unknown>) => {
+      mutationInput = vars.input as Record<string, unknown>;
+      return sampleMutationResponse;
+    },
+  });
+  const reg = captureRegistration();
+  registerPRRequestReviewsTool(reg.register, graphql);
+  await reg.entry.handler({
+    repo: "owner/repo",
+    number: 42,
+    bot_logins: ["copilot"],
+  });
+  assert.equal("userIds" in (mutationInput ?? {}), false);
+  assert.equal("teamIds" in (mutationInput ?? {}), false);
+  assert.deepEqual(mutationInput?.botIds, ["BOT_copilot"]);
+});
+
+test("gh.pr_request_reviews: surfaces 'team not found' clearly when slug doesn't exist", async () => {
+  const { graphql } = stubGraphqlClient({
+    "pr/_pr-lookup": { repository: { pullRequest: { id: "PR_target" } } },
+    "pr/_team-id": () => ({ organization: { team: null } }),
+    "pr/request_reviews": () => {
+      throw new Error("must not run");
+    },
+  });
+  const reg = captureRegistration();
+  registerPRRequestReviewsTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      repo: "owner/repo",
+      number: 42,
+      team_slugs: ["nonexistent"],
+    }),
+    /team 'owner\/nonexistent' not found/,
+  );
+});
+
+test("gh.pr_request_reviews: surfaces clear error when team_slugs are passed on a user-owned repo", async () => {
+  // GraphQL `organization(login: $userLogin)` returns null
+  // when the login is a User, not an Org. Translate that to a
+  // helpful "team_slugs not applicable" message so the caller
+  // doesn't think the team was simply missing.
+  const { graphql } = stubGraphqlClient({
+    "pr/_pr-lookup": { repository: { pullRequest: { id: "PR_target" } } },
+    "pr/_team-id": () => ({ organization: null }),
+    "pr/request_reviews": () => {
+      throw new Error("must not run");
+    },
+  });
+  const reg = captureRegistration();
+  registerPRRequestReviewsTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      repo: "person/repo",
+      number: 42,
+      team_slugs: ["platform"],
+    }),
+    /team_slugs is not applicable/,
+  );
+});
+
+test("gh.pr_request_reviews: rejects malformed repo slug at the input boundary", async () => {
+  const { graphql } = stubGraphqlClient({});
+  const reg = captureRegistration();
+  registerPRRequestReviewsTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      repo: "no-slash",
+      number: 42,
+      user_logins: ["alice"],
+    }),
+    /gh\.pr_request_reviews input/,
+  );
+});

--- a/tests/unit/tools/pr/request_reviews.test.ts
+++ b/tests/unit/tools/pr/request_reviews.test.ts
@@ -249,7 +249,7 @@ test("gh.pr_request_reviews: maps GraphqlError from user(login) onto a routing-h
       number: 42,
       user_logins: ["dependabot"],
     }),
-    /'dependabot' could not be resolved as a User .* use bot_logins/,
+    /'dependabot' could not be resolved as a User .* if this is a bot account, use bot_logins.* otherwise verify the spelling/,
   );
 });
 
@@ -394,6 +394,29 @@ test("gh.pr_request_reviews: surfaces 'team not found' clearly when slug doesn't
       team_slugs: ["nonexistent"],
     }),
     /team 'owner\/nonexistent' not found/,
+  );
+});
+
+test("gh.pr_request_reviews: rejects team_slugs that look like `org/slug`", async () => {
+  // Common mis-passing — caller types the team's full path
+  // when the schema wants just the slug. Catching it at the
+  // boundary produces a schema-validation error pointing at
+  // the offending instance path, instead of a confusing
+  // "team 'owner/org/slug' not found" later.
+  const { graphql } = stubGraphqlClient({
+    "pr/_pr-lookup": () => {
+      throw new Error("must not run when input is malformed");
+    },
+  });
+  const reg = captureRegistration();
+  registerPRRequestReviewsTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      repo: "owner/repo",
+      number: 42,
+      team_slugs: ["org/platform"],
+    }),
+    /gh\.pr_request_reviews input/,
   );
 });
 

--- a/tests/unit/tools/pr/request_reviews.test.ts
+++ b/tests/unit/tools/pr/request_reviews.test.ts
@@ -295,7 +295,7 @@ test("gh.pr_request_reviews: refuses a no-op call where every reviewer slot is e
   registerPRRequestReviewsTool(reg.register, graphql);
   await assert.rejects(
     reg.entry.handler({ repo: "owner/repo", number: 42 }),
-    /at least one of user_logins, team_logins, bot_logins must be non-empty/,
+    /at least one of user_logins, team_slugs, bot_logins must be non-empty/,
   );
 });
 

--- a/tests/unit/tools/pr/request_reviews.test.ts
+++ b/tests/unit/tools/pr/request_reviews.test.ts
@@ -16,6 +16,7 @@ import {
   registerPRRequestReviewsTool,
   _readReviewRequestsOff,
 } from "../../../../src/tools/pr/request_reviews.ts";
+import { GraphqlError } from "../../../../src/graphql/errors.ts";
 import type { ToolEntry } from "../../../../src/registry.ts";
 import { stubGraphqlClient } from "./_fixtures.ts";
 
@@ -218,13 +219,24 @@ test("gh.pr_request_reviews: rejects a human login passed in bot_logins", async 
   );
 });
 
-test("gh.pr_request_reviews: rejects a bot login passed in user_logins", async () => {
-  // Symmetric routing check. user(login) errors out for bots
-  // but we also defensively check __typename in case GitHub's
-  // API ever returns null instead of erroring.
+test("gh.pr_request_reviews: maps GraphqlError from user(login) onto a routing-hint message", async () => {
+  // Real-world failure shape: `user(login: "dependabot")`
+  // returns a GraphQL `errors[]` ("Could not resolve to a User
+  // with the login of 'dependabot'"). client.ts wraps that as
+  // a GraphqlError. The handler must catch it and rethrow with
+  // a tool-scoped message that points the caller at
+  // `bot_logins` — otherwise they'd see a generic
+  // GraphqlError and have no idea which input slot to use.
   const { graphql } = stubGraphqlClient({
     "pr/_pr-lookup": { repository: { pullRequest: { id: "PR_target" } } },
-    "pr/_user-id": () => ({ user: null }),
+    "pr/_user-id": () => {
+      throw new GraphqlError([
+        {
+          type: "NOT_FOUND",
+          message: "Could not resolve to a User with the login of 'dependabot'.",
+        },
+      ]);
+    },
     "pr/request_reviews": () => {
       throw new Error("mutation must NOT run when user resolution fails");
     },
@@ -237,7 +249,31 @@ test("gh.pr_request_reviews: rejects a bot login passed in user_logins", async (
       number: 42,
       user_logins: ["dependabot"],
     }),
-    /user 'dependabot' not found/,
+    /'dependabot' could not be resolved as a User .* use bot_logins/,
+  );
+});
+
+test("gh.pr_request_reviews: handles the rare null-user response cleanly", async () => {
+  // GitHub's GraphQL has been known to return `{ user: null }`
+  // for some special cases (deleted accounts) instead of
+  // erroring. Pin that we surface a "user not found" rather
+  // than crashing on `data.user.id` access.
+  const { graphql } = stubGraphqlClient({
+    "pr/_pr-lookup": { repository: { pullRequest: { id: "PR_target" } } },
+    "pr/_user-id": () => ({ user: null }),
+    "pr/request_reviews": () => {
+      throw new Error("mutation must NOT run");
+    },
+  });
+  const reg = captureRegistration();
+  registerPRRequestReviewsTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      repo: "owner/repo",
+      number: 42,
+      user_logins: ["ghost-account"],
+    }),
+    /user 'ghost-account' not found/,
   );
 });
 


### PR DESCRIPTION
## Summary

**The marquee tool.** This is the original reason `@ctxr/mcp-github` exists: `@github/mcp-server-github`'s review-request tools all silently call REST `POST /repos/.../requested_reviewers`, which no-ops for bot accounts (Copilot, Dependabot, custom apps). MCP-6 fixes that by routing through GraphQL's `requestReviews(input: { ..., botIds })` mutation, which actually applies bot reviewers as expected.

| Tool | Input | Output |
|---|---|---|
| `gh.pr_request_reviews` | `{repo, number, user_logins?[], team_slugs?[], bot_logins?[], union?}` | `{requested_reviewers[], requested_teams[], requested_bots[]}` |

### Why three input slots

GraphQL resolves each reviewer category to a distinct node type (`User`, `Team`, `Bot`) and `requestReviews` rejects type mismatches. Splitting the input means a routing error (a human login in `bot_logins`, or vice versa) surfaces with a clear structured message pointing at the correct slot — instead of a confusing "Bot not found" or, worse, a silently-discarded reviewer.

### Resolution flow

1. `lookupPRNodeId` by `(repo, number)`.
2. Resolve every supplied login/slug to a GraphQL node ID **in parallel** via `Promise.all`:
   - `user_logins` → `user(login)` (with `__typename === User` check)
   - `team_slugs` → `organization(login: $org).team(slug)` (org derived from the repo's owner; user-owned repos surface "team_slugs not applicable" rather than "team not found")
   - `bot_logins` → `repository.suggestedActors(loginNames, capabilities: [CAN_BE_ASSIGNED])` — the only practical path because `Query.user(login)` errors for bots
3. Run the `requestReviews` mutation with `{userIds?, teamIds?, botIds?, union}`. Each ID array is **omitted when empty** so a bot-only call doesn't accidentally clear the PR's existing humans/teams.
4. Read the post-mutation reviewer set off `pullRequest.reviewRequests.nodes[].requestedReviewer` and bucket it back into the canonical output.

### Behaviour worth flagging

- **`union: false` (default)** replaces the existing reviewer set; `true` adds without removing.
- **Refuse-empty** — the handler rejects calls where every reviewer slot is empty. Without this guard, `union: false` + no inputs would CLEAR all existing reviewers.
- **Output reads back from the mutation response** (not echoed inputs), so the caller sees the actual GitHub-reported state under both `union` modes.

### Files

- `src/tools/pr/request_reviews.ts` — handler.
- `src/graphql/queries/pr/_user-id.graphql`, `_team-id.graphql`, `_bot-id.graphql` — three parallel resolvers.
- `src/graphql/queries/pr/request_reviews.graphql` — the mutation.
- `src/tools/pr/index.ts` — wires the new tool into `registerPRTools()`.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — **169/169 pass** (12 new).
- [x] Smoke asserts 19 tools.
- [x] **The critical assertion** — `pr/request_reviews` mutation is called with `botIds: [...]` populated. A future regression that accidentally routed bot logins through any REST-shaped path or dropped them from the GraphQL input would fail this test loudly.
- [x] Routing-error tests: bot login in `user_logins` → `"user 'X' not found"`; human login in `bot_logins` → `"'X' is a User, not a Bot — use user_logins"`.
- [x] `union: true | false (default)` forwards correctly.
- [x] Refuse-empty guard.
- [x] Empty-array categories absent from mutation input.
- [x] Team-not-found vs `team_slugs-not-applicable-on-user-repo` distinct messages.
- [ ] Live integration probe (real reviewer request against a PAT with Copilot installed) lands in MCP-12.

## Stack

After **MCP-1/2/3 (merged) → MCP-4 (#21, merged) → MCP-5 (#22, merged) → MCP-7 (#23, merged)**. Nothing else in the epic depends on this — closing #7 unblocks the Bundle's `pr-iteration` skill from shelling out to `gh` for review-request, which is the bit it cared most about.

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)