### PR TITLE
feat: gh.issue_add_sub_issue (A1)

### DIFF
--- a/src/graphql/queries/issue/add_sub_issue.graphql
+++ b/src/graphql/queries/issue/add_sub_issue.graphql
@@ -1,0 +1,12 @@
+mutation IssueAddSubIssue($input: AddSubIssueInput!) {
+  addSubIssue(input: $input) {
+    issue {
+      id
+      number
+    }
+    subIssue {
+      id
+      number
+    }
+  }
+}

--- a/src/tools/issue/add_sub_issue.ts
+++ b/src/tools/issue/add_sub_issue.ts
@@ -1,0 +1,195 @@
+// src/tools/issue/add_sub_issue.ts
+//
+// `gh.issue_add_sub_issue` — wire a child issue under a parent
+// via GitHub's `addSubIssue` GraphQL mutation. The mutation
+// requires node IDs on both sides; this tool accepts either a
+// pre-resolved `node_id` or a `(repo, number)` pair per side and
+// resolves the IDs lazily, in parallel where possible, so the
+// methodology's plan-to-issues flow can wire the tree using the
+// numbers it just captured from `gh.issue_create`.
+
+import type { GraphqlClient } from "../../graphql/client.js";
+import type { ToolEntry } from "../../registry.js";
+import { validate } from "../../validation/validator.js";
+import {
+  lookupIssueNodeId,
+  parseRepoSlug,
+  repoSlugSchema,
+} from "./_shared.js";
+
+// Per-side input shape: EITHER `node_id` OR `(repo, number)`. The
+// `oneOf` schema fragment is built once here and reused for both
+// `parent` and `child` so the constraint is identical on each
+// side.
+const issueRefSchema = {
+  type: "object",
+  properties: {
+    node_id: {
+      type: "string",
+      minLength: 1,
+      description:
+        "Issue GraphQL node ID. Mutually exclusive with repo + " +
+        "number; supply ONE of the two shapes.",
+    },
+    repo: {
+      ...repoSlugSchema,
+      description:
+        "Repository in the form `owner/name`. Pair with " +
+        "`number`. Mutually exclusive with `node_id`.",
+    },
+    number: {
+      type: "integer",
+      minimum: 1,
+      description: "Issue number. Pair with `repo`.",
+    },
+  },
+  oneOf: [
+    {
+      required: ["node_id"],
+      not: { anyOf: [{ required: ["repo"] }, { required: ["number"] }] },
+    },
+    {
+      required: ["repo", "number"],
+      not: { required: ["node_id"] },
+    },
+  ],
+  additionalProperties: false,
+} as const;
+
+const inputSchema = {
+  type: "object",
+  required: ["parent", "child"],
+  properties: {
+    parent: issueRefSchema,
+    child: issueRefSchema,
+  },
+  additionalProperties: false,
+} as const;
+
+const outputSchema = {
+  type: "object",
+  required: ["parent", "child"],
+  properties: {
+    parent: {
+      type: "object",
+      required: ["number", "node_id"],
+      properties: {
+        number: { type: "integer" },
+        node_id: { type: "string" },
+      },
+      additionalProperties: false,
+    },
+    child: {
+      type: "object",
+      required: ["number", "node_id"],
+      properties: {
+        number: { type: "integer" },
+        node_id: { type: "string" },
+      },
+      additionalProperties: false,
+    },
+  },
+  additionalProperties: false,
+} as const;
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+interface IssueRef {
+  node_id?: string;
+  repo?: string;
+  number?: number;
+}
+
+interface Input {
+  parent: IssueRef;
+  child: IssueRef;
+}
+
+interface Output {
+  parent: { number: number; node_id: string };
+  child: { number: number; node_id: string };
+}
+
+interface AddSubIssueResponse {
+  addSubIssue: {
+    issue: { id: string; number: number };
+    subIssue: { id: string; number: number };
+  };
+}
+
+export function registerIssueAddSubIssueTool(
+  register: RegisterToolFn,
+  graphql: GraphqlClient,
+): void {
+  register("gh.issue_add_sub_issue", {
+    description:
+      "Wire a child issue under a parent via GitHub's native " +
+      "`addSubIssue` GraphQL mutation. Either side accepts a raw " +
+      "`node_id` or a `(repo, number)` pair — node IDs are resolved " +
+      "lazily when omitted. Idempotent in practice: GitHub returns " +
+      "success when the link already exists.",
+    inputSchema,
+    handler: async (raw) => {
+      const args = validate<Input>(
+        inputSchema,
+        raw,
+        "gh.issue_add_sub_issue input",
+      );
+      // Run both node-ID resolutions in parallel: the two lookups
+      // are independent, and on a plan-to-issues run we'll often
+      // be called dozens of times so the parallelism matters.
+      const [parentId, childId] = await Promise.all([
+        resolveSideId(graphql, args.parent, "parent"),
+        resolveSideId(graphql, args.child, "child"),
+      ]);
+      const data = await graphql<AddSubIssueResponse>(
+        "issue/add_sub_issue",
+        { input: { issueId: parentId, subIssueId: childId } },
+      );
+      const out: Output = {
+        parent: {
+          number: data.addSubIssue.issue.number,
+          node_id: data.addSubIssue.issue.id,
+        },
+        child: {
+          number: data.addSubIssue.subIssue.number,
+          node_id: data.addSubIssue.subIssue.id,
+        },
+      };
+      return validate<Output>(
+        outputSchema,
+        out,
+        "gh.issue_add_sub_issue output",
+      );
+    },
+  });
+}
+
+// Resolve one side (parent or child) to a GraphQL node ID. The
+// `oneOf` schema above guarantees exactly one of the two shapes
+// is present; the `else` branch is defensive against a schema
+// drift that ever loosens the constraint.
+async function resolveSideId(
+  graphql: GraphqlClient,
+  ref: IssueRef,
+  side: "parent" | "child",
+): Promise<string> {
+  if (typeof ref.node_id === "string") {
+    return ref.node_id;
+  }
+  if (typeof ref.repo === "string" && typeof ref.number === "number") {
+    const coords = parseRepoSlug(
+      ref.repo,
+      `gh.issue_add_sub_issue ${side}`,
+    );
+    return lookupIssueNodeId(
+      graphql,
+      coords,
+      ref.number,
+      `gh.issue_add_sub_issue ${side}`,
+    );
+  }
+  throw new Error(
+    `mcp-github: gh.issue_add_sub_issue ${side}: must supply either node_id or repo + number`,
+  );
+}

