### PR TITLE
feat: 4 workflow-ops tools (MCP-9)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -37,6 +37,7 @@ import { registerTestConnectionTool } from "./tools/auth/test_connection.js";
 import { registerIssueTools } from "./tools/issue/index.js";
 import { registerLabelTools } from "./tools/label/index.js";
 import { registerPRTools } from "./tools/pr/index.js";
+import { registerWorkflowTools } from "./tools/workflow/index.js";
 
 // Read the package version from the package.json next to the dist
 // tree at startup, so a single source of truth (package.json) drives
@@ -80,6 +81,11 @@ export async function startServer(): Promise<void> {
   registerIssueTools(registerTool, graphql);
   registerLabelTools(registerTool, graphql);
   registerPRTools(registerTool, graphql);
+  // Workflow tools take `authedRequest` rather than `graphql`
+  // because GitHub's GraphQL coverage of Actions is incomplete
+  // (no cancel mutation; weak filter surface on the run list).
+  // Same auth layer underneath, just a different request path.
+  registerWorkflowTools(registerTool, authedRequest);
 
   const server = new Server(
     {

--- a/src/tools/workflow/_shared.ts
+++ b/src/tools/workflow/_shared.ts
@@ -1,0 +1,204 @@
+// src/tools/workflow/_shared.ts
+//
+// Helpers shared across the four gh.workflow_* tools. Unlike the
+// issue/pr/label domains, these tools call REST under the hood:
+// GitHub's GraphQL coverage of Actions is incomplete — there is
+// no `cancelWorkflowRun` mutation, the run-list filters are
+// weaker than REST's, and the job-step detail surface barely
+// exists in GraphQL. Falling back to REST via the authed
+// `@octokit/request` client (the same one `gh.test_connection`
+// uses) keeps the surface complete.
+//
+// We still re-export `parseRepoSlug` and `repoSlugSchema` from
+// the issue domain so the shape rule for `repo` is identical
+// across every tool category.
+
+import type { RequestError } from "@octokit/request-error";
+
+import { parseRepoSlug as parseIssueRepoSlug, type RepoCoords, repoSlugSchema } from "../issue/_shared.js";
+
+export type { RepoCoords };
+export { repoSlugSchema };
+export const parseRepoSlug = parseIssueRepoSlug;
+
+// Canonical CI status enum used across this domain. Mirrors the
+// `status` × `conclusion` combination GitHub returns for Actions
+// runs: a run is `queued | in_progress | completed`, and a
+// completed run carries one of the conclusions below. We
+// flatten the two into a single `state` string for ergonomics —
+// callers care about "is it done? did it pass?" more than they
+// care about the status/conclusion split.
+export type RunState =
+  | "queued"
+  | "in_progress"
+  | "success"
+  | "failure"
+  | "cancelled"
+  | "skipped"
+  | "timed_out"
+  | "action_required"
+  | "neutral";
+
+export const runStateSchema = {
+  type: "string",
+  enum: [
+    "queued",
+    "in_progress",
+    "success",
+    "failure",
+    "cancelled",
+    "skipped",
+    "timed_out",
+    "action_required",
+    "neutral",
+  ],
+} as const;
+
+// REST returns `status` and `conclusion` separately. Collapse
+// them into the canonical `RunState` so consumers don't have to
+// branch on both. An in-flight run has `conclusion: null`; a
+// completed run's conclusion is the meaningful field.
+export function flattenRunState(
+  status: string | null | undefined,
+  conclusion: string | null | undefined,
+): RunState {
+  if (status === "queued") return "queued";
+  if (status === "in_progress" || status === "waiting" || status === "pending" || status === "requested")
+    return "in_progress";
+  // status === "completed" — fall through to conclusion
+  switch (conclusion) {
+    case "success":
+      return "success";
+    case "failure":
+      return "failure";
+    case "cancelled":
+      return "cancelled";
+    case "skipped":
+      return "skipped";
+    case "timed_out":
+      return "timed_out";
+    case "action_required":
+      return "action_required";
+    case "neutral":
+      return "neutral";
+    default:
+      // Unknown / null conclusion on a completed run is rare but
+      // possible (very old runs in archived repos); treat as
+      // neutral so the type stays inhabited.
+      return "neutral";
+  }
+}
+
+// Canonical run summary shape. Returned by both runs_list (per
+// item) and run_view.
+export interface RunSummary {
+  id: number;
+  url: string;
+  name: string;
+  workflow_name: string | null;
+  branch: string | null;
+  state: RunState;
+  event: string;
+  run_attempt: number;
+  head_sha: string;
+  actor: string | null;
+  created_at: string;
+  updated_at: string;
+  run_started_at: string | null;
+}
+
+export const runSummarySchema = {
+  type: "object",
+  required: [
+    "id",
+    "url",
+    "name",
+    "workflow_name",
+    "branch",
+    "state",
+    "event",
+    "run_attempt",
+    "head_sha",
+    "actor",
+    "created_at",
+    "updated_at",
+    "run_started_at",
+  ],
+  properties: {
+    id: { type: "integer" },
+    url: { type: "string" },
+    name: { type: "string" },
+    workflow_name: { type: ["string", "null"] },
+    branch: { type: ["string", "null"] },
+    state: runStateSchema,
+    event: { type: "string" },
+    run_attempt: { type: "integer", minimum: 1 },
+    head_sha: { type: "string" },
+    actor: { type: ["string", "null"] },
+    created_at: { type: "string" },
+    updated_at: { type: "string" },
+    run_started_at: { type: ["string", "null"] },
+  },
+  additionalProperties: false,
+} as const;
+
+// Raw shape REST returns under `runs[]` (or for a single run).
+// Only the fields we project onto `RunSummary` are typed.
+export interface RawRun {
+  id: number;
+  html_url?: string;
+  url?: string;
+  name?: string | null;
+  display_title?: string | null;
+  workflow_name?: string | null;
+  head_branch?: string | null;
+  status?: string | null;
+  conclusion?: string | null;
+  event?: string;
+  run_attempt?: number;
+  head_sha?: string;
+  actor?: { login: string } | null;
+  created_at?: string;
+  updated_at?: string;
+  run_started_at?: string | null;
+}
+
+export function summariseRun(raw: RawRun): RunSummary {
+  return {
+    id: raw.id,
+    // Prefer the HTML URL (browser-clickable); fall back to the
+    // API URL if html_url is missing (it shouldn't be, but the
+    // type lets it).
+    url: raw.html_url ?? raw.url ?? "",
+    name: raw.display_title ?? raw.name ?? "",
+    workflow_name: raw.workflow_name ?? null,
+    branch: raw.head_branch ?? null,
+    state: flattenRunState(raw.status, raw.conclusion),
+    event: raw.event ?? "",
+    run_attempt: raw.run_attempt ?? 1,
+    head_sha: raw.head_sha ?? "",
+    actor: raw.actor?.login ?? null,
+    created_at: raw.created_at ?? "",
+    updated_at: raw.updated_at ?? "",
+    run_started_at: raw.run_started_at ?? null,
+  };
+}
+
+// JSON-Schema fragment for run-id integers, reused across all
+// three tools that take one.
+export const runIdSchema = { type: "integer", minimum: 1 } as const;
+
+// Helper: read an HTTP status code off a thrown REST error
+// without dragging the full `@octokit/request-error` import
+// into every tool file.
+export function getStatus(err: unknown): number | undefined {
+  if (
+    typeof err === "object" &&
+    err !== null &&
+    "status" in err &&
+    typeof (err as RequestError).status === "number"
+  ) {
+    return (err as RequestError).status;
+  }
+  return undefined;
+}

--- a/src/tools/workflow/index.ts
+++ b/src/tools/workflow/index.ts
@@ -1,0 +1,26 @@
+// src/tools/workflow/index.ts
+//
+// Aggregator for the four gh.workflow_* tools. Differs from the
+// other domain aggregators in that the registrar takes
+// `authedRequest` (REST) rather than `graphql`: GitHub's GraphQL
+// coverage of Actions is incomplete, with no cancel mutation
+// and weak filter surface on the run list (see ./_shared.ts).
+
+import type { AuthedRequest } from "../../auth/octokit.js";
+import type { ToolEntry } from "../../registry.js";
+import { registerWorkflowRunCancelTool } from "./run_cancel.js";
+import { registerWorkflowRunJobsTool } from "./run_jobs.js";
+import { registerWorkflowRunViewTool } from "./run_view.js";
+import { registerWorkflowRunsListTool } from "./runs_list.js";
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+export function registerWorkflowTools(
+  register: RegisterToolFn,
+  authedRequest: AuthedRequest,
+): void {
+  registerWorkflowRunsListTool(register, authedRequest);
+  registerWorkflowRunViewTool(register, authedRequest);
+  registerWorkflowRunCancelTool(register, authedRequest);
+  registerWorkflowRunJobsTool(register, authedRequest);
+}

--- a/src/tools/workflow/run_cancel.ts
+++ b/src/tools/workflow/run_cancel.ts
@@ -74,8 +74,9 @@ export function registerWorkflowRunCancelTool(
     handler: async (raw) => {
       const args = validate<Input>(inputSchema, raw, "gh.workflow_run_cancel input");
       const coords = parseRepoSlug(args.repo, "gh.workflow_run_cancel input");
+      let response;
       try {
-        await authedRequest(
+        response = await authedRequest(
           "POST /repos/{owner}/{repo}/actions/runs/{run_id}/cancel",
           { owner: coords.owner, repo: coords.name, run_id: args.run_id },
         );
@@ -96,6 +97,16 @@ export function registerWorkflowRunCancelTool(
           );
         }
         throw err;
+      }
+      // Match the documented contract: \`cancelled: true\` corresponds
+      // to GitHub's HTTP 202 Accepted. Any non-202 success status
+      // (which would be unusual but technically possible) gets
+      // surfaced as a structured error so the output never claims
+      // a cancel was accepted when the response shape disagrees.
+      if (response.status !== 202) {
+        throw new Error(
+          `mcp-github: gh.workflow_run_cancel: unexpected HTTP ${response.status} on cancel; expected 202 Accepted`,
+        );
       }
       const out: Output = { cancelled: true, run_id: args.run_id };
       return validate<Output>(outputSchema, out, "gh.workflow_run_cancel output");

--- a/src/tools/workflow/run_cancel.ts
+++ b/src/tools/workflow/run_cancel.ts
@@ -1,0 +1,104 @@
+// src/tools/workflow/run_cancel.ts
+//
+// `gh.workflow_run_cancel` — cancels an in-flight workflow run.
+// REST `POST /repos/.../actions/runs/:id/cancel`. There is no
+// GraphQL mutation for this — the spec acknowledges that
+// "GraphQL coverage is incomplete" for Actions, and cancel is
+// the canonical example of the gap.
+//
+// REST returns 202 (Accepted) on a successful cancel request;
+// the cancellation is asynchronous, so the run's `state` won't
+// flip to `cancelled` immediately. Output `cancelled: true`
+// means "GitHub accepted the cancel request", not "the run is
+// in the cancelled state right now".
+
+import type { AuthedRequest } from "../../auth/octokit.js";
+import type { ToolEntry } from "../../registry.js";
+import { validate } from "../../validation/validator.js";
+import {
+  getStatus,
+  parseRepoSlug,
+  repoSlugSchema,
+  runIdSchema,
+} from "./_shared.js";
+
+const inputSchema = {
+  type: "object",
+  required: ["repo", "run_id"],
+  properties: {
+    repo: repoSlugSchema,
+    run_id: runIdSchema,
+  },
+  additionalProperties: false,
+} as const;
+
+const outputSchema = {
+  type: "object",
+  required: ["cancelled", "run_id"],
+  properties: {
+    cancelled: {
+      type: "boolean",
+      description:
+        "true means GitHub accepted the cancel request (HTTP 202). " +
+        "Cancellation is asynchronous; poll `gh.workflow_run_view` " +
+        "to observe the run transition into `cancelled` state.",
+    },
+    run_id: { type: "integer" },
+  },
+  additionalProperties: false,
+} as const;
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+interface Input {
+  repo: string;
+  run_id: number;
+}
+
+interface Output {
+  cancelled: boolean;
+  run_id: number;
+}
+
+export function registerWorkflowRunCancelTool(
+  register: RegisterToolFn,
+  authedRequest: AuthedRequest,
+): void {
+  register("gh.workflow_run_cancel", {
+    description:
+      "Cancel an in-flight Actions workflow run. POSTs to the REST " +
+      "cancel endpoint (no GraphQL equivalent exists). Returns " +
+      "`{cancelled: true, run_id}` on HTTP 202 — cancellation is " +
+      "asynchronous, so poll `gh.workflow_run_view` to confirm.",
+    inputSchema,
+    handler: async (raw) => {
+      const args = validate<Input>(inputSchema, raw, "gh.workflow_run_cancel input");
+      const coords = parseRepoSlug(args.repo, "gh.workflow_run_cancel input");
+      try {
+        await authedRequest(
+          "POST /repos/{owner}/{repo}/actions/runs/{run_id}/cancel",
+          { owner: coords.owner, repo: coords.name, run_id: args.run_id },
+        );
+      } catch (err) {
+        const status = getStatus(err);
+        if (status === 404) {
+          throw new Error(
+            `mcp-github: gh.workflow_run_cancel: run ${coords.owner}/${coords.name}#${args.run_id} not found`,
+          );
+        }
+        if (status === 409) {
+          // 409 Conflict: the run is already in a terminal state
+          // (completed, cancelled, etc.) and cannot be cancelled.
+          // Surface as a clean structured error rather than a
+          // generic RequestError.
+          throw new Error(
+            `mcp-github: gh.workflow_run_cancel: run ${coords.owner}/${coords.name}#${args.run_id} is already in a terminal state and cannot be cancelled`,
+          );
+        }
+        throw err;
+      }
+      const out: Output = { cancelled: true, run_id: args.run_id };
+      return validate<Output>(outputSchema, out, "gh.workflow_run_cancel output");
+    },
+  });
+}

--- a/src/tools/workflow/run_jobs.ts
+++ b/src/tools/workflow/run_jobs.ts
@@ -1,0 +1,224 @@
+// src/tools/workflow/run_jobs.ts
+//
+// `gh.workflow_run_jobs` — lists jobs for a workflow run with
+// step-level details. Differs from `run_view` by surfacing the
+// per-step status / conclusion / timestamps so callers can see
+// where in a run a failure happened.
+//
+// `attempt_number` defaults to the latest attempt; pass a
+// specific value to read a re-run's jobs.
+
+import type { AuthedRequest } from "../../auth/octokit.js";
+import type { ToolEntry } from "../../registry.js";
+import { validate } from "../../validation/validator.js";
+import {
+  type RunState,
+  flattenRunState,
+  getStatus,
+  parseRepoSlug,
+  repoSlugSchema,
+  runIdSchema,
+  runStateSchema,
+} from "./_shared.js";
+
+const inputSchema = {
+  type: "object",
+  required: ["repo", "run_id"],
+  properties: {
+    repo: repoSlugSchema,
+    run_id: runIdSchema,
+    attempt_number: {
+      type: "integer",
+      minimum: 1,
+      description:
+        "Attempt number to read jobs for. Omit for the latest attempt.",
+    },
+  },
+  additionalProperties: false,
+} as const;
+
+interface StepDetail {
+  name: string;
+  number: number;
+  state: RunState;
+  started_at: string | null;
+  completed_at: string | null;
+}
+
+const stepDetailSchema = {
+  type: "object",
+  required: ["name", "number", "state", "started_at", "completed_at"],
+  properties: {
+    name: { type: "string" },
+    number: { type: "integer", minimum: 1 },
+    state: runStateSchema,
+    started_at: { type: ["string", "null"] },
+    completed_at: { type: ["string", "null"] },
+  },
+  additionalProperties: false,
+} as const;
+
+interface JobDetail {
+  id: number;
+  name: string;
+  state: RunState;
+  started_at: string | null;
+  completed_at: string | null;
+  url: string;
+  attempt: number;
+  steps: StepDetail[];
+}
+
+const jobDetailSchema = {
+  type: "object",
+  required: [
+    "id",
+    "name",
+    "state",
+    "started_at",
+    "completed_at",
+    "url",
+    "attempt",
+    "steps",
+  ],
+  properties: {
+    id: { type: "integer" },
+    name: { type: "string" },
+    state: runStateSchema,
+    started_at: { type: ["string", "null"] },
+    completed_at: { type: ["string", "null"] },
+    url: { type: "string" },
+    attempt: { type: "integer", minimum: 1 },
+    steps: { type: "array", items: stepDetailSchema },
+  },
+  additionalProperties: false,
+} as const;
+
+const outputSchema = {
+  type: "object",
+  required: ["items", "total"],
+  properties: {
+    items: { type: "array", items: jobDetailSchema },
+    total: { type: "integer", minimum: 0 },
+  },
+  additionalProperties: false,
+} as const;
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+interface Input {
+  repo: string;
+  run_id: number;
+  attempt_number?: number;
+}
+
+interface Output {
+  items: JobDetail[];
+  total: number;
+}
+
+interface RawStep {
+  name: string;
+  number: number;
+  status?: string | null;
+  conclusion?: string | null;
+  started_at?: string | null;
+  completed_at?: string | null;
+}
+
+interface RawJob {
+  id: number;
+  name: string;
+  status: string | null;
+  conclusion: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  html_url?: string;
+  url?: string;
+  run_attempt?: number;
+  steps?: RawStep[];
+}
+
+interface JobsResponse {
+  total_count: number;
+  jobs: RawJob[];
+}
+
+export function registerWorkflowRunJobsTool(
+  register: RegisterToolFn,
+  authedRequest: AuthedRequest,
+): void {
+  register("gh.workflow_run_jobs", {
+    description:
+      "List jobs for a workflow run with step-level details. Use " +
+      "`attempt_number` to read jobs for a specific attempt; omit " +
+      "for the latest. Caps at 100 jobs (the REST endpoint's max).",
+    inputSchema,
+    handler: async (raw) => {
+      const args = validate<Input>(inputSchema, raw, "gh.workflow_run_jobs input");
+      const coords = parseRepoSlug(args.repo, "gh.workflow_run_jobs input");
+      const params: Record<string, string | number> = {
+        owner: coords.owner,
+        repo: coords.name,
+        run_id: args.run_id,
+        per_page: 100,
+      };
+      // The REST endpoint distinguishes between
+      //   GET .../runs/:id/jobs            → latest attempt
+      //   GET .../runs/:id/attempts/:n/jobs → specific attempt
+      // (`attempt_number` as a query param on the first URL was
+      // never honoured; use the dedicated route instead).
+      const url =
+        args.attempt_number === undefined
+          ? "GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs"
+          : "GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/jobs";
+      if (args.attempt_number !== undefined) {
+        params["attempt_number"] = args.attempt_number;
+      }
+      let response;
+      try {
+        // Same cast pattern as runs_list: Octokit's request
+        // narrows on the route string and our params object is
+        // too dynamic for that narrowing.
+        response = await authedRequest(
+          url,
+          params as unknown as { owner: string; repo: string; run_id: number },
+        );
+      } catch (err) {
+        if (getStatus(err) === 404) {
+          throw new Error(
+            `mcp-github: gh.workflow_run_jobs: run ${coords.owner}/${coords.name}#${args.run_id}` +
+              `${args.attempt_number !== undefined ? ` attempt ${args.attempt_number}` : ""}` +
+              ` not found`,
+          );
+        }
+        throw err;
+      }
+      const data = response.data as JobsResponse;
+      const out: Output = {
+        items: (data.jobs ?? []).map(buildJobDetail),
+        total: data.total_count,
+      };
+      return validate<Output>(outputSchema, out, "gh.workflow_run_jobs output");
+    },
+  });
+}
+
+function buildJobDetail(raw: RawJob): JobDetail {
+  return {
+    id: raw.id,
+    name: raw.name,
+    state: flattenRunState(raw.status, raw.conclusion),
+    started_at: raw.started_at,
+    completed_at: raw.completed_at,
+    url: raw.html_url ?? raw.url ?? "",
+    attempt: raw.run_attempt ?? 1,
+    steps: (raw.steps ?? []).map((s) => ({
+      name: s.name,
+      number: s.number,
+      state: flattenRunState(s.status, s.conclusion),
+      started_at: s.started_at ?? null,
+      completed_at: s.completed_at ?? null,
+    })),
+  };
+}

--- a/src/tools/workflow/run_jobs.ts
+++ b/src/tools/workflow/run_jobs.ts
@@ -33,6 +33,19 @@ const inputSchema = {
       description:
         "Attempt number to read jobs for. Omit for the latest attempt.",
     },
+    perPage: {
+      type: "integer",
+      minimum: 1,
+      maximum: 100,
+      description:
+        "Page size (1-100). Defaults to 100. The REST jobs endpoint " +
+        "is page-paginated; pass `page` to advance.",
+    },
+    page: {
+      type: "integer",
+      minimum: 1,
+      description: "1-indexed page number. Defaults to 1.",
+    },
   },
   additionalProperties: false,
 } as const;
@@ -96,10 +109,12 @@ const jobDetailSchema = {
 
 const outputSchema = {
   type: "object",
-  required: ["items", "total"],
+  required: ["items", "total", "hasNextPage", "page"],
   properties: {
     items: { type: "array", items: jobDetailSchema },
     total: { type: "integer", minimum: 0 },
+    hasNextPage: { type: "boolean" },
+    page: { type: "integer", minimum: 1 },
   },
   additionalProperties: false,
 } as const;
@@ -110,11 +125,15 @@ interface Input {
   repo: string;
   run_id: number;
   attempt_number?: number;
+  perPage?: number;
+  page?: number;
 }
 
 interface Output {
   items: JobDetail[];
   total: number;
+  hasNextPage: boolean;
+  page: number;
 }
 
 interface RawStep {
@@ -152,38 +171,45 @@ export function registerWorkflowRunJobsTool(
     description:
       "List jobs for a workflow run with step-level details. Use " +
       "`attempt_number` to read jobs for a specific attempt; omit " +
-      "for the latest. Caps at 100 jobs (the REST endpoint's max).",
+      "for the latest. Page-paginated via `page`/`perPage` (max 100); " +
+      "check `hasNextPage` to detect more results.",
     inputSchema,
     handler: async (raw) => {
       const args = validate<Input>(inputSchema, raw, "gh.workflow_run_jobs input");
       const coords = parseRepoSlug(args.repo, "gh.workflow_run_jobs input");
-      const params: Record<string, string | number> = {
-        owner: coords.owner,
-        repo: coords.name,
-        run_id: args.run_id,
-        per_page: 100,
-      };
+      const perPage = args.perPage ?? 100;
+      const page = args.page ?? 1;
       // The REST endpoint distinguishes between
       //   GET .../runs/:id/jobs            → latest attempt
       //   GET .../runs/:id/attempts/:n/jobs → specific attempt
       // (`attempt_number` as a query param on the first URL was
       // never honoured; use the dedicated route instead).
-      const url =
-        args.attempt_number === undefined
-          ? "GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs"
-          : "GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/jobs";
-      if (args.attempt_number !== undefined) {
-        params["attempt_number"] = args.attempt_number;
-      }
       let response;
       try {
-        // Same cast pattern as runs_list: Octokit's request
-        // narrows on the route string and our params object is
-        // too dynamic for that narrowing.
-        response = await authedRequest(
-          url,
-          params as unknown as { owner: string; repo: string; run_id: number },
-        );
+        if (args.attempt_number === undefined) {
+          response = await authedRequest(
+            "GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs",
+            {
+              owner: coords.owner,
+              repo: coords.name,
+              run_id: args.run_id,
+              per_page: perPage,
+              page,
+            },
+          );
+        } else {
+          response = await authedRequest(
+            "GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/jobs",
+            {
+              owner: coords.owner,
+              repo: coords.name,
+              run_id: args.run_id,
+              attempt_number: args.attempt_number,
+              per_page: perPage,
+              page,
+            },
+          );
+        }
       } catch (err) {
         if (getStatus(err) === 404) {
           throw new Error(
@@ -195,9 +221,14 @@ export function registerWorkflowRunJobsTool(
         throw err;
       }
       const data = response.data as JobsResponse;
+      const items = (data.jobs ?? []).map(buildJobDetail);
       const out: Output = {
-        items: (data.jobs ?? []).map(buildJobDetail),
+        items,
         total: data.total_count,
+        // Same hasNextPage approach as runs_list: page * per_page
+        // < total_count means there's another page available.
+        hasNextPage: page * perPage < data.total_count,
+        page,
       };
       return validate<Output>(outputSchema, out, "gh.workflow_run_jobs output");
     },

--- a/src/tools/workflow/run_view.ts
+++ b/src/tools/workflow/run_view.ts
@@ -1,0 +1,171 @@
+// src/tools/workflow/run_view.ts
+//
+// `gh.workflow_run_view` — fetches a single workflow run plus a
+// jobs summary. Two REST calls (one for the run, one for the
+// jobs of the latest attempt). Output stays flat — the run
+// summary at the top, an array of jobs alongside it.
+
+import type { AuthedRequest } from "../../auth/octokit.js";
+import type { ToolEntry } from "../../registry.js";
+import { validate } from "../../validation/validator.js";
+import {
+  type RawRun,
+  type RunState,
+  type RunSummary,
+  flattenRunState,
+  getStatus,
+  parseRepoSlug,
+  repoSlugSchema,
+  runIdSchema,
+  runStateSchema,
+  runSummarySchema,
+  summariseRun,
+} from "./_shared.js";
+
+const inputSchema = {
+  type: "object",
+  required: ["repo", "run_id"],
+  properties: {
+    repo: repoSlugSchema,
+    run_id: runIdSchema,
+  },
+  additionalProperties: false,
+} as const;
+
+interface JobSummary {
+  id: number;
+  name: string;
+  state: RunState;
+  started_at: string | null;
+  completed_at: string | null;
+  url: string;
+  steps_completed: number;
+  steps_total: number;
+}
+
+const jobSummarySchema = {
+  type: "object",
+  required: [
+    "id",
+    "name",
+    "state",
+    "started_at",
+    "completed_at",
+    "url",
+    "steps_completed",
+    "steps_total",
+  ],
+  properties: {
+    id: { type: "integer" },
+    name: { type: "string" },
+    state: runStateSchema,
+    started_at: { type: ["string", "null"] },
+    completed_at: { type: ["string", "null"] },
+    url: { type: "string" },
+    steps_completed: { type: "integer", minimum: 0 },
+    steps_total: { type: "integer", minimum: 0 },
+  },
+  additionalProperties: false,
+} as const;
+
+const outputSchema = {
+  type: "object",
+  required: ["run", "jobs"],
+  properties: {
+    run: runSummarySchema,
+    jobs: { type: "array", items: jobSummarySchema },
+  },
+  additionalProperties: false,
+} as const;
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+interface Input {
+  repo: string;
+  run_id: number;
+}
+
+interface Output {
+  run: RunSummary;
+  jobs: JobSummary[];
+}
+
+interface RawJobStep {
+  status?: string | null;
+  conclusion?: string | null;
+}
+
+interface RawJob {
+  id: number;
+  name: string;
+  status: string | null;
+  conclusion: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  html_url?: string;
+  url?: string;
+  steps?: RawJobStep[];
+}
+
+interface JobsResponse {
+  total_count: number;
+  jobs: RawJob[];
+}
+
+export function registerWorkflowRunViewTool(
+  register: RegisterToolFn,
+  authedRequest: AuthedRequest,
+): void {
+  register("gh.workflow_run_view", {
+    description:
+      "Fetch a single Actions workflow run plus a summary of its " +
+      "jobs (id, state, timestamps, step counts). Two REST calls " +
+      "under the hood: GET .../runs/:id and GET .../runs/:id/jobs.",
+    inputSchema,
+    handler: async (raw) => {
+      const args = validate<Input>(inputSchema, raw, "gh.workflow_run_view input");
+      const coords = parseRepoSlug(args.repo, "gh.workflow_run_view input");
+      let runResp;
+      try {
+        runResp = await authedRequest(
+          "GET /repos/{owner}/{repo}/actions/runs/{run_id}",
+          { owner: coords.owner, repo: coords.name, run_id: args.run_id },
+        );
+      } catch (err) {
+        // Translate 404 into a structured "not found" so the
+        // caller distinguishes it from a transport-level
+        // failure.
+        if (getStatus(err) === 404) {
+          throw new Error(
+            `mcp-github: gh.workflow_run_view: run ${coords.owner}/${coords.name}#${args.run_id} not found`,
+          );
+        }
+        throw err;
+      }
+      const jobsResp = await authedRequest(
+        "GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs",
+        { owner: coords.owner, repo: coords.name, run_id: args.run_id, per_page: 100 },
+      );
+      const out: Output = {
+        run: summariseRun(runResp.data as RawRun),
+        jobs: ((jobsResp.data as JobsResponse).jobs ?? []).map(summariseJob),
+      };
+      return validate<Output>(outputSchema, out, "gh.workflow_run_view output");
+    },
+  });
+}
+
+function summariseJob(raw: RawJob): JobSummary {
+  const steps = raw.steps ?? [];
+  const completed = steps.filter((s) => s.status === "completed").length;
+  return {
+    id: raw.id,
+    name: raw.name,
+    state: flattenRunState(raw.status, raw.conclusion),
+    started_at: raw.started_at,
+    completed_at: raw.completed_at,
+    url: raw.html_url ?? raw.url ?? "",
+    steps_completed: completed,
+    steps_total: steps.length,
+  };
+}

--- a/src/tools/workflow/run_view.ts
+++ b/src/tools/workflow/run_view.ts
@@ -70,10 +70,22 @@ const jobSummarySchema = {
 
 const outputSchema = {
   type: "object",
-  required: ["run", "jobs"],
+  required: ["run", "jobs", "jobs_total", "jobs_has_next_page"],
   properties: {
     run: runSummarySchema,
     jobs: { type: "array", items: jobSummarySchema },
+    jobs_total: {
+      type: "integer",
+      minimum: 0,
+      description: "Total jobs across all pages (`total_count` from the API).",
+    },
+    jobs_has_next_page: {
+      type: "boolean",
+      description:
+        "true when the run has more jobs than this single page returned " +
+        "(jobs are capped at 100 per page). Use `gh.workflow_run_jobs` to " +
+        "paginate through the rest.",
+    },
   },
   additionalProperties: false,
 } as const;
@@ -88,6 +100,8 @@ interface Input {
 interface Output {
   run: RunSummary;
   jobs: JobSummary[];
+  jobs_total: number;
+  jobs_has_next_page: boolean;
 }
 
 interface RawJobStep {
@@ -120,7 +134,9 @@ export function registerWorkflowRunViewTool(
     description:
       "Fetch a single Actions workflow run plus a summary of its " +
       "jobs (id, state, timestamps, step counts). Two REST calls " +
-      "under the hood: GET .../runs/:id and GET .../runs/:id/jobs.",
+      "under the hood: GET .../runs/:id and GET .../runs/:id/jobs. " +
+      "Jobs are capped at 100 per page; check `jobs_has_next_page` " +
+      "and use `gh.workflow_run_jobs` to paginate the remainder.",
     inputSchema,
     handler: async (raw) => {
       const args = validate<Input>(inputSchema, raw, "gh.workflow_run_view input");
@@ -146,9 +162,13 @@ export function registerWorkflowRunViewTool(
         "GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs",
         { owner: coords.owner, repo: coords.name, run_id: args.run_id, per_page: 100 },
       );
+      const jobsData = jobsResp.data as JobsResponse;
+      const jobs = (jobsData.jobs ?? []).map(summariseJob);
       const out: Output = {
         run: summariseRun(runResp.data as RawRun),
-        jobs: ((jobsResp.data as JobsResponse).jobs ?? []).map(summariseJob),
+        jobs,
+        jobs_total: jobsData.total_count,
+        jobs_has_next_page: jobsData.total_count > jobs.length,
       };
       return validate<Output>(outputSchema, out, "gh.workflow_run_view output");
     },

--- a/src/tools/workflow/runs_list.ts
+++ b/src/tools/workflow/runs_list.ts
@@ -1,0 +1,153 @@
+// src/tools/workflow/runs_list.ts
+//
+// `gh.workflow_runs_list` — paginated list of Actions workflow
+// runs in a repo, optionally filtered by branch / status. Calls
+// REST `GET /repos/:o/:r/actions/runs` because GraphQL's filter
+// surface for runs is too narrow (no branch/status filter on
+// `Repository.workflows.runs`). Output flattens the REST
+// status/conclusion pair onto the canonical `RunState` enum so
+// consumers don't have to branch on both fields.
+
+import type { AuthedRequest } from "../../auth/octokit.js";
+import type { ToolEntry } from "../../registry.js";
+import { validate } from "../../validation/validator.js";
+import {
+  type RawRun,
+  type RunSummary,
+  parseRepoSlug,
+  repoSlugSchema,
+  runSummarySchema,
+  summariseRun,
+} from "./_shared.js";
+
+const PER_PAGE_DEFAULT = 30;
+const PER_PAGE_MAX = 100;
+
+const inputSchema = {
+  type: "object",
+  required: ["repo"],
+  properties: {
+    repo: repoSlugSchema,
+    branch: {
+      type: "string",
+      minLength: 1,
+      description: "Filter to runs whose head branch matches.",
+    },
+    status: {
+      // The REST `status` query parameter accepts BOTH the raw
+      // `status` (queued | in_progress | completed) AND specific
+      // `conclusion` shorthand values (success | failure | etc.)
+      // — passing one filters the underlying list. Mirror the
+      // canonical `RunState` so callers don't have to know the
+      // distinction.
+      type: "string",
+      enum: [
+        "queued",
+        "in_progress",
+        "completed",
+        "success",
+        "failure",
+        "cancelled",
+        "skipped",
+        "timed_out",
+        "action_required",
+        "neutral",
+      ],
+    },
+    perPage: { type: "integer", minimum: 1, maximum: PER_PAGE_MAX },
+    page: {
+      type: "integer",
+      minimum: 1,
+      description:
+        "1-indexed page number. REST workflow-runs uses page-based " +
+        "pagination, not opaque cursors.",
+    },
+  },
+  additionalProperties: false,
+} as const;
+
+const outputSchema = {
+  type: "object",
+  required: ["items", "total", "hasNextPage", "page"],
+  properties: {
+    items: { type: "array", items: runSummarySchema },
+    total: {
+      type: "integer",
+      description: "Total runs across all pages (`total_count` from the API).",
+    },
+    hasNextPage: { type: "boolean" },
+    page: { type: "integer", minimum: 1 },
+  },
+  additionalProperties: false,
+} as const;
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+interface Input {
+  repo: string;
+  branch?: string;
+  status?: string;
+  perPage?: number;
+  page?: number;
+}
+
+interface Output {
+  items: RunSummary[];
+  total: number;
+  hasNextPage: boolean;
+  page: number;
+}
+
+interface Response {
+  total_count: number;
+  workflow_runs: RawRun[];
+}
+
+export function registerWorkflowRunsListTool(
+  register: RegisterToolFn,
+  authedRequest: AuthedRequest,
+): void {
+  register("gh.workflow_runs_list", {
+    description:
+      "List Actions workflow runs in a repo, optionally filtered " +
+      "by branch / status. `status` accepts both the raw status " +
+      "(queued|in_progress|completed) and a conclusion " +
+      "(success|failure|cancelled|skipped|timed_out|action_required|" +
+      "neutral). Returns one page; advance via `page`.",
+    inputSchema,
+    handler: async (raw) => {
+      const args = validate<Input>(inputSchema, raw, "gh.workflow_runs_list input");
+      const coords = parseRepoSlug(args.repo, "gh.workflow_runs_list input");
+      const params: Record<string, string | number> = {
+        owner: coords.owner,
+        repo: coords.name,
+        per_page: args.perPage ?? PER_PAGE_DEFAULT,
+        page: args.page ?? 1,
+      };
+      if (args.branch !== undefined) params["branch"] = args.branch;
+      if (args.status !== undefined) params["status"] = args.status;
+      // Cast through `unknown` because Octokit's request type
+      // narrows by route string and our incrementally-built
+      // params object is too dynamic for that narrowing — every
+      // value is a valid GET-query primitive at runtime, so the
+      // cast is sound.
+      const response = await authedRequest(
+        "GET /repos/{owner}/{repo}/actions/runs",
+        params as unknown as { owner: string; repo: string },
+      );
+      const data = response.data as Response;
+      const out: Output = {
+        items: data.workflow_runs.map(summariseRun),
+        total: data.total_count,
+        // REST returns Link headers for next/prev; computing
+        // hasNextPage from `total_count` and the current page +
+        // per_page is simpler and avoids parsing the header.
+        hasNextPage:
+          (params["page"] as number) * (params["per_page"] as number) <
+          data.total_count,
+        page: params["page"] as number,
+      };
+      return validate<Output>(outputSchema, out, "gh.workflow_runs_list output");
+    },
+  });
+}

--- a/tests/smoke/server-lists-tools.mjs
+++ b/tests/smoke/server-lists-tools.mjs
@@ -50,6 +50,10 @@ const EXPECTED_TOOLS = [
   "gh.pr_comment",
   "gh.pr_merge",
   "gh.pr_request_reviews",
+  "gh.workflow_runs_list",
+  "gh.workflow_run_view",
+  "gh.workflow_run_cancel",
+  "gh.workflow_run_jobs",
 ];
 
 function frame(payload) {

--- a/tests/unit/tools/workflow/_fixtures.ts
+++ b/tests/unit/tools/workflow/_fixtures.ts
@@ -13,9 +13,14 @@ export interface RestCall {
   params: Record<string, unknown>;
 }
 
+// Envelope every fixture goes through when a test wants to
+// pin a non-200 status. `status` is REQUIRED so the runtime
+// guard `isStubResponse()` and the static type agree on the
+// invariant — a `{ data: ... }`-only literal is treated as raw
+// data, never as a malformed envelope.
 interface StubResponse {
   data: unknown;
-  status?: number;
+  status: number;
 }
 
 // Wrap a fixture in `withStatus` to override the default 200
@@ -71,7 +76,7 @@ export function stubAuthedRequest(
     if (isStubResponse(resolved)) {
       return {
         data: resolved.data,
-        status: resolved.status ?? 200,
+        status: resolved.status,
         headers: {},
         url: route,
       };

--- a/tests/unit/tools/workflow/_fixtures.ts
+++ b/tests/unit/tools/workflow/_fixtures.ts
@@ -18,11 +18,29 @@ interface StubResponse {
   status?: number;
 }
 
+// Wrap a fixture in `withStatus` to override the default 200
+// response status — used by the cancel test where the handler
+// asserts on a specific HTTP 202.
+export function withStatus(status: number, data: unknown): StubResponse {
+  return { data, status };
+}
+
+function isStubResponse(v: unknown): v is StubResponse {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    "data" in v &&
+    "status" in v &&
+    typeof (v as { status: unknown }).status === "number"
+  );
+}
+
 // Build an `authedRequest` stub that dispatches by route string.
-// Each entry is either a value (returned directly as `data`) or
-// a function (called with the request params). Routes outside
-// the fixture map throw — every test must declare every endpoint
-// its handler will hit.
+// Each entry is either a value (returned directly as `data`), a
+// `{ data, status }` envelope (via `withStatus`), or a function
+// (called with the request params, returning either shape).
+// Routes outside the fixture map throw — every test must declare
+// every endpoint its handler will hit.
 export function stubAuthedRequest(
   fixtures: Record<
     string,
@@ -42,15 +60,23 @@ export function stubAuthedRequest(
       );
     }
     const entry = fixtures[route];
-    let data: unknown;
+    let resolved: unknown;
     if (typeof entry === "function") {
-      data = await (entry as (p: Record<string, unknown>) => unknown)(
+      resolved = await (entry as (p: Record<string, unknown>) => unknown)(
         params,
       );
     } else {
-      data = entry;
+      resolved = entry;
     }
-    return { data, status: 200, headers: {}, url: route } as StubResponse;
+    if (isStubResponse(resolved)) {
+      return {
+        data: resolved.data,
+        status: resolved.status ?? 200,
+        headers: {},
+        url: route,
+      };
+    }
+    return { data: resolved, status: 200, headers: {}, url: route };
   }) as unknown as AuthedRequest;
   return { authedRequest, calls };
 }

--- a/tests/unit/tools/workflow/_fixtures.ts
+++ b/tests/unit/tools/workflow/_fixtures.ts
@@ -1,0 +1,117 @@
+// tests/unit/tools/workflow/_fixtures.ts
+//
+// Stub helpers for the gh.workflow_* tool tests. Workflow tools
+// take an `AuthedRequest` (REST) rather than a `GraphqlClient`,
+// so the stub shape differs from the issue/pr/label fixtures:
+// dispatch by HTTP method + path, return `{ data, headers,
+// status }`.
+
+import type { AuthedRequest } from "../../../../src/auth/octokit.ts";
+
+export interface RestCall {
+  route: string;
+  params: Record<string, unknown>;
+}
+
+interface StubResponse {
+  data: unknown;
+  status?: number;
+}
+
+// Build an `authedRequest` stub that dispatches by route string.
+// Each entry is either a value (returned directly as `data`) or
+// a function (called with the request params). Routes outside
+// the fixture map throw — every test must declare every endpoint
+// its handler will hit.
+export function stubAuthedRequest(
+  fixtures: Record<
+    string,
+    | unknown
+    | ((params: Record<string, unknown>) => unknown | Promise<unknown>)
+  >,
+): { authedRequest: AuthedRequest; calls: RestCall[] } {
+  const calls: RestCall[] = [];
+  const authedRequest = (async (
+    route: string,
+    params: Record<string, unknown> = {},
+  ) => {
+    calls.push({ route, params });
+    if (!(route in fixtures)) {
+      throw new Error(
+        `tests: stubAuthedRequest saw unmocked route: ${route}`,
+      );
+    }
+    const entry = fixtures[route];
+    let data: unknown;
+    if (typeof entry === "function") {
+      data = await (entry as (p: Record<string, unknown>) => unknown)(
+        params,
+      );
+    } else {
+      data = entry;
+    }
+    return { data, status: 200, headers: {}, url: route } as StubResponse;
+  }) as unknown as AuthedRequest;
+  return { authedRequest, calls };
+}
+
+// Build a stub that throws an HTTP error with a given status
+// code. Used to exercise the 404 / 409 branches in the workflow
+// handlers without dragging the full @octokit/request-error
+// shape into every test.
+export function httpError(status: number, message = `HTTP ${status}`): Error {
+  const err = new Error(message) as Error & { status: number };
+  err.status = status;
+  return err;
+}
+
+// Canonical RawRun fixture — override fields per test by spread.
+export const sampleRawRun = {
+  id: 5_000_000_001,
+  html_url: "https://github.com/owner/repo/actions/runs/5000000001",
+  url: "https://api.github.com/repos/owner/repo/actions/runs/5000000001",
+  name: "CI",
+  display_title: "feat: thing",
+  workflow_name: "ci.yml",
+  head_branch: "feat/x",
+  status: "completed",
+  conclusion: "success",
+  event: "pull_request",
+  run_attempt: 1,
+  head_sha: "deadbeef",
+  actor: { login: "alice" },
+  created_at: "2026-04-01T00:00:00Z",
+  updated_at: "2026-04-01T00:01:30Z",
+  run_started_at: "2026-04-01T00:00:30Z",
+};
+
+// Canonical RawJob fixture used by run_view + run_jobs tests.
+export const sampleRawJob = {
+  id: 9_000_000_001,
+  name: "build",
+  status: "completed",
+  conclusion: "success",
+  started_at: "2026-04-01T00:00:30Z",
+  completed_at: "2026-04-01T00:01:25Z",
+  html_url: "https://github.com/owner/repo/actions/runs/5000000001/jobs/9000000001",
+  url: "https://api.github.com/repos/owner/repo/actions/jobs/9000000001",
+  run_attempt: 1,
+  steps: [
+    {
+      name: "Set up job",
+      number: 1,
+      status: "completed",
+      conclusion: "success",
+      started_at: "2026-04-01T00:00:30Z",
+      completed_at: "2026-04-01T00:00:35Z",
+    },
+    {
+      name: "Run tests",
+      number: 2,
+      status: "completed",
+      conclusion: "success",
+      started_at: "2026-04-01T00:00:35Z",
+      completed_at: "2026-04-01T00:01:25Z",
+    },
+  ],
+};

--- a/tests/unit/tools/workflow/run_cancel.test.ts
+++ b/tests/unit/tools/workflow/run_cancel.test.ts
@@ -1,0 +1,94 @@
+// tests/unit/tools/workflow/run_cancel.test.ts
+//
+// gh.workflow_run_cancel: pin the POST + 202 happy path, the
+// 404 / 409 → structured error translations, and the
+// asynchronous-cancellation contract documented in the tool
+// description.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { registerWorkflowRunCancelTool } from "../../../../src/tools/workflow/run_cancel.ts";
+import type { ToolEntry } from "../../../../src/registry.ts";
+import { httpError, stubAuthedRequest } from "./_fixtures.ts";
+
+function captureRegistration() {
+  let entry: ToolEntry | undefined;
+  const register = (name: string, e: ToolEntry) => {
+    if (name !== "gh.workflow_run_cancel") throw new Error(`unexpected: ${name}`);
+    entry = e;
+  };
+  return {
+    register,
+    get entry(): ToolEntry {
+      if (!entry) throw new Error("not registered");
+      return entry;
+    },
+  };
+}
+
+test("gh.workflow_run_cancel: POSTs to the cancel endpoint, returns {cancelled: true, run_id}", async () => {
+  const { authedRequest, calls } = stubAuthedRequest({
+    // REST returns an empty body on 202 Accepted; we don't
+    // read it.
+    "POST /repos/{owner}/{repo}/actions/runs/{run_id}/cancel": {},
+  });
+  const reg = captureRegistration();
+  registerWorkflowRunCancelTool(reg.register, authedRequest);
+  const out = await reg.entry.handler({
+    repo: "owner/repo",
+    run_id: 5_000_000_001,
+  });
+  assert.deepEqual(out, { cancelled: true, run_id: 5_000_000_001 });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]?.params.run_id, 5_000_000_001);
+});
+
+test("gh.workflow_run_cancel: 404 → 'run not found'", async () => {
+  const { authedRequest } = stubAuthedRequest({
+    "POST /repos/{owner}/{repo}/actions/runs/{run_id}/cancel": () => {
+      throw httpError(404);
+    },
+  });
+  const reg = captureRegistration();
+  registerWorkflowRunCancelTool(reg.register, authedRequest);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", run_id: 99 }),
+    /run owner\/repo#99 not found/,
+  );
+});
+
+test("gh.workflow_run_cancel: 409 → 'already in a terminal state'", async () => {
+  // 409 Conflict happens when the caller tries to cancel a run
+  // that has already completed / cancelled / errored. Translate
+  // to a clean message — the generic GitHub 409 body would
+  // otherwise look like a transport problem.
+  const { authedRequest } = stubAuthedRequest({
+    "POST /repos/{owner}/{repo}/actions/runs/{run_id}/cancel": () => {
+      throw httpError(409);
+    },
+  });
+  const reg = captureRegistration();
+  registerWorkflowRunCancelTool(reg.register, authedRequest);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", run_id: 1 }),
+    /already in a terminal state and cannot be cancelled/,
+  );
+});
+
+test("gh.workflow_run_cancel: other HTTP errors propagate unchanged", async () => {
+  // 5xx and other unexpected statuses should bubble up as-is so
+  // the caller sees the original error rather than a wrapped
+  // tool-scoped one.
+  const { authedRequest } = stubAuthedRequest({
+    "POST /repos/{owner}/{repo}/actions/runs/{run_id}/cancel": () => {
+      throw httpError(503, "Service Unavailable");
+    },
+  });
+  const reg = captureRegistration();
+  registerWorkflowRunCancelTool(reg.register, authedRequest);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", run_id: 1 }),
+    /Service Unavailable/,
+  );
+});

--- a/tests/unit/tools/workflow/run_cancel.test.ts
+++ b/tests/unit/tools/workflow/run_cancel.test.ts
@@ -10,7 +10,7 @@ import assert from "node:assert/strict";
 
 import { registerWorkflowRunCancelTool } from "../../../../src/tools/workflow/run_cancel.ts";
 import type { ToolEntry } from "../../../../src/registry.ts";
-import { httpError, stubAuthedRequest } from "./_fixtures.ts";
+import { httpError, stubAuthedRequest, withStatus } from "./_fixtures.ts";
 
 function captureRegistration() {
   let entry: ToolEntry | undefined;
@@ -30,8 +30,8 @@ function captureRegistration() {
 test("gh.workflow_run_cancel: POSTs to the cancel endpoint, returns {cancelled: true, run_id}", async () => {
   const { authedRequest, calls } = stubAuthedRequest({
     // REST returns an empty body on 202 Accepted; we don't
-    // read it.
-    "POST /repos/{owner}/{repo}/actions/runs/{run_id}/cancel": {},
+    // read it. The handler asserts on the 202 status itself.
+    "POST /repos/{owner}/{repo}/actions/runs/{run_id}/cancel": withStatus(202, {}),
   });
   const reg = captureRegistration();
   registerWorkflowRunCancelTool(reg.register, authedRequest);
@@ -42,6 +42,22 @@ test("gh.workflow_run_cancel: POSTs to the cancel endpoint, returns {cancelled: 
   assert.deepEqual(out, { cancelled: true, run_id: 5_000_000_001 });
   assert.equal(calls.length, 1);
   assert.equal(calls[0]?.params.run_id, 5_000_000_001);
+});
+
+test("gh.workflow_run_cancel: non-202 success status throws structured error", async () => {
+  // Defensive: GitHub's contract is 202 Accepted on cancel. Any
+  // other 2xx success would mean the API changed shape; we
+  // refuse to claim cancelled:true on a response we don't
+  // recognise.
+  const { authedRequest } = stubAuthedRequest({
+    "POST /repos/{owner}/{repo}/actions/runs/{run_id}/cancel": withStatus(200, {}),
+  });
+  const reg = captureRegistration();
+  registerWorkflowRunCancelTool(reg.register, authedRequest);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", run_id: 1 }),
+    /unexpected HTTP 200 on cancel; expected 202 Accepted/,
+  );
 });
 
 test("gh.workflow_run_cancel: 404 → 'run not found'", async () => {

--- a/tests/unit/tools/workflow/run_jobs.test.ts
+++ b/tests/unit/tools/workflow/run_jobs.test.ts
@@ -44,13 +44,40 @@ test("gh.workflow_run_jobs: omitting attempt_number hits the latest-attempt rout
   })) as {
     items: Array<{ id: number; steps: Array<{ name: string; state: string }> }>;
     total: number;
+    hasNextPage: boolean;
+    page: number;
   };
   assert.equal(out.total, 1);
   assert.equal(out.items[0]?.id, 9_000_000_001);
   assert.equal(out.items[0]?.steps.length, 2);
   assert.equal(out.items[0]?.steps[0]?.name, "Set up job");
   assert.equal(out.items[0]?.steps[0]?.state, "success");
+  assert.equal(out.hasNextPage, false);
+  assert.equal(out.page, 1);
   assert.equal(calls[0]?.route, "GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs");
+});
+
+test("gh.workflow_run_jobs: page/perPage forwarded; hasNextPage true when more results exist", async () => {
+  const { authedRequest, calls } = stubAuthedRequest({
+    "GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs": {
+      total_count: 250,
+      jobs: [sampleRawJob],
+    },
+  });
+  const reg = captureRegistration();
+  registerWorkflowRunJobsTool(reg.register, authedRequest);
+  const out = (await reg.entry.handler({
+    repo: "owner/repo",
+    run_id: 5_000_000_001,
+    page: 2,
+    perPage: 50,
+  })) as { total: number; hasNextPage: boolean; page: number };
+  assert.equal(calls[0]?.params.page, 2);
+  assert.equal(calls[0]?.params.per_page, 50);
+  assert.equal(out.total, 250);
+  // page 2 of 50 = 100 < 250, so there is more
+  assert.equal(out.hasNextPage, true);
+  assert.equal(out.page, 2);
 });
 
 test("gh.workflow_run_jobs: attempt_number switches to the dedicated attempts route", async () => {

--- a/tests/unit/tools/workflow/run_jobs.test.ts
+++ b/tests/unit/tools/workflow/run_jobs.test.ts
@@ -1,0 +1,123 @@
+// tests/unit/tools/workflow/run_jobs.test.ts
+//
+// gh.workflow_run_jobs: pin the per-attempt route switching, the
+// step-level detail, and the 404 → structured error.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { registerWorkflowRunJobsTool } from "../../../../src/tools/workflow/run_jobs.ts";
+import type { ToolEntry } from "../../../../src/registry.ts";
+import {
+  httpError,
+  sampleRawJob,
+  stubAuthedRequest,
+} from "./_fixtures.ts";
+
+function captureRegistration() {
+  let entry: ToolEntry | undefined;
+  const register = (name: string, e: ToolEntry) => {
+    if (name !== "gh.workflow_run_jobs") throw new Error(`unexpected: ${name}`);
+    entry = e;
+  };
+  return {
+    register,
+    get entry(): ToolEntry {
+      if (!entry) throw new Error("not registered");
+      return entry;
+    },
+  };
+}
+
+test("gh.workflow_run_jobs: omitting attempt_number hits the latest-attempt route", async () => {
+  const { authedRequest, calls } = stubAuthedRequest({
+    "GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs": {
+      total_count: 1,
+      jobs: [sampleRawJob],
+    },
+  });
+  const reg = captureRegistration();
+  registerWorkflowRunJobsTool(reg.register, authedRequest);
+  const out = (await reg.entry.handler({
+    repo: "owner/repo",
+    run_id: 5_000_000_001,
+  })) as {
+    items: Array<{ id: number; steps: Array<{ name: string; state: string }> }>;
+    total: number;
+  };
+  assert.equal(out.total, 1);
+  assert.equal(out.items[0]?.id, 9_000_000_001);
+  assert.equal(out.items[0]?.steps.length, 2);
+  assert.equal(out.items[0]?.steps[0]?.name, "Set up job");
+  assert.equal(out.items[0]?.steps[0]?.state, "success");
+  assert.equal(calls[0]?.route, "GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs");
+});
+
+test("gh.workflow_run_jobs: attempt_number switches to the dedicated attempts route", async () => {
+  // The REST API has TWO endpoints here. The query-param form
+  // on the latest-attempt route doesn't honour `attempt_number`;
+  // a specific attempt requires the dedicated path. Pin which
+  // route gets called.
+  const { authedRequest, calls } = stubAuthedRequest({
+    "GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/jobs": {
+      total_count: 1,
+      jobs: [sampleRawJob],
+    },
+  });
+  const reg = captureRegistration();
+  registerWorkflowRunJobsTool(reg.register, authedRequest);
+  await reg.entry.handler({
+    repo: "owner/repo",
+    run_id: 5_000_000_001,
+    attempt_number: 2,
+  });
+  assert.equal(
+    calls[0]?.route,
+    "GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/jobs",
+  );
+  assert.equal(calls[0]?.params.attempt_number, 2);
+});
+
+test("gh.workflow_run_jobs: failed step in a job surfaces state: failure on the step", async () => {
+  const failedStep = {
+    ...sampleRawJob,
+    steps: [
+      {
+        ...sampleRawJob.steps[0],
+        status: "completed",
+        conclusion: "failure",
+      },
+    ],
+  };
+  const { authedRequest } = stubAuthedRequest({
+    "GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs": {
+      total_count: 1,
+      jobs: [failedStep],
+    },
+  });
+  const reg = captureRegistration();
+  registerWorkflowRunJobsTool(reg.register, authedRequest);
+  const out = (await reg.entry.handler({
+    repo: "owner/repo",
+    run_id: 1,
+  })) as { items: Array<{ steps: Array<{ state: string }> }> };
+  assert.equal(out.items[0]?.steps[0]?.state, "failure");
+});
+
+test("gh.workflow_run_jobs: 404 → structured 'run/attempt not found'", async () => {
+  const { authedRequest } = stubAuthedRequest({
+    "GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/jobs": () => {
+      throw httpError(404);
+    },
+  });
+  const reg = captureRegistration();
+  registerWorkflowRunJobsTool(reg.register, authedRequest);
+  await assert.rejects(
+    reg.entry.handler({
+      repo: "owner/repo",
+      run_id: 99,
+      attempt_number: 7,
+    }),
+    /run owner\/repo#99 attempt 7 not found/,
+  );
+});

--- a/tests/unit/tools/workflow/run_view.test.ts
+++ b/tests/unit/tools/workflow/run_view.test.ts
@@ -52,6 +52,8 @@ test("gh.workflow_run_view: returns run + jobs summary in two REST calls", async
       steps_completed: number;
       steps_total: number;
     }>;
+    jobs_total: number;
+    jobs_has_next_page: boolean;
   };
   assert.equal(out.run.id, 5_000_000_001);
   assert.equal(out.run.state, "success");
@@ -60,7 +62,28 @@ test("gh.workflow_run_view: returns run + jobs summary in two REST calls", async
   assert.equal(out.jobs[0]?.state, "success");
   assert.equal(out.jobs[0]?.steps_completed, 2);
   assert.equal(out.jobs[0]?.steps_total, 2);
+  assert.equal(out.jobs_total, 1);
+  assert.equal(out.jobs_has_next_page, false);
   assert.equal(calls.length, 2);
+});
+
+test("gh.workflow_run_view: jobs_has_next_page=true when total_count exceeds returned page", async () => {
+  const { authedRequest } = stubAuthedRequest({
+    "GET /repos/{owner}/{repo}/actions/runs/{run_id}": sampleRawRun,
+    "GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs": {
+      // total_count > the single returned job → there is another page
+      total_count: 137,
+      jobs: [sampleRawJob],
+    },
+  });
+  const reg = captureRegistration();
+  registerWorkflowRunViewTool(reg.register, authedRequest);
+  const out = (await reg.entry.handler({
+    repo: "owner/repo",
+    run_id: 5_000_000_001,
+  })) as { jobs_total: number; jobs_has_next_page: boolean };
+  assert.equal(out.jobs_total, 137);
+  assert.equal(out.jobs_has_next_page, true);
 });
 
 test("gh.workflow_run_view: 404 on run fetch translates to structured 'not found'", async () => {

--- a/tests/unit/tools/workflow/run_view.test.ts
+++ b/tests/unit/tools/workflow/run_view.test.ts
@@ -1,0 +1,99 @@
+// tests/unit/tools/workflow/run_view.test.ts
+//
+// gh.workflow_run_view: pin the two-call REST flow (run + jobs),
+// the job-summary shape, and the 404 → structured error
+// translation.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { registerWorkflowRunViewTool } from "../../../../src/tools/workflow/run_view.ts";
+import type { ToolEntry } from "../../../../src/registry.ts";
+import {
+  httpError,
+  sampleRawJob,
+  sampleRawRun,
+  stubAuthedRequest,
+} from "./_fixtures.ts";
+
+function captureRegistration() {
+  let entry: ToolEntry | undefined;
+  const register = (name: string, e: ToolEntry) => {
+    if (name !== "gh.workflow_run_view") throw new Error(`unexpected: ${name}`);
+    entry = e;
+  };
+  return {
+    register,
+    get entry(): ToolEntry {
+      if (!entry) throw new Error("not registered");
+      return entry;
+    },
+  };
+}
+
+test("gh.workflow_run_view: returns run + jobs summary in two REST calls", async () => {
+  const { authedRequest, calls } = stubAuthedRequest({
+    "GET /repos/{owner}/{repo}/actions/runs/{run_id}": sampleRawRun,
+    "GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs": {
+      total_count: 1,
+      jobs: [sampleRawJob],
+    },
+  });
+  const reg = captureRegistration();
+  registerWorkflowRunViewTool(reg.register, authedRequest);
+  const out = (await reg.entry.handler({
+    repo: "owner/repo",
+    run_id: 5_000_000_001,
+  })) as {
+    run: { id: number; state: string };
+    jobs: Array<{
+      id: number;
+      state: string;
+      steps_completed: number;
+      steps_total: number;
+    }>;
+  };
+  assert.equal(out.run.id, 5_000_000_001);
+  assert.equal(out.run.state, "success");
+  assert.equal(out.jobs.length, 1);
+  assert.equal(out.jobs[0]?.id, 9_000_000_001);
+  assert.equal(out.jobs[0]?.state, "success");
+  assert.equal(out.jobs[0]?.steps_completed, 2);
+  assert.equal(out.jobs[0]?.steps_total, 2);
+  assert.equal(calls.length, 2);
+});
+
+test("gh.workflow_run_view: 404 on run fetch translates to structured 'not found'", async () => {
+  const { authedRequest } = stubAuthedRequest({
+    "GET /repos/{owner}/{repo}/actions/runs/{run_id}": () => {
+      throw httpError(404, "Not Found");
+    },
+  });
+  const reg = captureRegistration();
+  registerWorkflowRunViewTool(reg.register, authedRequest);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", run_id: 12345 }),
+    /run owner\/repo#12345 not found/,
+  );
+});
+
+test("gh.workflow_run_view: failed job reports state: failure (conclusion-driven)", async () => {
+  const failedJob = {
+    ...sampleRawJob,
+    conclusion: "failure",
+  };
+  const { authedRequest } = stubAuthedRequest({
+    "GET /repos/{owner}/{repo}/actions/runs/{run_id}": sampleRawRun,
+    "GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs": {
+      total_count: 1,
+      jobs: [failedJob],
+    },
+  });
+  const reg = captureRegistration();
+  registerWorkflowRunViewTool(reg.register, authedRequest);
+  const out = (await reg.entry.handler({
+    repo: "owner/repo",
+    run_id: 1,
+  })) as { jobs: Array<{ state: string }> };
+  assert.equal(out.jobs[0]?.state, "failure");
+});

--- a/tests/unit/tools/workflow/runs_list.test.ts
+++ b/tests/unit/tools/workflow/runs_list.test.ts
@@ -1,0 +1,126 @@
+// tests/unit/tools/workflow/runs_list.test.ts
+//
+// gh.workflow_runs_list: pin the REST query-param shape, the
+// status/conclusion → state flattening, and the page-based
+// hasNextPage computation.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { registerWorkflowRunsListTool } from "../../../../src/tools/workflow/runs_list.ts";
+import type { ToolEntry } from "../../../../src/registry.ts";
+import { sampleRawRun, stubAuthedRequest } from "./_fixtures.ts";
+
+function captureRegistration() {
+  let entry: ToolEntry | undefined;
+  const register = (name: string, e: ToolEntry) => {
+    if (name !== "gh.workflow_runs_list") throw new Error(`unexpected: ${name}`);
+    entry = e;
+  };
+  return {
+    register,
+    get entry(): ToolEntry {
+      if (!entry) throw new Error("not registered");
+      return entry;
+    },
+  };
+}
+
+test("gh.workflow_runs_list: maps REST response onto canonical RunSummary", async () => {
+  const { authedRequest, calls } = stubAuthedRequest({
+    "GET /repos/{owner}/{repo}/actions/runs": {
+      total_count: 1,
+      workflow_runs: [sampleRawRun],
+    },
+  });
+  const reg = captureRegistration();
+  registerWorkflowRunsListTool(reg.register, authedRequest);
+  const out = (await reg.entry.handler({ repo: "owner/repo" })) as {
+    items: Array<{ id: number; state: string; branch: string | null }>;
+    total: number;
+    hasNextPage: boolean;
+    page: number;
+  };
+  assert.equal(out.items.length, 1);
+  assert.equal(out.items[0]?.id, 5_000_000_001);
+  assert.equal(out.items[0]?.state, "success");
+  assert.equal(out.items[0]?.branch, "feat/x");
+  assert.equal(out.total, 1);
+  assert.equal(out.hasNextPage, false);
+  assert.equal(out.page, 1);
+  assert.equal(calls[0]?.params.owner, "owner");
+  assert.equal(calls[0]?.params.repo, "repo");
+});
+
+test("gh.workflow_runs_list: branch + status filters pass through to query params", async () => {
+  const { authedRequest, calls } = stubAuthedRequest({
+    "GET /repos/{owner}/{repo}/actions/runs": {
+      total_count: 0,
+      workflow_runs: [],
+    },
+  });
+  const reg = captureRegistration();
+  registerWorkflowRunsListTool(reg.register, authedRequest);
+  await reg.entry.handler({
+    repo: "owner/repo",
+    branch: "main",
+    status: "failure",
+    perPage: 50,
+    page: 2,
+  });
+  assert.equal(calls[0]?.params.branch, "main");
+  assert.equal(calls[0]?.params.status, "failure");
+  assert.equal(calls[0]?.params.per_page, 50);
+  assert.equal(calls[0]?.params.page, 2);
+});
+
+test("gh.workflow_runs_list: hasNextPage true when total exceeds page * per_page", async () => {
+  const { authedRequest } = stubAuthedRequest({
+    "GET /repos/{owner}/{repo}/actions/runs": {
+      total_count: 200,
+      workflow_runs: [sampleRawRun, { ...sampleRawRun, id: 5_000_000_002 }],
+    },
+  });
+  const reg = captureRegistration();
+  registerWorkflowRunsListTool(reg.register, authedRequest);
+  const out = (await reg.entry.handler({
+    repo: "owner/repo",
+    perPage: 30,
+    page: 1,
+  })) as { hasNextPage: boolean };
+  assert.equal(out.hasNextPage, true);
+});
+
+test("gh.workflow_runs_list: in-flight run reports state: in_progress (status overrides null conclusion)", async () => {
+  const inFlight = {
+    ...sampleRawRun,
+    status: "in_progress",
+    conclusion: null,
+  };
+  const { authedRequest } = stubAuthedRequest({
+    "GET /repos/{owner}/{repo}/actions/runs": {
+      total_count: 1,
+      workflow_runs: [inFlight],
+    },
+  });
+  const reg = captureRegistration();
+  registerWorkflowRunsListTool(reg.register, authedRequest);
+  const out = (await reg.entry.handler({ repo: "owner/repo" })) as {
+    items: Array<{ state: string }>;
+  };
+  assert.equal(out.items[0]?.state, "in_progress");
+});
+
+test("gh.workflow_runs_list: rejects malformed status enum at the input boundary", async () => {
+  const { authedRequest } = stubAuthedRequest({
+    "GET /repos/{owner}/{repo}/actions/runs": () => {
+      throw new Error("must not run");
+    },
+  });
+  const reg = captureRegistration();
+  registerWorkflowRunsListTool(reg.register, authedRequest);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", status: "wonky" }),
+    /gh\.workflow_runs_list input/,
+  );
+});


### PR DESCRIPTION
## Summary

Wraps GitHub Actions workflow ops as 4 MCP tools. **REST-based** (not GraphQL): GitHub's GraphQL coverage of Actions is incomplete — there is no `cancelWorkflowRun` mutation, the run-list filter surface is weaker than REST's, and step-level job detail is barely present. The spec acknowledges this trade-off explicitly.

| Tool | Input | Output |
|---|---|---|
| `gh.workflow_runs_list` | `{repo, branch?, status?, perPage?, page?}` | `{items[], total, hasNextPage, page}` |
| `gh.workflow_run_view` | `{repo, run_id}` | `{run, jobs[], jobs_total, jobs_has_next_page}` |
| `gh.workflow_run_cancel` | `{repo, run_id}` | `{cancelled, run_id}` |
| `gh.workflow_run_jobs` | `{repo, run_id, attempt_number?, perPage?, page?}` | `{items[], total, hasNextPage, page}` |

### Behaviour notes

- **Canonical `RunState` enum.** REST returns `status` × `conclusion` separately; we flatten them onto a single `state` (`queued | in_progress | success | failure | cancelled | skipped | timed_out | action_required | neutral`). Same enum applies to runs, jobs, and steps so consumers don't have to branch on two fields.
- **`gh.workflow_run_cancel` is asynchronous.** REST returns 202 (Accepted); the run won't flip to `cancelled` immediately. Output `cancelled: true` means "GitHub accepted the cancel request" — poll `gh.workflow_run_view` to confirm. The handler asserts on HTTP 202 explicitly: any non-202 success (which would mean the API contract drifted) surfaces as a structured error rather than a silent acceptance. 404 → "run not found"; 409 → "already in a terminal state".
- **`gh.workflow_run_jobs` switches routes by `attempt_number`.** Omitted → `/jobs` (latest); supplied → `/attempts/:n/jobs` (the query-param form on the latest route doesn't honour the attempt number). Page-paginated via `page`/`perPage` (max 100); the output exposes `hasNextPage` so a caller can detect more results.
- **`gh.workflow_run_view` exposes truncation signals.** The jobs side-call is capped at 100 per page; output includes `jobs_total` and `jobs_has_next_page` so a caller can detect when a run has more jobs than fit on a single page (and switch to `gh.workflow_run_jobs` to paginate).
- **`gh.workflow_runs_list` `status` accepts both shapes.** Raw status (queued/in_progress/completed) AND conclusion shorthand (success/failure/...). REST maps them onto the same query param so consumers can filter by either.

### Files

- `src/tools/workflow/` — `_shared.ts` (RunState enum + `flattenRunState` + `getStatus` HTTP helper + canonical schemas), 4 tool files, `index.ts` aggregator.
- `src/server.ts` — wires `registerWorkflowTools()` alongside the existing tool registrations. Takes `authedRequest` (REST) rather than `graphql`; same auth layer underneath.
- No `.graphql` files (REST-based domain).

## Test plan

- [x] `npm run lint` (tsc --noEmit on src + tests configs) clean
- [x] `npm test` — **all unit tests pass** (new tests covering pagination signals on run_view + run_jobs, plus the 202-status assertion on run_cancel).
- [x] Smoke asserts 23 tools.
- [x] Run-state flattening pinned (in-flight `status: in_progress, conclusion: null` → "in_progress"; completed `conclusion: failure` → "failure"; etc.).
- [x] Cancel's 404 / 409 → distinct structured errors; other HTTP errors propagate unchanged; non-202 success surfaces as a structured error.
- [x] Run-jobs route switching pinned; page/perPage forwarded; `hasNextPage` true when total exceeds page size.
- [x] Run-view jobs truncation signal pinned (`jobs_has_next_page` true when `total_count` exceeds returned page).
- [ ] Live integration probe (real Actions runs against a PAT) lands in MCP-12.

## Stack

After the merged epic chain (MCP-1 through MCP-7). Independent of MCP-10 (Project v2, also incoming) — both can merge in either order.

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)