### PR TITLE
feat: 4 Project v2 tools (MCP-10)

### DIFF
--- a/src/graphql/queries/project/_resolve-content-id.graphql
+++ b/src/graphql/queries/project/_resolve-content-id.graphql
@@ -1,0 +1,15 @@
+# Resolve a content_url's (owner, repo, number, kind) → GraphQL
+# node ID for `addProjectV2ItemById`. The handler parses the
+# URL upstream and selects either `issue` or `pullRequest` from
+# the response; only one of them will be non-null on a real URL.
+
+query ContentIdByOwnerRepoNumber($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    issue(number: $number) {
+      id
+    }
+    pullRequest(number: $number) {
+      id
+    }
+  }
+}

--- a/src/graphql/queries/project/_resolve-project-id.graphql
+++ b/src/graphql/queries/project/_resolve-project-id.graphql
@@ -1,0 +1,17 @@
+# Project v2 lives under either Organization or User. We try
+# both in one round-trip and the handler picks whichever returns
+# non-null (a project number is unique within its owner, so at
+# most one of the two branches resolves).
+
+query ProjectIdByOwnerNumber($owner: String!, $number: Int!) {
+  organization(login: $owner) {
+    projectV2(number: $number) {
+      id
+    }
+  }
+  user(login: $owner) {
+    projectV2(number: $number) {
+      id
+    }
+  }
+}