--- a/src/tools/issue/index.ts
+++ b/src/tools/issue/index.ts
@@ -1,10 +1,13 @@
 // src/tools/issue/index.ts
 //
-// Aggregator for the seven `gh.issue_*` tools. Imported by
+// Aggregator for the gh.issue_* tools. Imported by
 // `src/server.ts`'s `startServer()` and called once at boot to
 // register every issue-domain tool against the registry. Each
 // individual tool lives in its own file to keep the per-tool
 // schemas + handlers manageable; this file just orchestrates.
+// The authoritative list is the function body below — no
+// hard-coded count in this header so it doesn't drift each time
+// a tool joins or leaves the group.
 
 import type { GraphqlClient } from "../../graphql/client.js";
 import type { ToolEntry } from "../../registry.js";

--- a/src/tools/issue/index.ts
+++ b/src/tools/issue/index.ts
@@ -8,6 +8,7 @@
 
 import type { GraphqlClient } from "../../graphql/client.js";
 import type { ToolEntry } from "../../registry.js";
+import { registerIssueAddSubIssueTool } from "./add_sub_issue.js";
 import { registerIssueCloseTool } from "./close.js";
 import { registerIssueCommentTool } from "./comment.js";
 import { registerIssueCreateTool } from "./create.js";
@@ -29,4 +30,5 @@ export function registerIssueTools(
   registerIssueCloseTool(register, graphql);
   registerIssueCommentTool(register, graphql);
   registerIssueSearchTool(register, graphql);
+  registerIssueAddSubIssueTool(register, graphql);
 }

--- a/tests/smoke/server-lists-tools.mjs
+++ b/tests/smoke/server-lists-tools.mjs
@@ -9,9 +9,10 @@
 // + tool registration chain end-to-end without pulling in the
 // unit-test framework.
 //
-// Current surface: 1 auth probe (`gh.test_connection` from MCP-2)
-// + 7 issue tools (MCP-4) + 4 label tools (MCP-7) + 7 PR tools
-// (MCP-5 + MCP-6, the latter adding `gh.pr_request_reviews`).
+// The EXPECTED_TOOLS array below is the authoritative list of
+// the current tool surface; this header used to also carry a
+// human-readable count, but that drifted on every PR. Read the
+// array if you want the current set.
 //
 // Wire format: the MCP SDK's StdioServerTransport uses newline-
 // delimited JSON-RPC (one JSON message per `\n`-terminated line),

--- a/tests/smoke/server-lists-tools.mjs
+++ b/tests/smoke/server-lists-tools.mjs
@@ -39,6 +39,7 @@ const EXPECTED_TOOLS = [
   "gh.issue_close",
   "gh.issue_comment",
   "gh.issue_search",
+  "gh.issue_add_sub_issue",
   "gh.label_create",
   "gh.label_list",
   "gh.label_edit",

--- a/tests/smoke/server-lists-tools.mjs
+++ b/tests/smoke/server-lists-tools.mjs
@@ -9,11 +9,6 @@
 // + tool registration chain end-to-end without pulling in the
 // unit-test framework.
 //
-// The EXPECTED_TOOLS array below is the authoritative list of
-// the current tool surface; this header used to also carry a
-// human-readable count, but that drifted on every PR. Read the
-// array if you want the current set.
-//
 // Wire format: the MCP SDK's StdioServerTransport uses newline-
 // delimited JSON-RPC (one JSON message per `\n`-terminated line),
 // not LSP-style Content-Length framing. Confirmed in the SDK

--- a/tests/unit/tools/issue/add_sub_issue.test.ts
+++ b/tests/unit/tools/issue/add_sub_issue.test.ts
@@ -1,0 +1,202 @@
+// tests/unit/tools/issue/add_sub_issue.test.ts
+//
+// gh.issue_add_sub_issue: pin the lazy-node-id resolution paths
+// (raw node_id passes through; (repo, number) triggers a lookup),
+// the parallel-lookup behaviour, the mutation input shape, and
+// the input-schema's oneOf rejection of mixed shapes.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { registerIssueAddSubIssueTool } from "../../../../src/tools/issue/add_sub_issue.ts";
+import type { ToolEntry } from "../../../../src/registry.ts";
+import { stubGraphqlClient } from "./_fixtures.ts";
+
+function captureRegistration() {
+  let entry: ToolEntry | undefined;
+  const register = (name: string, e: ToolEntry) => {
+    if (name !== "gh.issue_add_sub_issue") throw new Error(`unexpected: ${name}`);
+    entry = e;
+  };
+  return {
+    register,
+    get entry(): ToolEntry {
+      if (!entry) throw new Error("not registered");
+      return entry;
+    },
+  };
+}
+
+test("gh.issue_add_sub_issue: (repo, number) on both sides → two lookups + one mutation", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "issue/_issue-lookup": (vars: Record<string, unknown>) => {
+      // Two lookups: tell them apart by issue number.
+      if (vars.number === 1) {
+        return { repository: { issue: { id: "I_parent" } } };
+      }
+      if (vars.number === 2) {
+        return { repository: { issue: { id: "I_child" } } };
+      }
+      throw new Error(`unexpected lookup number: ${String(vars.number)}`);
+    },
+    "issue/add_sub_issue": (vars: Record<string, unknown>) => {
+      const input = vars.input as Record<string, unknown>;
+      assert.equal(input.issueId, "I_parent");
+      assert.equal(input.subIssueId, "I_child");
+      return {
+        addSubIssue: {
+          issue: { id: "I_parent", number: 1 },
+          subIssue: { id: "I_child", number: 2 },
+        },
+      };
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueAddSubIssueTool(reg.register, graphql);
+  const out = (await reg.entry.handler({
+    parent: { repo: "owner/repo", number: 1 },
+    child: { repo: "owner/repo", number: 2 },
+  })) as { parent: { number: number; node_id: string }; child: { number: number; node_id: string } };
+  assert.deepEqual(out, {
+    parent: { number: 1, node_id: "I_parent" },
+    child: { number: 2, node_id: "I_child" },
+  });
+  // Two lookups + one mutation. We don't pin order between the
+  // two lookups because they run in parallel via Promise.all.
+  assert.equal(calls.length, 3);
+  const queryNames = calls.map((c) => c.queryName).sort();
+  assert.deepEqual(queryNames, [
+    "issue/_issue-lookup",
+    "issue/_issue-lookup",
+    "issue/add_sub_issue",
+  ]);
+});
+
+test("gh.issue_add_sub_issue: node_id on both sides → zero lookups, one mutation", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "issue/add_sub_issue": (vars: Record<string, unknown>) => {
+      const input = vars.input as Record<string, unknown>;
+      assert.equal(input.issueId, "I_pre_parent");
+      assert.equal(input.subIssueId, "I_pre_child");
+      return {
+        addSubIssue: {
+          issue: { id: "I_pre_parent", number: 10 },
+          subIssue: { id: "I_pre_child", number: 11 },
+        },
+      };
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueAddSubIssueTool(reg.register, graphql);
+  const out = (await reg.entry.handler({
+    parent: { node_id: "I_pre_parent" },
+    child: { node_id: "I_pre_child" },
+  })) as { parent: { number: number }; child: { number: number } };
+  assert.equal(out.parent.number, 10);
+  assert.equal(out.child.number, 11);
+  // Zero lookups: both IDs were supplied.
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]?.queryName, "issue/add_sub_issue");
+});
+
+test("gh.issue_add_sub_issue: mixed shapes — node_id on parent, (repo, number) on child", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "issue/_issue-lookup": (_vars: Record<string, unknown>) =>
+      ({ repository: { issue: { id: "I_child" } } }),
+    "issue/add_sub_issue": (vars: Record<string, unknown>) => {
+      const input = vars.input as Record<string, unknown>;
+      assert.equal(input.issueId, "I_parent_pre");
+      assert.equal(input.subIssueId, "I_child");
+      return {
+        addSubIssue: {
+          issue: { id: "I_parent_pre", number: 1 },
+          subIssue: { id: "I_child", number: 2 },
+        },
+      };
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueAddSubIssueTool(reg.register, graphql);
+  await reg.entry.handler({
+    parent: { node_id: "I_parent_pre" },
+    child: { repo: "owner/repo", number: 2 },
+  });
+  // One lookup (child only) + one mutation.
+  assert.equal(calls.length, 2);
+});
+
+test("gh.issue_add_sub_issue: rejects mixed (node_id + repo) at the input boundary", async () => {
+  const { graphql } = stubGraphqlClient({
+    "issue/_issue-lookup": () => {
+      throw new Error("must not run");
+    },
+    "issue/add_sub_issue": () => {
+      throw new Error("must not run");
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueAddSubIssueTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      parent: { node_id: "I_x", repo: "owner/repo", number: 1 },
+      child: { node_id: "I_y" },
+    }),
+    /gh\.issue_add_sub_issue input/,
+  );
+});
+
+test("gh.issue_add_sub_issue: rejects an empty side at the input boundary", async () => {
+  const { graphql } = stubGraphqlClient({});
+  const reg = captureRegistration();
+  registerIssueAddSubIssueTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      parent: {},
+      child: { node_id: "I_y" },
+    }),
+    /gh\.issue_add_sub_issue input/,
+  );
+});
+
+test("gh.issue_add_sub_issue: lookup error on parent surfaces with the parent side labelled", async () => {
+  const { graphql } = stubGraphqlClient({
+    "issue/_issue-lookup": (vars: Record<string, unknown>) => {
+      // Repo missing on the parent lookup, child lookup never
+      // returns because Promise.all rejects on first failure. We
+      // mock both anyway because graphql() is called for both.
+      if (vars.number === 1) {
+        return { repository: null };
+      }
+      return { repository: { issue: { id: "I_child" } } };
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueAddSubIssueTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      parent: { repo: "owner/repo", number: 1 },
+      child: { repo: "owner/repo", number: 2 },
+    }),
+    /gh\.issue_add_sub_issue parent/,
+  );
+});
+
+test("gh.issue_add_sub_issue: lookup error on child surfaces with the child side labelled", async () => {
+  const { graphql } = stubGraphqlClient({
+    "issue/_issue-lookup": (vars: Record<string, unknown>) => {
+      if (vars.number === 1) {
+        return { repository: { issue: { id: "I_parent" } } };
+      }
+      return { repository: { issue: null } };
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueAddSubIssueTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      parent: { repo: "owner/repo", number: 1 },
+      child: { repo: "owner/repo", number: 99 },
+    }),
+    /gh\.issue_add_sub_issue child/,
+  );
+});