--- a/src/graphql/queries/project/field_list.graphql
+++ b/src/graphql/queries/project/field_list.graphql
@@ -1,0 +1,55 @@
+# Reads project fields via `node(id: $projectId)` with a
+# `... on ProjectV2` selection. Going through `node` means we
+# don't have to know whether the project is owned by an
+# Organization or a User — the polymorphic node lookup handles
+# both.
+#
+# `first: 100` is the GraphQL cap. Projects with more than 100
+# fields are vanishingly rare in practice; field_list returns
+# `pageInfo.hasNextPage` so consumers can still detect
+# truncation.
+
+query ProjectFieldList($projectId: ID!) {
+  node(id: $projectId) {
+    __typename
+    ... on ProjectV2 {
+      fields(first: 100) {
+        pageInfo {
+          hasNextPage
+        }
+        nodes {
+          __typename
+          ... on ProjectV2Field {
+            id
+            name
+            dataType
+          }
+          ... on ProjectV2SingleSelectField {
+            id
+            name
+            dataType
+            options {
+              id
+              name
+            }
+          }
+          ... on ProjectV2IterationField {
+            id
+            name
+            dataType
+            configuration {
+              iterations {
+                id
+                title
+              }
+              completedIterations {
+                id
+                title
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/graphql/queries/project/item_add.graphql
+++ b/src/graphql/queries/project/item_add.graphql
@@ -1,0 +1,7 @@
+mutation ProjectItemAdd($input: AddProjectV2ItemByIdInput!) {
+  addProjectV2ItemById(input: $input) {
+    item {
+      id
+    }
+  }
+}

--- a/src/graphql/queries/project/item_update_field.graphql
+++ b/src/graphql/queries/project/item_update_field.graphql
@@ -1,0 +1,8 @@
+mutation ProjectItemUpdateField($input: UpdateProjectV2ItemFieldValueInput!) {
+  updateProjectV2ItemFieldValue(input: $input) {
+    projectV2Item {
+      id
+      updatedAt
+    }
+  }
+}

--- a/src/graphql/queries/project/items_list.graphql
+++ b/src/graphql/queries/project/items_list.graphql
@@ -1,0 +1,112 @@
+# Paginated items in a project, with field values populated.
+# Each item carries:
+#   - the underlying content (issue / PR / draftIssue) — kind
+#     and minimal identification (URL + title) so the consumer
+#     can correlate without an extra round-trip.
+#   - fieldValues: a union of typed values per field. We select
+#     enough variants that the handler can flatten each one
+#     onto a `{field_id, field_name, type, value}` shape.
+#
+# `first: 50` is the GraphQL cap on Project v2 items connection;
+# the cursor-based pagination uses the `endCursor` returned
+# alongside.
+
+query ProjectItemsList($projectId: ID!, $first: Int!, $after: String) {
+  node(id: $projectId) {
+    __typename
+    ... on ProjectV2 {
+      items(first: $first, after: $after) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          id
+          updatedAt
+          content {
+            __typename
+            ... on Issue {
+              number
+              url
+              title
+              repository {
+                nameWithOwner
+              }
+            }
+            ... on PullRequest {
+              number
+              url
+              title
+              repository {
+                nameWithOwner
+              }
+            }
+            ... on DraftIssue {
+              title
+            }
+          }
+          fieldValues(first: 50) {
+            pageInfo {
+              hasNextPage
+            }
+            nodes {
+              __typename
+              ... on ProjectV2ItemFieldTextValue {
+                text
+                field {
+                  ... on ProjectV2FieldCommon {
+                    id
+                    name
+                    dataType
+                  }
+                }
+              }
+              ... on ProjectV2ItemFieldNumberValue {
+                number
+                field {
+                  ... on ProjectV2FieldCommon {
+                    id
+                    name
+                    dataType
+                  }
+                }
+              }
+              ... on ProjectV2ItemFieldDateValue {
+                date
+                field {
+                  ... on ProjectV2FieldCommon {
+                    id
+                    name
+                    dataType
+                  }
+                }
+              }
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                optionId
+                name
+                field {
+                  ... on ProjectV2FieldCommon {
+                    id
+                    name
+                    dataType
+                  }
+                }
+              }
+              ... on ProjectV2ItemFieldIterationValue {
+                iterationId
+                title
+                field {
+                  ... on ProjectV2FieldCommon {
+                    id
+                    name
+                    dataType
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -37,6 +37,7 @@ import { registerTestConnectionTool } from "./tools/auth/test_connection.js";
 import { registerIssueTools } from "./tools/issue/index.js";
 import { registerLabelTools } from "./tools/label/index.js";
 import { registerPRTools } from "./tools/pr/index.js";
+import { registerProjectTools } from "./tools/project/index.js";
 
 // Read the package version from the package.json next to the dist
 // tree at startup, so a single source of truth (package.json) drives
@@ -80,6 +81,7 @@ export async function startServer(): Promise<void> {
   registerIssueTools(registerTool, graphql);
   registerLabelTools(registerTool, graphql);
   registerPRTools(registerTool, graphql);
+  registerProjectTools(registerTool, graphql);
 
   const server = new Server(
     {

--- a/src/tools/project/_shared.ts
+++ b/src/tools/project/_shared.ts
@@ -1,0 +1,246 @@
+// src/tools/project/_shared.ts
+//
+// Helpers shared across the four gh.project_* tools. Two
+// resolvers live here: project-id lookup from `(owner, number)`
+// and content-id lookup from a GitHub issue/PR URL — both are
+// pre-mutation steps that any tool taking a "project" or
+// "content item" reference might need.
+
+import type { GraphqlClient } from "../../graphql/client.js";
+
+// Project v2 lives under Organization.projectV2(number) OR
+// User.projectV2(number). We try both in a single query and
+// take whichever returns non-null.
+interface ProjectIdResponse {
+  organization: { projectV2: { id: string } | null } | null;
+  user: { projectV2: { id: string } | null } | null;
+}
+
+export async function lookupProjectIdByOwnerNumber(
+  graphql: GraphqlClient,
+  owner: string,
+  number: number,
+  where: string,
+): Promise<string> {
+  const data = await graphql<ProjectIdResponse>(
+    "project/_resolve-project-id",
+    { owner, number },
+  );
+  const id =
+    data.organization?.projectV2?.id ?? data.user?.projectV2?.id ?? null;
+  if (id === null) {
+    throw new Error(
+      `mcp-github: ${where}: project '${owner}/projects/${number}' not found (or token lacks read access; project v2 needs the 'project' scope on a classic PAT, or 'Projects: Read' on a fine-grained token)`,
+    );
+  }
+  return id;
+}
+
+// JSON-Schema fragment that demands EITHER `project_id` (raw
+// GraphQL node ID) OR `(owner, number)`. Reused across every
+// project tool that takes a project reference.
+export const projectRefSchemaProps = {
+  project_id: {
+    type: "string",
+    minLength: 1,
+    description:
+      "Project v2 GraphQL node ID. Mutually exclusive with " +
+      "owner + number; supply ONE of the two.",
+  },
+  owner: {
+    type: "string",
+    minLength: 1,
+    description:
+      "Project owner login (org or user). Pair with `number`. " +
+      "Mutually exclusive with project_id.",
+  },
+  number: {
+    type: "integer",
+    minimum: 1,
+    description: "Project number. Pair with `owner`.",
+  },
+} as const;
+
+// `oneOf` block to pin the project-reference contract: either
+// `project_id` alone, or `owner + number` together. Mixed shapes
+// (e.g. project_id + owner) are rejected at the schema boundary.
+export const projectRefOneOf = [
+  {
+    required: ["project_id"],
+    not: { anyOf: [{ required: ["owner"] }, { required: ["number"] }] },
+  },
+  {
+    required: ["owner", "number"],
+    not: { required: ["project_id"] },
+  },
+] as const;
+
+// Resolve a project reference (one of the two shapes above) to
+// a GraphQL node ID. Tools call this once at the top of their
+// handler so the body can assume `projectId: string`.
+export async function resolveProjectId(
+  graphql: GraphqlClient,
+  args: { project_id?: string; owner?: string; number?: number },
+  where: string,
+): Promise<string> {
+  if (typeof args.project_id === "string") {
+    return args.project_id;
+  }
+  if (typeof args.owner === "string" && typeof args.number === "number") {
+    return lookupProjectIdByOwnerNumber(graphql, args.owner, args.number, where);
+  }
+  // Should be unreachable because the schema's `oneOf` enforces
+  // one of the two shapes — defensive throw in case the schema
+  // ever drifts.
+  throw new Error(
+    `mcp-github: ${where}: must supply either project_id or owner + number`,
+  );
+}
+
+// Parse a GitHub issue/PR URL into the components needed to
+// look up its GraphQL node ID. Returns null on no match (the
+// caller surfaces a structured error).
+export interface ContentRef {
+  owner: string;
+  name: string;
+  number: number;
+  type: "issue" | "pullRequest";
+}
+
+const URL_RE =
+  /^https:\/\/github\.com\/([A-Za-z0-9._-]+)\/([A-Za-z0-9._-]+)\/(issues|pull)\/(\d+)/;
+
+export function parseContentUrl(url: string): ContentRef | null {
+  const m = URL_RE.exec(url);
+  if (!m) return null;
+  const [, owner = "", name = "", typeSegment = "", numberStr = ""] = m;
+  const number = Number.parseInt(numberStr, 10);
+  if (!Number.isFinite(number) || number < 1) return null;
+  return {
+    owner,
+    name,
+    number,
+    type: typeSegment === "pull" ? "pullRequest" : "issue",
+  };
+}
+
+interface ContentIdResponse {
+  repository: {
+    issue: { id: string } | null;
+    pullRequest: { id: string } | null;
+  } | null;
+}
+
+export async function lookupContentIdByUrl(
+  graphql: GraphqlClient,
+  url: string,
+  where: string,
+): Promise<string> {
+  const ref = parseContentUrl(url);
+  if (!ref) {
+    throw new Error(
+      `mcp-github: ${where}: content_url '${url}' is not a recognised github.com issue or pull URL`,
+    );
+  }
+  const data = await graphql<ContentIdResponse>(
+    "project/_resolve-content-id",
+    { owner: ref.owner, name: ref.name, number: ref.number },
+  );
+  if (!data.repository) {
+    throw new Error(
+      `mcp-github: ${where}: repository '${ref.owner}/${ref.name}' (from content_url) not found or token lacks read access`,
+    );
+  }
+  const id =
+    ref.type === "issue"
+      ? data.repository.issue?.id
+      : data.repository.pullRequest?.id;
+  if (typeof id !== "string") {
+    throw new Error(
+      `mcp-github: ${where}: ${ref.type} ${ref.owner}/${ref.name}#${ref.number} (from content_url) not found`,
+    );
+  }
+  return id;
+}
+
+// Project v2 field types we surface. Excludes the derived ones
+// (ASSIGNEES, LABELS, MILESTONE, etc.) which are read-only
+// projections of the underlying issue/PR — they're returned in
+// items_list responses but you don't update them via the
+// project field-value mutation.
+export type ProjectFieldType =
+  | "TEXT"
+  | "NUMBER"
+  | "DATE"
+  | "SINGLE_SELECT"
+  | "ITERATION"
+  | "ASSIGNEES"
+  | "LABELS"
+  | "MILESTONE"
+  | "REPOSITORY"
+  | "TITLE"
+  | "REVIEWERS"
+  | "TRACKED_BY"
+  | "TRACKS"
+  | "LINKED_PULL_REQUESTS"
+  | "PARENT_ISSUE"
+  | "SUB_ISSUES_PROGRESS";
+
+export const projectFieldTypeSchema = {
+  type: "string",
+  enum: [
+    "TEXT",
+    "NUMBER",
+    "DATE",
+    "SINGLE_SELECT",
+    "ITERATION",
+    "ASSIGNEES",
+    "LABELS",
+    "MILESTONE",
+    "REPOSITORY",
+    "TITLE",
+    "REVIEWERS",
+    "TRACKED_BY",
+    "TRACKS",
+    "LINKED_PULL_REQUESTS",
+    "PARENT_ISSUE",
+    "SUB_ISSUES_PROGRESS",
+  ],
+} as const;
+
+export interface ProjectFieldOption {
+  id: string;
+  name: string;
+}
+
+export const projectFieldOptionSchema = {
+  type: "object",
+  required: ["id", "name"],
+  properties: {
+    id: { type: "string" },
+    name: { type: "string" },
+  },
+  additionalProperties: false,
+} as const;
+
+export interface ProjectFieldSummary {
+  id: string;
+  name: string;
+  data_type: ProjectFieldType;
+  options: ProjectFieldOption[];
+}
+
+export const projectFieldSummarySchema = {
+  type: "object",
+  required: ["id", "name", "data_type", "options"],
+  properties: {
+    id: { type: "string" },
+    name: { type: "string" },
+    data_type: projectFieldTypeSchema,
+    // `options` is non-empty only for SINGLE_SELECT and
+    // ITERATION fields. Always present (empty array elsewhere)
+    // so the shape is uniform.
+    options: { type: "array", items: projectFieldOptionSchema },
+  },
+  additionalProperties: false,
+} as const;

--- a/src/tools/project/_shared.ts
+++ b/src/tools/project/_shared.ts
@@ -163,11 +163,15 @@ export async function lookupContentIdByUrl(
   return id;
 }
 
-// Project v2 field types we surface. Excludes the derived ones
-// (ASSIGNEES, LABELS, MILESTONE, etc.) which are read-only
-// projections of the underlying issue/PR — they're returned in
-// items_list responses but you don't update them via the
-// project field-value mutation.
+// Project v2 field types we surface. Both user-defined types
+// (TEXT / NUMBER / DATE / SINGLE_SELECT / ITERATION) and the
+// derived ones (ASSIGNEES, LABELS, MILESTONE, REPOSITORY, TITLE,
+// REVIEWERS, TRACKED_BY, TRACKS, LINKED_PULL_REQUESTS,
+// PARENT_ISSUE, SUB_ISSUES_PROGRESS) are returned by
+// `gh.project_field_list` and `gh.project_items_list`. The
+// derived ones are read-only projections of the underlying
+// issue/PR; they cannot be set via `gh.project_item_update_field`,
+// which only accepts the five user-defined types.
 export type ProjectFieldType =
   | "TEXT"
   | "NUMBER"

--- a/src/tools/project/_shared.ts
+++ b/src/tools/project/_shared.ts
@@ -107,8 +107,13 @@ export interface ContentRef {
   type: "issue" | "pullRequest";
 }
 
+// Anchor after the numeric segment so `/issues/123abc` doesn't
+// parse as `123` and silently resolve the wrong content. Allow
+// end-of-string OR a real URL boundary character (`/`, `?`, `#`)
+// so the common `/issues/123#issuecomment-1` and
+// `/issues/123?foo=bar` shapes still match.
 const URL_RE =
-  /^https:\/\/github\.com\/([A-Za-z0-9._-]+)\/([A-Za-z0-9._-]+)\/(issues|pull)\/(\d+)/;
+  /^https:\/\/github\.com\/([A-Za-z0-9._-]+)\/([A-Za-z0-9._-]+)\/(issues|pull)\/(\d+)(?:[/?#]|$)/;
 
 export function parseContentUrl(url: string): ContentRef | null {
   const m = URL_RE.exec(url);

--- a/src/tools/project/field_list.ts
+++ b/src/tools/project/field_list.ts
@@ -1,0 +1,186 @@
+// src/tools/project/field_list.ts
+//
+// `gh.project_field_list` — lists every field configured on a
+// Project v2 board, including the per-field options for
+// SINGLE_SELECT and per-field iterations for ITERATION fields.
+// Caller uses this output to discover field IDs + valid option
+// IDs before calling gh.project_item_update_field.
+//
+// Implementation reads through `node(id: $projectId)` so the
+// query works for both Organization-owned and User-owned
+// projects without branching.
+
+import type { GraphqlClient } from "../../graphql/client.js";
+import type { ToolEntry } from "../../registry.js";
+import { validate } from "../../validation/validator.js";
+import {
+  type ProjectFieldOption,
+  type ProjectFieldSummary,
+  type ProjectFieldType,
+  projectFieldSummarySchema,
+  projectRefOneOf,
+  projectRefSchemaProps,
+  resolveProjectId,
+} from "./_shared.js";
+
+const inputSchema = {
+  type: "object",
+  properties: { ...projectRefSchemaProps },
+  allOf: [{ oneOf: [...projectRefOneOf] }],
+  additionalProperties: false,
+} as const;
+
+const outputSchema = {
+  type: "object",
+  required: ["fields", "hasNextPage"],
+  properties: {
+    fields: { type: "array", items: projectFieldSummarySchema },
+    hasNextPage: {
+      type: "boolean",
+      description:
+        "True when the project has > 100 fields (the GraphQL " +
+        "page cap). Vanishingly rare in practice; surfaces as a " +
+        "signal that pagination support is needed.",
+    },
+  },
+  additionalProperties: false,
+} as const;
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+interface Input {
+  project_id?: string;
+  owner?: string;
+  number?: number;
+}
+
+interface Output {
+  fields: ProjectFieldSummary[];
+  hasNextPage: boolean;
+}
+
+interface RawFieldCommon {
+  __typename: "ProjectV2Field";
+  id: string;
+  name: string;
+  dataType: ProjectFieldType;
+}
+
+interface RawFieldSingleSelect {
+  __typename: "ProjectV2SingleSelectField";
+  id: string;
+  name: string;
+  dataType: ProjectFieldType;
+  options: ProjectFieldOption[];
+}
+
+interface RawFieldIteration {
+  __typename: "ProjectV2IterationField";
+  id: string;
+  name: string;
+  dataType: ProjectFieldType;
+  configuration: {
+    iterations: Array<{ id: string; title: string }>;
+    completedIterations: Array<{ id: string; title: string }>;
+  };
+}
+
+type RawField = RawFieldCommon | RawFieldSingleSelect | RawFieldIteration;
+
+interface ProjectV2Node {
+  __typename: "ProjectV2";
+  fields: {
+    pageInfo: { hasNextPage: boolean };
+    nodes: RawField[];
+  };
+}
+
+interface Response {
+  // `node()` returns a polymorphic Node | null. We narrow via
+  // the helper below rather than a discriminated-union type so
+  // the literal `"ProjectV2"` check actually performs the
+  // narrowing — TS can't narrow when one arm of the union has
+  // `__typename: string`.
+  node: { __typename: string } | null;
+}
+
+function isProjectV2(node: Response["node"]): node is ProjectV2Node {
+  return node !== null && node.__typename === "ProjectV2";
+}
+
+export function registerProjectFieldListTool(
+  register: RegisterToolFn,
+  graphql: GraphqlClient,
+): void {
+  register("gh.project_field_list", {
+    description:
+      "List the fields configured on a Project v2 board. For " +
+      "SINGLE_SELECT fields each entry's `options` carries the " +
+      "selectable option IDs + names; for ITERATION fields the " +
+      "current and completed iterations appear in the same " +
+      "`options` array (current iterations come first). Use " +
+      "this to discover IDs before calling " +
+      "`gh.project_item_update_field`.",
+    inputSchema,
+    handler: async (raw) => {
+      const args = validate<Input>(inputSchema, raw, "gh.project_field_list input");
+      const projectId = await resolveProjectId(
+        graphql,
+        args,
+        "gh.project_field_list",
+      );
+      const data = await graphql<Response>("project/field_list", { projectId });
+      if (!isProjectV2(data.node)) {
+        // The `node()` lookup returns null for an unknown ID
+        // and a non-ProjectV2 typename for an ID that resolves
+        // to something else (e.g. an Issue ID accidentally
+        // passed as project_id). Both surface as a clean error.
+        throw new Error(
+          `mcp-github: gh.project_field_list: project_id '${projectId}' does not resolve to a ProjectV2`,
+        );
+      }
+      const fields = data.node.fields.nodes.map(summariseField);
+      const out: Output = {
+        fields,
+        hasNextPage: data.node.fields.pageInfo.hasNextPage,
+      };
+      return validate<Output>(outputSchema, out, "gh.project_field_list output");
+    },
+  });
+}
+
+function summariseField(raw: RawField): ProjectFieldSummary {
+  if (raw.__typename === "ProjectV2SingleSelectField") {
+    return {
+      id: raw.id,
+      name: raw.name,
+      data_type: raw.dataType,
+      options: raw.options,
+    };
+  }
+  if (raw.__typename === "ProjectV2IterationField") {
+    // Combine current + completed iterations into the same
+    // `options` array so the consumer doesn't have to switch on
+    // the typename. Current iterations are listed first because
+    // those are the ones a fresh update is most likely to
+    // target.
+    return {
+      id: raw.id,
+      name: raw.name,
+      data_type: raw.dataType,
+      options: [
+        ...raw.configuration.iterations.map((i) => ({ id: i.id, name: i.title })),
+        ...raw.configuration.completedIterations.map((i) => ({
+          id: i.id,
+          name: i.title,
+        })),
+      ],
+    };
+  }
+  return {
+    id: raw.id,
+    name: raw.name,
+    data_type: raw.dataType,
+    options: [],
+  };
+}

--- a/src/tools/project/index.ts
+++ b/src/tools/project/index.ts
@@ -1,0 +1,24 @@
+// src/tools/project/index.ts
+//
+// Aggregator for the four gh.project_* tools. Imported by
+// `src/server.ts`'s startServer() and called once at boot to
+// register every Project v2 tool against the registry.
+
+import type { GraphqlClient } from "../../graphql/client.js";
+import type { ToolEntry } from "../../registry.js";
+import { registerProjectFieldListTool } from "./field_list.js";
+import { registerProjectItemAddTool } from "./item_add.js";
+import { registerProjectItemUpdateFieldTool } from "./item_update_field.js";
+import { registerProjectItemsListTool } from "./items_list.js";
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+export function registerProjectTools(
+  register: RegisterToolFn,
+  graphql: GraphqlClient,
+): void {
+  registerProjectItemAddTool(register, graphql);
+  registerProjectItemUpdateFieldTool(register, graphql);
+  registerProjectFieldListTool(register, graphql);
+  registerProjectItemsListTool(register, graphql);
+}

--- a/src/tools/project/item_add.ts
+++ b/src/tools/project/item_add.ts
@@ -1,0 +1,126 @@
+// src/tools/project/item_add.ts
+//
+// `gh.project_item_add` — adds an issue or PR to a Project v2
+// board. Two valid input shapes for the project reference
+// (project_id OR owner+number) and two valid input shapes for
+// the content reference (content_id OR content_url). Each pair
+// is enforced by `oneOf` blocks at the schema boundary so a
+// caller can't slip a half-specified reference past the input
+// gate.
+//
+// content_url is the gh-CLI-friendly form
+// (`https://github.com/owner/repo/issues/N` or `.../pull/N`);
+// the handler parses + looks up the GraphQL ID before calling
+// the AddProjectV2ItemById mutation.
+
+import type { GraphqlClient } from "../../graphql/client.js";
+import type { ToolEntry } from "../../registry.js";
+import { validate } from "../../validation/validator.js";
+import {
+  lookupContentIdByUrl,
+  projectRefOneOf,
+  projectRefSchemaProps,
+  resolveProjectId,
+} from "./_shared.js";
+
+const inputSchema = {
+  type: "object",
+  properties: {
+    ...projectRefSchemaProps,
+    content_id: {
+      type: "string",
+      minLength: 1,
+      description: "GraphQL node ID of the issue/PR to add.",
+    },
+    content_url: {
+      type: "string",
+      pattern: "^https://github\\.com/",
+      description:
+        "GitHub URL of an issue (`.../issues/N`) or pull " +
+        "(`.../pull/N`). Resolved to the underlying GraphQL node " +
+        "ID via a small lookup query before the mutation runs. " +
+        "Mutually exclusive with content_id.",
+    },
+  },
+  // Compose the project-ref oneOf and the content-ref oneOf
+  // into a single `allOf` so both groups are independently
+  // enforced. ajv interprets allOf as "every branch must
+  // validate", which gives us the cross-product we want.
+  allOf: [
+    { oneOf: [...projectRefOneOf] },
+    {
+      oneOf: [
+        {
+          required: ["content_id"],
+          not: { required: ["content_url"] },
+        },
+        {
+          required: ["content_url"],
+          not: { required: ["content_id"] },
+        },
+      ],
+    },
+  ],
+  additionalProperties: false,
+} as const;
+
+const outputSchema = {
+  type: "object",
+  required: ["item_id"],
+  properties: {
+    item_id: { type: "string" },
+  },
+  additionalProperties: false,
+} as const;
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+interface Input {
+  project_id?: string;
+  owner?: string;
+  number?: number;
+  content_id?: string;
+  content_url?: string;
+}
+
+interface Output {
+  item_id: string;
+}
+
+interface AddResponse {
+  addProjectV2ItemById: { item: { id: string } };
+}
+
+export function registerProjectItemAddTool(
+  register: RegisterToolFn,
+  graphql: GraphqlClient,
+): void {
+  register("gh.project_item_add", {
+    description:
+      "Add an issue or pull request to a Project v2 board. " +
+      "Project ref: either `project_id` (raw GraphQL node ID) or " +
+      "`owner + number` (the project URL form). Content ref: " +
+      "either `content_id` (raw GraphQL node ID of the issue/PR) " +
+      "or `content_url` (e.g. `https://github.com/o/r/issues/N`). " +
+      "Schema enforces exactly one of each pair.",
+    inputSchema,
+    handler: async (raw) => {
+      const args = validate<Input>(inputSchema, raw, "gh.project_item_add input");
+      const [projectId, contentId] = await Promise.all([
+        resolveProjectId(graphql, args, "gh.project_item_add"),
+        args.content_id !== undefined
+          ? Promise.resolve(args.content_id)
+          : lookupContentIdByUrl(
+              graphql,
+              args.content_url as string,
+              "gh.project_item_add",
+            ),
+      ]);
+      const data = await graphql<AddResponse>("project/item_add", {
+        input: { projectId, contentId },
+      });
+      const out: Output = { item_id: data.addProjectV2ItemById.item.id };
+      return validate<Output>(outputSchema, out, "gh.project_item_add output");
+    },
+  });
+}

--- a/src/tools/project/item_update_field.ts
+++ b/src/tools/project/item_update_field.ts
@@ -1,0 +1,212 @@
+// src/tools/project/item_update_field.ts
+//
+// `gh.project_item_update_field` — updates one field on a
+// Project v2 item. The field-value input is a tagged union over
+// the five user-configurable Project v2 field types: text,
+// number, date, single-select option, iteration. Schema's
+// `oneOf` enforces exactly one branch — passing more than one
+// (or none) is rejected at the input boundary so the underlying
+// mutation never sees an ambiguous payload.
+
+import type { GraphqlClient } from "../../graphql/client.js";
+import type { ToolEntry } from "../../registry.js";
+import { validate } from "../../validation/validator.js";
+import {
+  projectRefOneOf,
+  projectRefSchemaProps,
+  resolveProjectId,
+} from "./_shared.js";
+
+const valueSchema = {
+  type: "object",
+  properties: {
+    text: { type: "string" },
+    number: { type: "number" },
+    date: {
+      type: "string",
+      format: "date",
+      description: "ISO-8601 date (YYYY-MM-DD), no time component.",
+    },
+    single_select_option_id: { type: "string", minLength: 1 },
+    iteration_id: { type: "string", minLength: 1 },
+  },
+  // Exactly one of the five branches. Empty `value: {}` (none)
+  // and double-set values (e.g. text + number) are both
+  // rejected.
+  oneOf: [
+    {
+      required: ["text"],
+      not: {
+        anyOf: [
+          { required: ["number"] },
+          { required: ["date"] },
+          { required: ["single_select_option_id"] },
+          { required: ["iteration_id"] },
+        ],
+      },
+    },
+    {
+      required: ["number"],
+      not: {
+        anyOf: [
+          { required: ["text"] },
+          { required: ["date"] },
+          { required: ["single_select_option_id"] },
+          { required: ["iteration_id"] },
+        ],
+      },
+    },
+    {
+      required: ["date"],
+      not: {
+        anyOf: [
+          { required: ["text"] },
+          { required: ["number"] },
+          { required: ["single_select_option_id"] },
+          { required: ["iteration_id"] },
+        ],
+      },
+    },
+    {
+      required: ["single_select_option_id"],
+      not: {
+        anyOf: [
+          { required: ["text"] },
+          { required: ["number"] },
+          { required: ["date"] },
+          { required: ["iteration_id"] },
+        ],
+      },
+    },
+    {
+      required: ["iteration_id"],
+      not: {
+        anyOf: [
+          { required: ["text"] },
+          { required: ["number"] },
+          { required: ["date"] },
+          { required: ["single_select_option_id"] },
+        ],
+      },
+    },
+  ],
+  additionalProperties: false,
+} as const;
+
+const inputSchema = {
+  type: "object",
+  required: ["item_id", "field_id", "value"],
+  properties: {
+    ...projectRefSchemaProps,
+    item_id: {
+      type: "string",
+      minLength: 1,
+      description: "Project v2 item GraphQL node ID.",
+    },
+    field_id: {
+      type: "string",
+      minLength: 1,
+      description: "Project v2 field GraphQL node ID.",
+    },
+    value: valueSchema,
+  },
+  allOf: [{ oneOf: [...projectRefOneOf] }],
+  additionalProperties: false,
+} as const;
+
+const outputSchema = {
+  type: "object",
+  required: ["item_id", "updated_at"],
+  properties: {
+    item_id: { type: "string" },
+    updated_at: { type: "string" },
+  },
+  additionalProperties: false,
+} as const;
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+interface Input {
+  project_id?: string;
+  owner?: string;
+  number?: number;
+  item_id: string;
+  field_id: string;
+  value: {
+    text?: string;
+    number?: number;
+    date?: string;
+    single_select_option_id?: string;
+    iteration_id?: string;
+  };
+}
+
+interface Output {
+  item_id: string;
+  updated_at: string;
+}
+
+interface UpdateResponse {
+  updateProjectV2ItemFieldValue: {
+    projectV2Item: { id: string; updatedAt: string };
+  };
+}
+
+export function registerProjectItemUpdateFieldTool(
+  register: RegisterToolFn,
+  graphql: GraphqlClient,
+): void {
+  register("gh.project_item_update_field", {
+    description:
+      "Update one field on a Project v2 item. `value` is a tagged " +
+      "union: pass exactly one of `text`, `number`, `date` " +
+      "(YYYY-MM-DD), `single_select_option_id`, or `iteration_id`. " +
+      "The choice must match the field's data type — passing " +
+      "a `text` value to a SINGLE_SELECT field returns a clean " +
+      "GraphQL error from GitHub.",
+    inputSchema,
+    handler: async (raw) => {
+      const args = validate<Input>(
+        inputSchema,
+        raw,
+        "gh.project_item_update_field input",
+      );
+      const projectId = await resolveProjectId(
+        graphql,
+        args,
+        "gh.project_item_update_field",
+      );
+      // Translate snake-case input keys to GraphQL camel-case.
+      const value: Record<string, unknown> = {};
+      if (args.value.text !== undefined) value.text = args.value.text;
+      if (args.value.number !== undefined) value.number = args.value.number;
+      if (args.value.date !== undefined) value.date = args.value.date;
+      if (args.value.single_select_option_id !== undefined) {
+        value.singleSelectOptionId = args.value.single_select_option_id;
+      }
+      if (args.value.iteration_id !== undefined) {
+        value.iterationId = args.value.iteration_id;
+      }
+      const data = await graphql<UpdateResponse>(
+        "project/item_update_field",
+        {
+          input: {
+            projectId,
+            itemId: args.item_id,
+            fieldId: args.field_id,
+            value,
+          },
+        },
+      );
+      const out: Output = {
+        item_id: data.updateProjectV2ItemFieldValue.projectV2Item.id,
+        updated_at: data.updateProjectV2ItemFieldValue.projectV2Item.updatedAt,
+      };
+      return validate<Output>(
+        outputSchema,
+        out,
+        "gh.project_item_update_field output",
+      );
+    },
+  });
+}

--- a/src/tools/project/items_list.ts
+++ b/src/tools/project/items_list.ts
@@ -1,0 +1,344 @@
+// src/tools/project/items_list.ts
+//
+// `gh.project_items_list` — paginated list of items on a
+// Project v2 board, with each item's field values flattened
+// onto a uniform `{field_id, field_name, type, value}` shape.
+// The flattening absorbs the tagged-union complexity of the
+// underlying GraphQL `ProjectV2ItemFieldValue` union — a
+// consumer building a status board doesn't have to switch on
+// __typename to read a value.
+
+import type { GraphqlClient } from "../../graphql/client.js";
+import type { ToolEntry } from "../../registry.js";
+import { validate } from "../../validation/validator.js";
+import {
+  type ProjectFieldType,
+  projectFieldTypeSchema,
+  projectRefOneOf,
+  projectRefSchemaProps,
+  resolveProjectId,
+} from "./_shared.js";
+
+const PER_PAGE_DEFAULT = 30;
+const PER_PAGE_MAX = 50; // GraphQL caps Project v2 items at 50 per page.
+
+const inputSchema = {
+  type: "object",
+  properties: {
+    ...projectRefSchemaProps,
+    perPage: { type: "integer", minimum: 1, maximum: PER_PAGE_MAX },
+    after: {
+      type: "string",
+      minLength: 1,
+      description: "Opaque cursor from a previous page's endCursor.",
+    },
+  },
+  allOf: [{ oneOf: [...projectRefOneOf] }],
+  additionalProperties: false,
+} as const;
+
+interface FieldValue {
+  field_id: string;
+  field_name: string;
+  type: ProjectFieldType;
+  value: string | number;
+}
+
+const fieldValueSchema = {
+  type: "object",
+  required: ["field_id", "field_name", "type", "value"],
+  properties: {
+    field_id: { type: "string" },
+    field_name: { type: "string" },
+    type: projectFieldTypeSchema,
+    // The flattened value: text → string, number → number,
+    // date → ISO string, single-select → option name (also
+    // returns option_id alongside), iteration → title (also
+    // returns iteration_id alongside).
+    value: { type: ["string", "number"] },
+  },
+  additionalProperties: false,
+} as const;
+
+interface Item {
+  id: string;
+  updated_at: string;
+  content_type: "Issue" | "PullRequest" | "DraftIssue" | "Unknown";
+  content_repo: string | null;
+  content_number: number | null;
+  content_url: string | null;
+  content_title: string;
+  field_values: FieldValue[];
+}
+
+const itemSchema = {
+  type: "object",
+  required: [
+    "id",
+    "updated_at",
+    "content_type",
+    "content_repo",
+    "content_number",
+    "content_url",
+    "content_title",
+    "field_values",
+  ],
+  properties: {
+    id: { type: "string" },
+    updated_at: { type: "string" },
+    content_type: {
+      type: "string",
+      enum: ["Issue", "PullRequest", "DraftIssue", "Unknown"],
+    },
+    content_repo: { type: ["string", "null"] },
+    content_number: { type: ["integer", "null"] },
+    content_url: { type: ["string", "null"] },
+    content_title: { type: "string" },
+    field_values: { type: "array", items: fieldValueSchema },
+  },
+  additionalProperties: false,
+} as const;
+
+const outputSchema = {
+  type: "object",
+  required: ["items", "hasNextPage", "endCursor"],
+  properties: {
+    items: { type: "array", items: itemSchema },
+    hasNextPage: { type: "boolean" },
+    endCursor: { type: ["string", "null"] },
+  },
+  additionalProperties: false,
+} as const;
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+interface Input {
+  project_id?: string;
+  owner?: string;
+  number?: number;
+  perPage?: number;
+  after?: string;
+}
+
+interface Output {
+  items: Item[];
+  hasNextPage: boolean;
+  endCursor: string | null;
+}
+
+// Raw shapes from the items_list GraphQL query.
+interface RawFieldCommon {
+  id: string;
+  name: string;
+  dataType: ProjectFieldType;
+}
+
+// The five field-value variants the query selects, plus a
+// generic fallback. We type the discriminator on the typed
+// branches as the literal __typename, but the fallback uses a
+// distinct property name so `__typename` stays a literal-only
+// discriminator (TS won't narrow against a `string`-typed
+// discriminator branch).
+type RawFieldValueTyped =
+  | { __typename: "ProjectV2ItemFieldTextValue"; text: string; field: RawFieldCommon }
+  | { __typename: "ProjectV2ItemFieldNumberValue"; number: number; field: RawFieldCommon }
+  | { __typename: "ProjectV2ItemFieldDateValue"; date: string; field: RawFieldCommon }
+  | { __typename: "ProjectV2ItemFieldSingleSelectValue"; optionId: string | null; name: string | null; field: RawFieldCommon }
+  | { __typename: "ProjectV2ItemFieldIterationValue"; iterationId: string; title: string; field: RawFieldCommon };
+
+type TypedTypename = RawFieldValueTyped["__typename"];
+
+const TYPED_TYPENAMES: ReadonlySet<TypedTypename> = new Set([
+  "ProjectV2ItemFieldTextValue",
+  "ProjectV2ItemFieldNumberValue",
+  "ProjectV2ItemFieldDateValue",
+  "ProjectV2ItemFieldSingleSelectValue",
+  "ProjectV2ItemFieldIterationValue",
+]);
+
+// Raw nodes we accept off the wire. Untyped because GraphQL's
+// fieldValues union has many other variants (assignees, labels,
+// etc.) that we filter out via TYPED_TYPENAMES below.
+type RawFieldValue = { __typename: string } & Record<string, unknown>;
+
+interface RawContentIssueOrPR {
+  __typename: "Issue" | "PullRequest";
+  number: number;
+  url: string;
+  title: string;
+  repository: { nameWithOwner: string };
+}
+
+interface RawContentDraft {
+  __typename: "DraftIssue";
+  title: string;
+}
+
+type RawContent = RawContentIssueOrPR | RawContentDraft | { __typename: string };
+
+interface RawItem {
+  id: string;
+  updatedAt: string;
+  content: RawContent | null;
+  fieldValues: {
+    pageInfo: { hasNextPage: boolean };
+    nodes: RawFieldValue[];
+  };
+}
+
+interface ProjectV2WithItems {
+  __typename: "ProjectV2";
+  items: {
+    pageInfo: { hasNextPage: boolean; endCursor: string | null };
+    nodes: RawItem[];
+  };
+}
+
+interface Response {
+  // Same shape rationale as field_list.ts: keep the response
+  // shape loose and narrow via a helper because TS can't narrow
+  // a union where one arm has `__typename: string`.
+  node: { __typename: string } | null;
+}
+
+function isProjectV2WithItems(
+  node: Response["node"],
+): node is ProjectV2WithItems {
+  return node !== null && node.__typename === "ProjectV2";
+}
+
+export function registerProjectItemsListTool(
+  register: RegisterToolFn,
+  graphql: GraphqlClient,
+): void {
+  register("gh.project_items_list", {
+    description:
+      "List items on a Project v2 board, with field values " +
+      "flattened to `{field_id, field_name, type, value}` so " +
+      "callers don't have to switch on the GraphQL union " +
+      "typename. Date / number / text values pass through; " +
+      "single-select returns the option name as the value " +
+      "(consult `gh.project_field_list` for option IDs); " +
+      "iteration returns the iteration title.",
+    inputSchema,
+    handler: async (raw) => {
+      const args = validate<Input>(inputSchema, raw, "gh.project_items_list input");
+      const projectId = await resolveProjectId(
+        graphql,
+        args,
+        "gh.project_items_list",
+      );
+      const data = await graphql<Response>("project/items_list", {
+        projectId,
+        first: args.perPage ?? PER_PAGE_DEFAULT,
+        after: args.after ?? null,
+      });
+      if (!isProjectV2WithItems(data.node)) {
+        throw new Error(
+          `mcp-github: gh.project_items_list: project_id '${projectId}' does not resolve to a ProjectV2`,
+        );
+      }
+      const items = data.node.items.nodes.map(buildItem);
+      const out: Output = {
+        items,
+        hasNextPage: data.node.items.pageInfo.hasNextPage,
+        endCursor: data.node.items.pageInfo.endCursor,
+      };
+      return validate<Output>(outputSchema, out, "gh.project_items_list output");
+    },
+  });
+}
+
+function buildItem(raw: RawItem): Item {
+  let content_type: Item["content_type"] = "Unknown";
+  let content_repo: string | null = null;
+  let content_number: number | null = null;
+  let content_url: string | null = null;
+  let content_title = "";
+  if (raw.content) {
+    const c = raw.content as RawContent;
+    if (c.__typename === "Issue" || c.__typename === "PullRequest") {
+      const ipr = c as RawContentIssueOrPR;
+      content_type = ipr.__typename;
+      content_repo = ipr.repository.nameWithOwner;
+      content_number = ipr.number;
+      content_url = ipr.url;
+      content_title = ipr.title;
+    } else if (c.__typename === "DraftIssue") {
+      content_type = "DraftIssue";
+      content_title = (c as RawContentDraft).title;
+    }
+  }
+  return {
+    id: raw.id,
+    updated_at: raw.updatedAt,
+    content_type,
+    content_repo,
+    content_number,
+    content_url,
+    content_title,
+    field_values: raw.fieldValues.nodes.flatMap(flattenFieldValue),
+  };
+}
+
+// Flatten one tagged-union field-value node onto our flat
+// shape. Returns an empty array for the (rare) case where the
+// node's __typename isn't one of the five typed variants the
+// query selects, so the caller's array still type-checks
+// against `FieldValue[]`.
+function flattenFieldValue(raw: RawFieldValue): FieldValue[] {
+  // Skip untyped fallback variants (assignees, labels, etc.)
+  // upfront so the typed cast below is sound.
+  if (!TYPED_TYPENAMES.has(raw.__typename as TypedTypename)) return [];
+  const typed = raw as RawFieldValueTyped;
+  switch (typed.__typename) {
+    case "ProjectV2ItemFieldTextValue":
+      return [
+        {
+          field_id: typed.field.id,
+          field_name: typed.field.name,
+          type: typed.field.dataType,
+          value: typed.text,
+        },
+      ];
+    case "ProjectV2ItemFieldNumberValue":
+      return [
+        {
+          field_id: typed.field.id,
+          field_name: typed.field.name,
+          type: typed.field.dataType,
+          value: typed.number,
+        },
+      ];
+    case "ProjectV2ItemFieldDateValue":
+      return [
+        {
+          field_id: typed.field.id,
+          field_name: typed.field.name,
+          type: typed.field.dataType,
+          value: typed.date,
+        },
+      ];
+    case "ProjectV2ItemFieldSingleSelectValue":
+      // `name` may be null when the option has been deleted
+      // since the value was set; surface "" so the consumer
+      // doesn't have to handle null vs string-or-number.
+      return [
+        {
+          field_id: typed.field.id,
+          field_name: typed.field.name,
+          type: typed.field.dataType,
+          value: typed.name ?? "",
+        },
+      ];
+    case "ProjectV2ItemFieldIterationValue":
+      return [
+        {
+          field_id: typed.field.id,
+          field_name: typed.field.name,
+          type: typed.field.dataType,
+          value: typed.title,
+        },
+      ];
+  }
+}

--- a/src/tools/project/items_list.ts
+++ b/src/tools/project/items_list.ts
@@ -52,9 +52,11 @@ const fieldValueSchema = {
     field_name: { type: "string" },
     type: projectFieldTypeSchema,
     // The flattened value: text → string, number → number,
-    // date → ISO string, single-select → option name (also
-    // returns option_id alongside), iteration → title (also
-    // returns iteration_id alongside).
+    // date → ISO string, single-select → option name,
+    // iteration → iteration title. Single-select option IDs
+    // (needed for `gh.project_item_update_field`) live on the
+    // field definitions returned by `gh.project_field_list`,
+    // not on items.
     value: { type: ["string", "number"] },
   },
   additionalProperties: false,
@@ -67,8 +69,17 @@ interface Item {
   content_repo: string | null;
   content_number: number | null;
   content_url: string | null;
-  content_title: string;
+  // string when the underlying content carries a title
+  // (Issue / PullRequest / DraftIssue), null when the item has
+  // no resolvable content (Unknown).
+  content_title: string | null;
   field_values: FieldValue[];
+  // True when the project item has more than `field_values.length`
+  // field values on GitHub's side (the GraphQL fieldValues
+  // connection capped at 50 per item). Use `gh.project_field_list`
+  // to enumerate the project's full field set if the truncation
+  // matters for your use-case.
+  field_values_truncated: boolean;
 }
 
 const itemSchema = {
@@ -82,6 +93,7 @@ const itemSchema = {
     "content_url",
     "content_title",
     "field_values",
+    "field_values_truncated",
   ],
   properties: {
     id: { type: "string" },
@@ -93,8 +105,9 @@ const itemSchema = {
     content_repo: { type: ["string", "null"] },
     content_number: { type: ["integer", "null"] },
     content_url: { type: ["string", "null"] },
-    content_title: { type: "string" },
+    content_title: { type: ["string", "null"] },
     field_values: { type: "array", items: fieldValueSchema },
+    field_values_truncated: { type: "boolean" },
   },
   additionalProperties: false,
 } as const;
@@ -219,7 +232,10 @@ export function registerProjectItemsListTool(
       "typename. Date / number / text values pass through; " +
       "single-select returns the option name as the value " +
       "(consult `gh.project_field_list` for option IDs); " +
-      "iteration returns the iteration title.",
+      "iteration returns the iteration title. Each item carries " +
+      "`field_values_truncated: true` when the GraphQL 50-cap on " +
+      "fieldValues hides additional values; `content_title` is " +
+      "null for items whose content is no longer resolvable.",
     inputSchema,
     handler: async (raw) => {
       const args = validate<Input>(inputSchema, raw, "gh.project_items_list input");
@@ -254,7 +270,7 @@ function buildItem(raw: RawItem): Item {
   let content_repo: string | null = null;
   let content_number: number | null = null;
   let content_url: string | null = null;
-  let content_title = "";
+  let content_title: string | null = null;
   if (raw.content) {
     const c = raw.content as RawContent;
     if (c.__typename === "Issue" || c.__typename === "PullRequest") {
@@ -278,6 +294,11 @@ function buildItem(raw: RawItem): Item {
     content_url,
     content_title,
     field_values: raw.fieldValues.nodes.flatMap(flattenFieldValue),
+    // Surface the per-item fieldValues pagination flag so callers
+    // can detect when a project item has more field values than
+    // GraphQL returned in a single page (cap is 50). Without this,
+    // truncation would be silent.
+    field_values_truncated: raw.fieldValues.pageInfo.hasNextPage,
   };
 }
 

--- a/tests/smoke/server-lists-tools.mjs
+++ b/tests/smoke/server-lists-tools.mjs
@@ -50,6 +50,10 @@ const EXPECTED_TOOLS = [
   "gh.pr_comment",
   "gh.pr_merge",
   "gh.pr_request_reviews",
+  "gh.project_item_add",
+  "gh.project_item_update_field",
+  "gh.project_field_list",
+  "gh.project_items_list",
 ];
 
 function frame(payload) {

--- a/tests/unit/tools/project/_fixtures.ts
+++ b/tests/unit/tools/project/_fixtures.ts
@@ -1,0 +1,55 @@
+// tests/unit/tools/project/_fixtures.ts
+//
+// Shared stub-graphql helper for the gh.project_* tool tests,
+// matching the issue/pr/label fixture shape.
+
+import type { GraphqlClient } from "../../../../src/graphql/client.ts";
+
+export interface MockedCall {
+  queryName: string;
+  vars: Record<string, unknown>;
+}
+
+export function stubGraphqlClient(
+  fixtures: Record<
+    string,
+    | unknown
+    | ((vars: Record<string, unknown>) => unknown | Promise<unknown>)
+  >,
+): { graphql: GraphqlClient; calls: MockedCall[] } {
+  const calls: MockedCall[] = [];
+  const graphql = (async (
+    queryName: string,
+    vars: Record<string, unknown> = {},
+  ) => {
+    calls.push({ queryName, vars });
+    if (!(queryName in fixtures)) {
+      throw new Error(
+        `tests: stubGraphqlClient saw unmocked queryName: ${queryName}`,
+      );
+    }
+    const entry = fixtures[queryName];
+    if (typeof entry === "function") {
+      return await (entry as (v: Record<string, unknown>) => unknown)(vars);
+    }
+    return entry;
+  }) as unknown as GraphqlClient;
+  return { graphql, calls };
+}
+
+// Common project-resolution fixtures used by every project tool
+// test (each tool resolves the project ref before the actual op).
+export const projectIdResolutionOrgWins = {
+  organization: { projectV2: { id: "PVT_kwDO_proj" } },
+  user: null,
+};
+
+export const projectIdResolutionUserWins = {
+  organization: null,
+  user: { projectV2: { id: "PVT_kwDO_userproj" } },
+};
+
+export const projectIdResolutionNotFound = {
+  organization: null,
+  user: null,
+};

--- a/tests/unit/tools/project/field_list.test.ts
+++ b/tests/unit/tools/project/field_list.test.ts
@@ -1,0 +1,153 @@
+// tests/unit/tools/project/field_list.test.ts
+//
+// gh.project_field_list: pin the polymorphic ProjectV2 field
+// flattening — single-select carries `options[]`, iteration
+// merges current + completed iterations into the same shape,
+// other field types come back with `options: []`.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { registerProjectFieldListTool } from "../../../../src/tools/project/field_list.ts";
+import type { ToolEntry } from "../../../../src/registry.ts";
+import { stubGraphqlClient } from "./_fixtures.ts";
+
+function captureRegistration() {
+  let entry: ToolEntry | undefined;
+  const register = (name: string, e: ToolEntry) => {
+    if (name !== "gh.project_field_list") throw new Error(`unexpected: ${name}`);
+    entry = e;
+  };
+  return {
+    register,
+    get entry(): ToolEntry {
+      if (!entry) throw new Error("not registered");
+      return entry;
+    },
+  };
+}
+
+test("gh.project_field_list: flattens common, single-select, and iteration fields uniformly", async () => {
+  const { graphql } = stubGraphqlClient({
+    "project/field_list": {
+      node: {
+        __typename: "ProjectV2",
+        fields: {
+          pageInfo: { hasNextPage: false },
+          nodes: [
+            {
+              __typename: "ProjectV2Field",
+              id: "PVTF_text",
+              name: "Notes",
+              dataType: "TEXT",
+            },
+            {
+              __typename: "ProjectV2SingleSelectField",
+              id: "PVTSF_status",
+              name: "Status",
+              dataType: "SINGLE_SELECT",
+              options: [
+                { id: "OPT_todo", name: "Todo" },
+                { id: "OPT_done", name: "Done" },
+              ],
+            },
+            {
+              __typename: "ProjectV2IterationField",
+              id: "PVTIF_sprint",
+              name: "Sprint",
+              dataType: "ITERATION",
+              configuration: {
+                iterations: [{ id: "ITER_q2", title: "2026-Q2" }],
+                completedIterations: [{ id: "ITER_q1", title: "2026-Q1" }],
+              },
+            },
+          ],
+        },
+      },
+    },
+  });
+  const reg = captureRegistration();
+  registerProjectFieldListTool(reg.register, graphql);
+  const out = (await reg.entry.handler({ project_id: "PVT_X" })) as {
+    fields: Array<{
+      id: string;
+      name: string;
+      data_type: string;
+      options: Array<{ id: string; name: string }>;
+    }>;
+    hasNextPage: boolean;
+  };
+  assert.equal(out.fields.length, 3);
+  // Common field: empty options array.
+  assert.equal(out.fields[0]?.id, "PVTF_text");
+  assert.equal(out.fields[0]?.data_type, "TEXT");
+  assert.deepEqual(out.fields[0]?.options, []);
+  // Single-select: options pass through.
+  assert.deepEqual(
+    out.fields[1]?.options.map((o) => o.id),
+    ["OPT_todo", "OPT_done"],
+  );
+  // Iteration: current + completed merge, current first.
+  assert.deepEqual(
+    out.fields[2]?.options.map((o) => o.id),
+    ["ITER_q2", "ITER_q1"],
+  );
+  assert.equal(out.hasNextPage, false);
+});
+
+test("gh.project_field_list: throws when project_id resolves to a non-ProjectV2 node", async () => {
+  // Defends against the easy footgun where someone passes an
+  // Issue's GraphQL ID as `project_id`. node() would return the
+  // Issue, our typename check rejects it.
+  const { graphql } = stubGraphqlClient({
+    "project/field_list": {
+      node: { __typename: "Issue" },
+    },
+  });
+  const reg = captureRegistration();
+  registerProjectFieldListTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ project_id: "I_kwDO_42" }),
+    /'I_kwDO_42' does not resolve to a ProjectV2/,
+  );
+});
+
+test("gh.project_field_list: owner+number path resolves project id first", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "project/_resolve-project-id": {
+      organization: { projectV2: { id: "PVT_resolved" } },
+      user: null,
+    },
+    "project/field_list": (vars: Record<string, unknown>) => {
+      assert.equal(vars.projectId, "PVT_resolved");
+      return {
+        node: {
+          __typename: "ProjectV2",
+          fields: { pageInfo: { hasNextPage: false }, nodes: [] },
+        },
+      };
+    },
+  });
+  const reg = captureRegistration();
+  registerProjectFieldListTool(reg.register, graphql);
+  await reg.entry.handler({ owner: "myorg", number: 1 });
+  assert.deepEqual(
+    calls.map((c) => c.queryName),
+    ["project/_resolve-project-id", "project/field_list"],
+  );
+});
+
+test("gh.project_field_list: throws clear error when project not found by owner+number", async () => {
+  const { graphql } = stubGraphqlClient({
+    "project/_resolve-project-id": {
+      organization: null,
+      user: null,
+    },
+  });
+  const reg = captureRegistration();
+  registerProjectFieldListTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ owner: "ghost", number: 999 }),
+    /'ghost\/projects\/999' not found/,
+  );
+});

--- a/tests/unit/tools/project/item_add.test.ts
+++ b/tests/unit/tools/project/item_add.test.ts
@@ -1,0 +1,160 @@
+// tests/unit/tools/project/item_add.test.ts
+//
+// gh.project_item_add: pin the two cross-product oneOf shapes
+// (project ref × content ref), the URL parser, and the
+// post-resolve mutation input shape.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { registerProjectItemAddTool } from "../../../../src/tools/project/item_add.ts";
+import type { ToolEntry } from "../../../../src/registry.ts";
+import {
+  projectIdResolutionOrgWins,
+  stubGraphqlClient,
+} from "./_fixtures.ts";
+
+function captureRegistration() {
+  let entry: ToolEntry | undefined;
+  const register = (name: string, e: ToolEntry) => {
+    if (name !== "gh.project_item_add") throw new Error(`unexpected: ${name}`);
+    entry = e;
+  };
+  return {
+    register,
+    get entry(): ToolEntry {
+      if (!entry) throw new Error("not registered");
+      return entry;
+    },
+  };
+}
+
+test("gh.project_item_add: project_id + content_id path skips both lookups, runs only the mutation", async () => {
+  let mutationInput: Record<string, unknown> | undefined;
+  const { graphql, calls } = stubGraphqlClient({
+    "project/item_add": (vars: Record<string, unknown>) => {
+      mutationInput = vars.input as Record<string, unknown>;
+      return { addProjectV2ItemById: { item: { id: "PVTI_new" } } };
+    },
+  });
+  const reg = captureRegistration();
+  registerProjectItemAddTool(reg.register, graphql);
+  const out = await reg.entry.handler({
+    project_id: "PVT_existing",
+    content_id: "I_existing",
+  });
+  assert.deepEqual(out, { item_id: "PVTI_new" });
+  assert.deepEqual(mutationInput, {
+    projectId: "PVT_existing",
+    contentId: "I_existing",
+  });
+  // No resolution calls, just the mutation.
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]?.queryName, "project/item_add");
+});
+
+test("gh.project_item_add: owner+number + content_url resolves both before the mutation", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "project/_resolve-project-id": projectIdResolutionOrgWins,
+    "project/_resolve-content-id": (vars: Record<string, unknown>) => {
+      assert.equal(vars.owner, "myorg");
+      assert.equal(vars.name, "myrepo");
+      assert.equal(vars.number, 42);
+      return {
+        repository: {
+          issue: { id: "I_kwDO_42" },
+          pullRequest: null,
+        },
+      };
+    },
+    "project/item_add": (vars: Record<string, unknown>) => {
+      const input = vars.input as Record<string, unknown>;
+      assert.equal(input.projectId, "PVT_kwDO_proj");
+      assert.equal(input.contentId, "I_kwDO_42");
+      return { addProjectV2ItemById: { item: { id: "PVTI_new" } } };
+    },
+  });
+  const reg = captureRegistration();
+  registerProjectItemAddTool(reg.register, graphql);
+  await reg.entry.handler({
+    owner: "myorg",
+    number: 1,
+    content_url: "https://github.com/myorg/myrepo/issues/42",
+  });
+  // Both resolution queries + the mutation.
+  assert.equal(calls.length, 3);
+});
+
+test("gh.project_item_add: pull URL routes to the pullRequest field on the content lookup", async () => {
+  const { graphql } = stubGraphqlClient({
+    "project/_resolve-project-id": projectIdResolutionOrgWins,
+    "project/_resolve-content-id": () => ({
+      repository: {
+        issue: null,
+        pullRequest: { id: "PR_kwDO_99" },
+      },
+    }),
+    "project/item_add": (vars: Record<string, unknown>) => {
+      assert.equal(
+        (vars.input as Record<string, unknown>).contentId,
+        "PR_kwDO_99",
+      );
+      return { addProjectV2ItemById: { item: { id: "PVTI_pr" } } };
+    },
+  });
+  const reg = captureRegistration();
+  registerProjectItemAddTool(reg.register, graphql);
+  const out = await reg.entry.handler({
+    owner: "myorg",
+    number: 1,
+    content_url: "https://github.com/myorg/myrepo/pull/99",
+  });
+  assert.equal((out as { item_id: string }).item_id, "PVTI_pr");
+});
+
+test("gh.project_item_add: rejects mixing project_id with owner/number", async () => {
+  // The schema's project-ref oneOf must reject the four-field
+  // mixed shape so an under-specified call can't slip through.
+  const { graphql } = stubGraphqlClient({});
+  const reg = captureRegistration();
+  registerProjectItemAddTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      project_id: "PVT_X",
+      owner: "myorg",
+      number: 1,
+      content_id: "I_Y",
+    }),
+    /gh\.project_item_add input/,
+  );
+});
+
+test("gh.project_item_add: rejects mixing content_id with content_url", async () => {
+  const { graphql } = stubGraphqlClient({});
+  const reg = captureRegistration();
+  registerProjectItemAddTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      project_id: "PVT_X",
+      content_id: "I_Y",
+      content_url: "https://github.com/o/r/issues/1",
+    }),
+    /gh\.project_item_add input/,
+  );
+});
+
+test("gh.project_item_add: rejects malformed content_url", async () => {
+  const { graphql } = stubGraphqlClient({});
+  const reg = captureRegistration();
+  registerProjectItemAddTool(reg.register, graphql);
+  // The schema's `pattern: "^https://github\\.com/"` rejects
+  // upfront; a URL that passes the pattern but isn't a real
+  // issue/PR path also gets a clean error from the parser.
+  await assert.rejects(
+    reg.entry.handler({
+      project_id: "PVT_X",
+      content_url: "https://github.com/foo",
+    }),
+    /not a recognised github\.com issue or pull URL/,
+  );
+});

--- a/tests/unit/tools/project/item_add.test.ts
+++ b/tests/unit/tools/project/item_add.test.ts
@@ -158,3 +158,20 @@ test("gh.project_item_add: rejects malformed content_url", async () => {
     /not a recognised github\.com issue or pull URL/,
   );
 });
+
+test("gh.project_item_add: rejects URL with garbage tail after the issue number", async () => {
+  // `.../issues/123abc` previously parsed as 123 because the
+  // regex didn't anchor a boundary after the numeric segment.
+  // Pin the rejection so a typo can never silently resolve to
+  // the wrong issue.
+  const { graphql } = stubGraphqlClient({});
+  const reg = captureRegistration();
+  registerProjectItemAddTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      project_id: "PVT_X",
+      content_url: "https://github.com/o/r/issues/123abc",
+    }),
+    /not a recognised github\.com issue or pull URL/,
+  );
+});

--- a/tests/unit/tools/project/item_update_field.test.ts
+++ b/tests/unit/tools/project/item_update_field.test.ts
@@ -1,0 +1,160 @@
+// tests/unit/tools/project/item_update_field.test.ts
+//
+// gh.project_item_update_field: pin the value-tagged-union
+// behaviour at the schema boundary (exactly-one-of) and the
+// snake_case → camelCase translation in the GraphQL input.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { registerProjectItemUpdateFieldTool } from "../../../../src/tools/project/item_update_field.ts";
+import type { ToolEntry } from "../../../../src/registry.ts";
+import { stubGraphqlClient } from "./_fixtures.ts";
+
+function captureRegistration() {
+  let entry: ToolEntry | undefined;
+  const register = (name: string, e: ToolEntry) => {
+    if (name !== "gh.project_item_update_field") throw new Error(`unexpected: ${name}`);
+    entry = e;
+  };
+  return {
+    register,
+    get entry(): ToolEntry {
+      if (!entry) throw new Error("not registered");
+      return entry;
+    },
+  };
+}
+
+const sampleResponse = {
+  updateProjectV2ItemFieldValue: {
+    projectV2Item: {
+      id: "PVTI_target",
+      updatedAt: "2026-04-29T00:00:00Z",
+    },
+  },
+};
+
+test("gh.project_item_update_field: text value passes through unchanged", async () => {
+  const { graphql } = stubGraphqlClient({
+    "project/item_update_field": (vars: Record<string, unknown>) => {
+      const input = vars.input as Record<string, unknown>;
+      assert.equal(input.projectId, "PVT_X");
+      assert.equal(input.itemId, "PVTI_X");
+      assert.equal(input.fieldId, "PVTF_X");
+      assert.deepEqual(input.value, { text: "hello" });
+      return sampleResponse;
+    },
+  });
+  const reg = captureRegistration();
+  registerProjectItemUpdateFieldTool(reg.register, graphql);
+  const out = await reg.entry.handler({
+    project_id: "PVT_X",
+    item_id: "PVTI_X",
+    field_id: "PVTF_X",
+    value: { text: "hello" },
+  });
+  assert.deepEqual(out, {
+    item_id: "PVTI_target",
+    updated_at: "2026-04-29T00:00:00Z",
+  });
+});
+
+test("gh.project_item_update_field: snake-case single_select_option_id → camelCase singleSelectOptionId", async () => {
+  // GraphQL field naming convention requires camelCase. Pin the
+  // translation so a future refactor that drops the snake-case
+  // input shape breaks here visibly.
+  const { graphql } = stubGraphqlClient({
+    "project/item_update_field": (vars: Record<string, unknown>) => {
+      const input = vars.input as Record<string, unknown>;
+      assert.deepEqual(input.value, { singleSelectOptionId: "OPT_in_progress" });
+      return sampleResponse;
+    },
+  });
+  const reg = captureRegistration();
+  registerProjectItemUpdateFieldTool(reg.register, graphql);
+  await reg.entry.handler({
+    project_id: "PVT_X",
+    item_id: "PVTI_X",
+    field_id: "PVTF_X",
+    value: { single_select_option_id: "OPT_in_progress" },
+  });
+});
+
+test("gh.project_item_update_field: iteration_id → iterationId", async () => {
+  const { graphql } = stubGraphqlClient({
+    "project/item_update_field": (vars: Record<string, unknown>) => {
+      const input = vars.input as Record<string, unknown>;
+      assert.deepEqual(input.value, { iterationId: "ITER_2026Q2" });
+      return sampleResponse;
+    },
+  });
+  const reg = captureRegistration();
+  registerProjectItemUpdateFieldTool(reg.register, graphql);
+  await reg.entry.handler({
+    project_id: "PVT_X",
+    item_id: "PVTI_X",
+    field_id: "PVTF_X",
+    value: { iteration_id: "ITER_2026Q2" },
+  });
+});
+
+test("gh.project_item_update_field: rejects mixing two value branches", async () => {
+  const { graphql } = stubGraphqlClient({
+    "project/item_update_field": () => {
+      throw new Error("must not run when input shape is invalid");
+    },
+  });
+  const reg = captureRegistration();
+  registerProjectItemUpdateFieldTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      project_id: "PVT_X",
+      item_id: "PVTI_X",
+      field_id: "PVTF_X",
+      // Both `text` AND `number` set — schema's oneOf must
+      // reject. Otherwise GraphQL would silently pick whichever
+      // it processes first.
+      value: { text: "hi", number: 5 },
+    }),
+    /gh\.project_item_update_field input/,
+  );
+});
+
+test("gh.project_item_update_field: rejects empty value object", async () => {
+  const { graphql } = stubGraphqlClient({
+    "project/item_update_field": () => {
+      throw new Error("must not run");
+    },
+  });
+  const reg = captureRegistration();
+  registerProjectItemUpdateFieldTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      project_id: "PVT_X",
+      item_id: "PVTI_X",
+      field_id: "PVTF_X",
+      value: {},
+    }),
+    /gh\.project_item_update_field input/,
+  );
+});
+
+test("gh.project_item_update_field: rejects malformed date format (not YYYY-MM-DD)", async () => {
+  const { graphql } = stubGraphqlClient({
+    "project/item_update_field": () => {
+      throw new Error("must not run");
+    },
+  });
+  const reg = captureRegistration();
+  registerProjectItemUpdateFieldTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      project_id: "PVT_X",
+      item_id: "PVTI_X",
+      field_id: "PVTF_X",
+      value: { date: "not-a-date" },
+    }),
+    /gh\.project_item_update_field input/,
+  );
+});