--- a/tests/unit/tools/issue/add_sub_issue.test.ts
+++ b/tests/unit/tools/issue/add_sub_issue.test.ts
@@ -161,9 +161,11 @@ test("gh.issue_add_sub_issue: rejects an empty side at the input boundary", asyn
 test("gh.issue_add_sub_issue: lookup error on parent surfaces with the parent side labelled", async () => {
   const { graphql } = stubGraphqlClient({
     "issue/_issue-lookup": (vars: Record<string, unknown>) => {
-      // Repo missing on the parent lookup, child lookup never
-      // returns because Promise.all rejects on first failure. We
-      // mock both anyway because graphql() is called for both.
+      // Repo missing on the parent lookup → Promise.all rejects
+      // as soon as the parent lookup throws, but the CHILD lookup
+      // is started concurrently and isn't cancellable. We mock
+      // both branches so the child call's body runs cleanly
+      // alongside the rejecting parent call.
       if (vars.number === 1) {
         return { repository: null };
       }


### PR DESCRIPTION
## Summary
- New tool `gh.issue_add_sub_issue` wires a child issue under a parent via the GitHub GraphQL `addSubIssue` mutation.
- Either side accepts a `node_id` or a `(repo, number)` pair; node IDs resolve lazily in parallel via `lookupIssueNodeId`.
- Backs the methodology's `plan-to-issues` parent-child tree wiring without an agent-side `gh api graphql` shell-out.

## Test plan
- [x] `npm run lint` (tsc on src + tests)
- [x] `npm test` — 7 new unit tests pin: both-(repo,number) → two lookups + mutation; both-node_id → zero lookups + mutation; mixed shapes; oneOf schema rejection of mixed input and empty side; per-side error labelling for parent vs child lookup failure.