--- a/tests/unit/tools/project/items_list.test.ts
+++ b/tests/unit/tools/project/items_list.test.ts
@@ -99,13 +99,14 @@ test("gh.project_items_list: flattens five typed value variants onto the uniform
       content_type: string;
       content_repo: string | null;
       content_number: number | null;
-      content_title: string;
+      content_title: string | null;
       field_values: Array<{
         field_id: string;
         field_name: string;
         type: string;
         value: string | number;
       }>;
+      field_values_truncated: boolean;
     }>;
     hasNextPage: boolean;
   };
@@ -115,6 +116,7 @@ test("gh.project_items_list: flattens five typed value variants onto the uniform
   assert.equal(item.content_repo, "o/r");
   assert.equal(item.content_number, 42);
   assert.equal(item.content_title, "Sample issue");
+  assert.equal(item.field_values_truncated, false);
   // Five flattened entries (the LabelValue is dropped).
   assert.equal(item.field_values.length, 5);
   assert.deepEqual(
@@ -213,6 +215,48 @@ test("gh.project_items_list: deleted single-select option surfaces value '' inst
     items: Array<{ field_values: Array<{ value: string | number }> }>;
   };
   assert.equal(out.items[0]?.field_values[0]?.value, "");
+});
+
+test("gh.project_items_list: field_values_truncated true when fieldValues page has more results", async () => {
+  // GraphQL fieldValues caps at 50 per item. Surface the
+  // truncation flag from the per-item pageInfo.hasNextPage so a
+  // caller doesn't operate on a partial flat-value set without
+  // realising it.
+  const { graphql } = stubGraphqlClient({
+    "project/items_list": {
+      node: {
+        __typename: "ProjectV2",
+        items: {
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: [
+            {
+              id: "PVTI_big",
+              updatedAt: "2026-04-29T00:00:00Z",
+              content: null,
+              fieldValues: {
+                pageInfo: { hasNextPage: true },
+                nodes: [
+                  {
+                    __typename: "ProjectV2ItemFieldTextValue",
+                    text: "first of many",
+                    field: fieldNotes,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    },
+  });
+  const reg = captureRegistration();
+  registerProjectItemsListTool(reg.register, graphql);
+  const out = (await reg.entry.handler({ project_id: "PVT_X" })) as {
+    items: Array<{ field_values_truncated: boolean; content_title: string | null }>;
+  };
+  assert.equal(out.items[0]?.field_values_truncated, true);
+  // Unknown content (raw.content === null) → content_title null.
+  assert.equal(out.items[0]?.content_title, null);
 });
 
 test("gh.project_items_list: throws when project_id resolves to a non-ProjectV2 node", async () => {

--- a/tests/unit/tools/project/items_list.test.ts
+++ b/tests/unit/tools/project/items_list.test.ts
@@ -1,0 +1,230 @@
+// tests/unit/tools/project/items_list.test.ts
+//
+// gh.project_items_list: pin the field-value flattening (the
+// tagged-union union → flat {field_id, field_name, type, value}
+// shape) and the content-type bucketing (Issue/PR/DraftIssue).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { registerProjectItemsListTool } from "../../../../src/tools/project/items_list.ts";
+import type { ToolEntry } from "../../../../src/registry.ts";
+import { stubGraphqlClient } from "./_fixtures.ts";
+
+function captureRegistration() {
+  let entry: ToolEntry | undefined;
+  const register = (name: string, e: ToolEntry) => {
+    if (name !== "gh.project_items_list") throw new Error(`unexpected: ${name}`);
+    entry = e;
+  };
+  return {
+    register,
+    get entry(): ToolEntry {
+      if (!entry) throw new Error("not registered");
+      return entry;
+    },
+  };
+}
+
+const fieldStatus = { id: "F_status", name: "Status", dataType: "SINGLE_SELECT" };
+const fieldNotes = { id: "F_notes", name: "Notes", dataType: "TEXT" };
+const fieldEffort = { id: "F_effort", name: "Effort", dataType: "NUMBER" };
+const fieldSprint = { id: "F_sprint", name: "Sprint", dataType: "ITERATION" };
+const fieldDue = { id: "F_due", name: "Due", dataType: "DATE" };
+
+test("gh.project_items_list: flattens five typed value variants onto the uniform shape", async () => {
+  const { graphql } = stubGraphqlClient({
+    "project/items_list": {
+      node: {
+        __typename: "ProjectV2",
+        items: {
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: [
+            {
+              id: "PVTI_a",
+              updatedAt: "2026-04-29T00:00:00Z",
+              content: {
+                __typename: "Issue",
+                number: 42,
+                url: "https://github.com/o/r/issues/42",
+                title: "Sample issue",
+                repository: { nameWithOwner: "o/r" },
+              },
+              fieldValues: {
+                pageInfo: { hasNextPage: false },
+                nodes: [
+                  {
+                    __typename: "ProjectV2ItemFieldTextValue",
+                    text: "Hello",
+                    field: fieldNotes,
+                  },
+                  {
+                    __typename: "ProjectV2ItemFieldNumberValue",
+                    number: 5,
+                    field: fieldEffort,
+                  },
+                  {
+                    __typename: "ProjectV2ItemFieldDateValue",
+                    date: "2026-05-01",
+                    field: fieldDue,
+                  },
+                  {
+                    __typename: "ProjectV2ItemFieldSingleSelectValue",
+                    optionId: "OPT_in_progress",
+                    name: "In progress",
+                    field: fieldStatus,
+                  },
+                  {
+                    __typename: "ProjectV2ItemFieldIterationValue",
+                    iterationId: "ITER_q2",
+                    title: "2026-Q2",
+                    field: fieldSprint,
+                  },
+                  // An untyped variant we don't select for —
+                  // must be silently skipped.
+                  { __typename: "ProjectV2ItemFieldLabelValue" },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    },
+  });
+  const reg = captureRegistration();
+  registerProjectItemsListTool(reg.register, graphql);
+  const out = (await reg.entry.handler({ project_id: "PVT_X" })) as {
+    items: Array<{
+      id: string;
+      content_type: string;
+      content_repo: string | null;
+      content_number: number | null;
+      content_title: string;
+      field_values: Array<{
+        field_id: string;
+        field_name: string;
+        type: string;
+        value: string | number;
+      }>;
+    }>;
+    hasNextPage: boolean;
+  };
+  assert.equal(out.items.length, 1);
+  const item = out.items[0]!;
+  assert.equal(item.content_type, "Issue");
+  assert.equal(item.content_repo, "o/r");
+  assert.equal(item.content_number, 42);
+  assert.equal(item.content_title, "Sample issue");
+  // Five flattened entries (the LabelValue is dropped).
+  assert.equal(item.field_values.length, 5);
+  assert.deepEqual(
+    item.field_values.map((v) => ({ name: v.field_name, value: v.value })),
+    [
+      { name: "Notes", value: "Hello" },
+      { name: "Effort", value: 5 },
+      { name: "Due", value: "2026-05-01" },
+      { name: "Status", value: "In progress" },
+      { name: "Sprint", value: "2026-Q2" },
+    ],
+  );
+});
+
+test("gh.project_items_list: DraftIssue content surfaces with content_type DraftIssue + null repo/number/url", async () => {
+  // Drafts are project-only items not backed by an issue/PR.
+  // Pin the null-shape so consumers can tell them apart from
+  // issue/PR items at a glance.
+  const { graphql } = stubGraphqlClient({
+    "project/items_list": {
+      node: {
+        __typename: "ProjectV2",
+        items: {
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: [
+            {
+              id: "PVTI_draft",
+              updatedAt: "2026-04-29T00:00:00Z",
+              content: {
+                __typename: "DraftIssue",
+                title: "Draft idea",
+              },
+              fieldValues: {
+                pageInfo: { hasNextPage: false },
+                nodes: [],
+              },
+            },
+          ],
+        },
+      },
+    },
+  });
+  const reg = captureRegistration();
+  registerProjectItemsListTool(reg.register, graphql);
+  const out = (await reg.entry.handler({ project_id: "PVT_X" })) as {
+    items: Array<{
+      content_type: string;
+      content_repo: string | null;
+      content_number: number | null;
+      content_url: string | null;
+      content_title: string;
+    }>;
+  };
+  assert.equal(out.items[0]?.content_type, "DraftIssue");
+  assert.equal(out.items[0]?.content_repo, null);
+  assert.equal(out.items[0]?.content_number, null);
+  assert.equal(out.items[0]?.content_url, null);
+  assert.equal(out.items[0]?.content_title, "Draft idea");
+});
+
+test("gh.project_items_list: deleted single-select option surfaces value '' instead of null", async () => {
+  // GraphQL returns name: null when the option has been deleted
+  // since the value was set. We coerce to '' so the consumer's
+  // `value: string | number` invariant holds.
+  const { graphql } = stubGraphqlClient({
+    "project/items_list": {
+      node: {
+        __typename: "ProjectV2",
+        items: {
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: [
+            {
+              id: "PVTI_a",
+              updatedAt: "2026-04-29T00:00:00Z",
+              content: null,
+              fieldValues: {
+                pageInfo: { hasNextPage: false },
+                nodes: [
+                  {
+                    __typename: "ProjectV2ItemFieldSingleSelectValue",
+                    optionId: null,
+                    name: null,
+                    field: fieldStatus,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    },
+  });
+  const reg = captureRegistration();
+  registerProjectItemsListTool(reg.register, graphql);
+  const out = (await reg.entry.handler({ project_id: "PVT_X" })) as {
+    items: Array<{ field_values: Array<{ value: string | number }> }>;
+  };
+  assert.equal(out.items[0]?.field_values[0]?.value, "");
+});
+
+test("gh.project_items_list: throws when project_id resolves to a non-ProjectV2 node", async () => {
+  const { graphql } = stubGraphqlClient({
+    "project/items_list": {
+      node: { __typename: "Issue" },
+    },
+  });
+  const reg = captureRegistration();
+  registerProjectItemsListTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ project_id: "I_kwDO_42" }),
+    /does not resolve to a ProjectV2/,
+  );
+});


### PR DESCRIPTION
## Summary

Wraps GitHub Projects v2 ops as 4 MCP tools. **GraphQL-based.** Heavily used by the Bundle's tracker-sync skill for the org-wide tracking board (status / priority / size field updates per issue + adding new issues to the project on creation).

| Tool | Input | Output |
|---|---|---|
| `gh.project_item_add` | `{project_id\|owner+number, content_id\|content_url}` | `{item_id}` |
| `gh.project_item_update_field` | `{project_id\|owner+number, item_id, field_id, value: tagged-union}` | `{item_id, updated_at}` |
| `gh.project_field_list` | `{project_id\|owner+number}` | `{fields[], hasNextPage}` |
| `gh.project_items_list` | `{project_id\|owner+number, perPage?, after?}` | `{items[], hasNextPage, endCursor}` |

### Cross-product oneOf shapes

`gh.project_item_add` enforces TWO mutually-exclusive pairs at the schema boundary:
- **Project reference:** either `project_id` (raw GraphQL node ID) OR `owner + number` (project URL form).
- **Content reference:** either `content_id` (raw GraphQL node ID of the issue/PR) OR `content_url` (the standard `https://github.com/owner/repo/(issues|pull)/N` shape, resolved to the node ID via a small lookup).

Schema rejects the four-field mixed shape upfront. The other three tools enforce only the project-ref oneOf.

### `gh.project_item_update_field` value union

Pass exactly one of:
- `text` (string)
- `number` (number)
- `date` (ISO YYYY-MM-DD; ajv-formats validates the format)
- `single_select_option_id` (string)
- `iteration_id` (string)

Snake-case input keys translate to GraphQL camelCase (`single_select_option_id` → `singleSelectOptionId`). Empty `value: {}` and double-set values both fail at the input boundary.

### Field + item shape design

- **Field list flattens iteration fields:** `ProjectV2IterationField`'s `configuration` carries separate `iterations` and `completedIterations` arrays; we merge them into a single `options` array (current iterations first) so consumers don't have to switch on `__typename`.
- **Items list flattens field values:** the GraphQL response is a tagged union over text/number/date/single-select/iteration value variants. Output flattens to `{field_id, field_name, type, value}` per value, with single-select returning the option name as the value (consult `field_list` for option IDs). Untyped variants we don't model (assignees/labels/etc., derived from the issue/PR) are silently skipped. Each item carries `field_values_truncated: true` when the GraphQL 50-cap on per-item fieldValues hides additional values, so callers can detect the truncation explicitly.
- **Items carry the content (Issue/PR/DraftIssue/Unknown)** at the top level — `content_repo`, `content_number`, `content_url` populated for issues and PRs (null for drafts and unknown). `content_title` is the title for Issue/PR/DraftIssue; null only when the underlying content is no longer resolvable (Unknown).

### Files

- `src/tools/project/` — `_shared.ts` (parsers + project ref helpers + canonical schemas), 4 tool files, `index.ts` aggregator.
- `src/graphql/queries/project/` — 6 `.graphql` files (2 resolvers + 4 main ops). Reading through `node(id: \$projectId)` means the same query handles both Organization-owned and User-owned projects without branching.
- `src/server.ts` — wires `registerProjectTools()` alongside the existing tool registrations.

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` — **all unit tests pass** (new tests across the four tools, including field_values_truncated and Unknown-content null content_title).
- [x] Smoke asserts 23 tools (1 auth + 7 issue + 4 label + 7 PR + 4 project).
- [x] Cross-product oneOf enforcement: rejecting `project_id + owner/number` mix and `content_id + content_url` mix on `item_add`.
- [x] Value tagged-union: exactly-one-of branches, snake → camel translation, empty `value: {}` rejection, malformed date rejection.
- [x] Field flattening: common / single-select / iteration variants pin the same output shape.
- [x] Items flattening: five typed value variants pin to flat shape; untyped variants silently skipped; deleted single-select option surfaces as `""` (not null); `field_values_truncated` flag pinned.
- [x] Content-type bucketing: Issue / PullRequest / DraftIssue / Unknown (DraftIssue surfaces its title via content_title; Unknown surfaces null).
- [x] Non-ProjectV2 node ID rejected with clear "does not resolve to a ProjectV2".
- [ ] Live integration probe (real Project v2 ops against a PAT) lands in MCP-12.

## Stack

After the merged epic chain. **Independent of MCP-9** (Workflow ops, also incoming as PR #25) — both can merge in either order; whichever lands first gets a clean rebase on the other.

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)