### PR TITLE
feat: gh.pr_review_threads_list (A2)

### DIFF
--- a/src/graphql/queries/pr/review_threads_list.graphql
+++ b/src/graphql/queries/pr/review_threads_list.graphql
@@ -1,0 +1,47 @@
+query PRReviewThreadsList(
+  $owner: String!
+  $name: String!
+  $number: Int!
+  $first: Int!
+  $after: String
+  $commentsFirst: Int!
+) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviewThreads(first: $first, after: $after) {
+        totalCount
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          id
+          isResolved
+          path
+          line
+          originalLine
+          startLine
+          originalStartLine
+          diffSide
+          comments(first: $commentsFirst) {
+            totalCount
+            pageInfo {
+              hasNextPage
+            }
+            nodes {
+              author {
+                login
+              }
+              body
+              path
+              line
+              originalLine
+              createdAt
+              url
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/graphql/queries/pr/review_threads_list.graphql
+++ b/src/graphql/queries/pr/review_threads_list.graphql
@@ -20,8 +20,6 @@ query PRReviewThreadsList(
           path
           line
           originalLine
-          startLine
-          originalStartLine
           diffSide
           comments(first: $commentsFirst) {
             totalCount

--- a/src/tools/pr/index.ts
+++ b/src/tools/pr/index.ts
@@ -1,8 +1,11 @@
 // src/tools/pr/index.ts
 //
-// Aggregator for the seven gh.pr_* tools. Imported by
+// Aggregator for the gh.pr_* tools. Imported by
 // `src/server.ts`'s startServer() and called once at boot to
-// register every PR-domain tool against the registry.
+// register every PR-domain tool against the registry. The
+// function body below is the authoritative list — no hard-coded
+// count in this header so it doesn't drift each time a tool
+// joins or leaves the group.
 
 import type { GraphqlClient } from "../../graphql/client.js";
 import type { ToolEntry } from "../../registry.js";

--- a/src/tools/pr/index.ts
+++ b/src/tools/pr/index.ts
@@ -12,6 +12,7 @@ import { registerPREditTool } from "./edit.js";
 import { registerPRListTool } from "./list.js";
 import { registerPRMergeTool } from "./merge.js";
 import { registerPRRequestReviewsTool } from "./request_reviews.js";
+import { registerPRReviewThreadsListTool } from "./review_threads_list.js";
 import { registerPRViewTool } from "./view.js";
 
 type RegisterToolFn = (name: string, entry: ToolEntry) => void;
@@ -27,4 +28,5 @@ export function registerPRTools(
   registerPRCommentTool(register, graphql);
   registerPRMergeTool(register, graphql);
   registerPRRequestReviewsTool(register, graphql);
+  registerPRReviewThreadsListTool(register, graphql);
 }

--- a/src/tools/pr/review_threads_list.ts
+++ b/src/tools/pr/review_threads_list.ts
@@ -2,11 +2,12 @@
 //
 // `gh.pr_review_threads_list` — paginated list of a PR's review
 // threads (the conversation containers around inline review
-// comments). Each thread carries the `id` that the resolver tool
-// consumes and a per-thread preview of comments (file path,
-// line, body, author, timestamp). The methodology's pr-loop
-// flow drives this in a loop: read unresolved threads → address
-// each → call the resolver per thread.
+// comments). Each thread carries the GraphQL `id` callers feed
+// into GitHub's `resolveReviewThread` mutation, plus a per-
+// thread preview of comments (file path, line, body, author,
+// timestamp). The methodology's pr-loop flow drives this in a
+// loop: read unresolved threads → address each → mark each as
+// resolved.
 //
 // Pagination follows the codebase-wide convention from
 // `gh.issue_list` / `gh.pr_list` / `gh.label_list`: input uses
@@ -230,14 +231,14 @@ export function registerPRReviewThreadsListTool(
     description:
       "Paginated list of a PR's review threads (the conversation " +
       "containers around inline review comments). Returns each " +
-      "thread's `id` (consumed by the resolver tool) plus a " +
-      "per-thread preview of comments (path, line, author, body, " +
-      "timestamp). Pagination uses `perPage` / `after` on input " +
-      "and `hasNextPage` / `endCursor` at top of output, matching " +
-      "the other list tools. `include_resolved` defaults to false " +
-      "because the methodology's same-turn-resolve rule means the " +
-      "agent usually only cares about open threads — `total` " +
-      "still reflects the GraphQL total (all threads).",
+      "thread's GraphQL `id` (suitable for `resolveReviewThread`) " +
+      "plus a per-thread preview of comments (path, line, author, " +
+      "body, timestamp). Pagination uses `perPage` / `after` on " +
+      "input and `hasNextPage` / `endCursor` at top of output, " +
+      "matching the other list tools. `include_resolved` defaults " +
+      "to false because the methodology's same-turn-resolve rule " +
+      "means the agent usually only cares about open threads — " +
+      "`total` still reflects the GraphQL total (all threads).",
     inputSchema,
     handler: async (raw) => {
       const args = validate<Input>(

--- a/src/tools/pr/review_threads_list.ts
+++ b/src/tools/pr/review_threads_list.ts
@@ -2,30 +2,42 @@
 //
 // `gh.pr_review_threads_list` — paginated list of a PR's review
 // threads (the conversation containers around inline review
-// comments). Each thread carries the `id` that
-// `gh.pr_review_thread_resolve` needs and a small per-thread
-// preview of the latest comments (file path, line, body, author,
-// timestamp). The methodology's pr-loop flow drives this in a
-// loop: read unresolved threads → address each → call
-// `pr_review_thread_resolve` per thread.
+// comments). Each thread carries the `id` that the resolver tool
+// consumes and a per-thread preview of comments (file path,
+// line, body, author, timestamp). The methodology's pr-loop
+// flow drives this in a loop: read unresolved threads → address
+// each → call the resolver per thread.
 //
-// Pagination is caller-driven (`cursor: endCursor`). We do NOT
-// auto-paginate inside the tool: large PRs can have hundreds of
-// threads and the methodology often only cares about the first
-// page (the agent fixes the visible set, pushes, and the loop
-// repeats). `include_resolved` defaults to false because the
-// "resolve same turn" rule (`feedback_pr_thread_resolve_same_turn.md`)
+// Pagination follows the codebase-wide convention from
+// `gh.issue_list` / `gh.pr_list` / `gh.label_list`: input uses
+// `perPage` + `after`, output exposes `hasNextPage` + `endCursor`
+// at the top level (no `pageInfo` wrapper). Pagination is
+// caller-driven; large PRs can have hundreds of threads and the
+// methodology often only cares about the first page (the agent
+// fixes the visible set, pushes, and the loop repeats).
+//
+// `include_resolved` defaults to false because the "resolve
+// same turn" rule (memory `feedback_pr_thread_resolve_same_turn`)
 // means the orchestrator usually wants only the unresolved set.
 // Filtering is client-side; `totalCount` reflects the GraphQL
 // totalCount (all threads), not the filtered length, so the
-// caller has an honest signal even when a page has no unresolved
-// threads.
+// caller has an honest signal even when a page has no
+// unresolved threads after filtering.
+//
+// Comments per thread default to the first 10 (the conversation
+// is naturally ordered chronologically; the methodology reads
+// the opening comment to decide what to fix, plus a few follow-
+// ups for context). Threads with more comments than the cap set
+// `comments_truncated: true`; consumers who need the tail can
+// query GraphQL directly.
 
 import type { GraphqlClient } from "../../graphql/client.js";
 import type { ToolEntry } from "../../registry.js";
 import { validate } from "../../validation/validator.js";
 import { parseRepoSlug, repoSlugSchema } from "./_shared.js";
 
+const PER_PAGE_DEFAULT = 100;
+const PER_PAGE_MAX = 100;
 const COMMENTS_PER_THREAD_DEFAULT = 10;
 const COMMENTS_PER_THREAD_MAX = 50;
 
@@ -35,29 +47,32 @@ const inputSchema = {
   properties: {
     repo: repoSlugSchema,
     number: { type: "integer", minimum: 1 },
-    cursor: {
+    after: {
       type: "string",
       minLength: 1,
       description:
-        "Opaque pagination cursor from a previous call's " +
-        "`pageInfo.endCursor`. Omit on the first call.",
+        "Opaque cursor from a previous call's `endCursor`. Omit " +
+        "on the first call. Naming matches `gh.pr_list` / " +
+        "`gh.issue_list` / `gh.label_list`.",
     },
-    page_size: {
+    perPage: {
       type: "integer",
       minimum: 1,
-      maximum: 100,
+      maximum: PER_PAGE_MAX,
       description:
-        "Threads per page. GitHub caps at 100; we mirror that.",
+        `Threads per page (default ${PER_PAGE_DEFAULT}, max ${PER_PAGE_MAX}). ` +
+        "Naming matches the other paginated list tools.",
     },
     comments_per_thread: {
       type: "integer",
       minimum: 1,
       maximum: COMMENTS_PER_THREAD_MAX,
       description:
-        "How many comments to surface per thread (default 10, " +
-        "max 50). Threads with more than this set " +
-        "`comments_truncated: true`; fetch the full set via the " +
-        "GitHub API directly if needed.",
+        `How many comments to surface per thread (default ${COMMENTS_PER_THREAD_DEFAULT}, ` +
+        `max ${COMMENTS_PER_THREAD_MAX}). Comments are returned in chronological order ` +
+        "(GraphQL `comments(first:N)`) so the thread's opening message " +
+        "is included even when the conversation is long. Threads with " +
+        "more comments than the cap set `comments_truncated: true`.",
     },
     include_resolved: {
       type: "boolean",
@@ -117,19 +132,18 @@ const threadSchema = {
 
 const outputSchema = {
   type: "object",
-  required: ["totalCount", "pageInfo", "threads"],
+  required: ["threads", "total", "hasNextPage", "endCursor"],
   properties: {
-    totalCount: { type: "integer", minimum: 0 },
-    pageInfo: {
-      type: "object",
-      required: ["hasNextPage", "endCursor"],
-      properties: {
-        hasNextPage: { type: "boolean" },
-        endCursor: { type: ["string", "null"] },
-      },
-      additionalProperties: false,
-    },
     threads: { type: "array", items: threadSchema },
+    total: {
+      type: "integer",
+      minimum: 0,
+      description:
+        "GraphQL totalCount across resolved + unresolved threads — " +
+        "unaffected by client-side `include_resolved` filtering.",
+    },
+    hasNextPage: { type: "boolean" },
+    endCursor: { type: ["string", "null"] },
   },
   additionalProperties: false,
 } as const;
@@ -139,8 +153,8 @@ type RegisterToolFn = (name: string, entry: ToolEntry) => void;
 interface Input {
   repo: string;
   number: number;
-  cursor?: string;
-  page_size?: number;
+  after?: string;
+  perPage?: number;
   comments_per_thread?: number;
   include_resolved?: boolean;
 }
@@ -161,8 +175,6 @@ interface RawThread {
   path: string | null;
   line: number | null;
   originalLine: number | null;
-  startLine: number | null;
-  originalStartLine: number | null;
   diffSide: "LEFT" | "RIGHT" | null;
   comments: {
     totalCount: number;
@@ -204,9 +216,10 @@ interface ThreadSummary {
 }
 
 interface Output {
-  totalCount: number;
-  pageInfo: { hasNextPage: boolean; endCursor: string | null };
   threads: ThreadSummary[];
+  total: number;
+  hasNextPage: boolean;
+  endCursor: string | null;
 }
 
 export function registerPRReviewThreadsListTool(
@@ -216,13 +229,14 @@ export function registerPRReviewThreadsListTool(
   register("gh.pr_review_threads_list", {
     description:
       "Paginated list of a PR's review threads (the conversation " +
-      "containers around inline review comments). Returns the " +
-      "thread `id` that `gh.pr_review_thread_resolve` consumes, " +
-      "plus a per-thread preview of comments (path, line, author, " +
-      "body, timestamp). Caller drives pagination via " +
-      "`cursor: endCursor`. `include_resolved` defaults to false " +
+      "containers around inline review comments). Returns each " +
+      "thread's `id` (consumed by the resolver tool) plus a " +
+      "per-thread preview of comments (path, line, author, body, " +
+      "timestamp). Pagination uses `perPage` / `after` on input " +
+      "and `hasNextPage` / `endCursor` at top of output, matching " +
+      "the other list tools. `include_resolved` defaults to false " +
       "because the methodology's same-turn-resolve rule means the " +
-      "agent usually only cares about open threads — `totalCount` " +
+      "agent usually only cares about open threads — `total` " +
       "still reflects the GraphQL total (all threads).",
     inputSchema,
     handler: async (raw) => {
@@ -239,8 +253,8 @@ export function registerPRReviewThreadsListTool(
         owner: coords.owner,
         name: coords.name,
         number: args.number,
-        first: args.page_size ?? 100,
-        after: args.cursor ?? null,
+        first: args.perPage ?? PER_PAGE_DEFAULT,
+        after: args.after ?? null,
         commentsFirst:
           args.comments_per_thread ?? COMMENTS_PER_THREAD_DEFAULT,
       });
@@ -262,9 +276,10 @@ export function registerPRReviewThreadsListTool(
         : pr.reviewThreads.nodes.filter((n) => !n.isResolved);
       const threads: ThreadSummary[] = filtered.map(summariseThread);
       const out: Output = {
-        totalCount: pr.reviewThreads.totalCount,
-        pageInfo: pr.reviewThreads.pageInfo,
         threads,
+        total: pr.reviewThreads.totalCount,
+        hasNextPage: pr.reviewThreads.pageInfo.hasNextPage,
+        endCursor: pr.reviewThreads.pageInfo.endCursor,
       };
       return validate<Output>(
         outputSchema,

--- a/src/tools/pr/review_threads_list.ts
+++ b/src/tools/pr/review_threads_list.ts
@@ -1,0 +1,305 @@
+// src/tools/pr/review_threads_list.ts
+//
+// `gh.pr_review_threads_list` — paginated list of a PR's review
+// threads (the conversation containers around inline review
+// comments). Each thread carries the `id` that
+// `gh.pr_review_thread_resolve` needs and a small per-thread
+// preview of the latest comments (file path, line, body, author,
+// timestamp). The methodology's pr-loop flow drives this in a
+// loop: read unresolved threads → address each → call
+// `pr_review_thread_resolve` per thread.
+//
+// Pagination is caller-driven (`cursor: endCursor`). We do NOT
+// auto-paginate inside the tool: large PRs can have hundreds of
+// threads and the methodology often only cares about the first
+// page (the agent fixes the visible set, pushes, and the loop
+// repeats). `include_resolved` defaults to false because the
+// "resolve same turn" rule (`feedback_pr_thread_resolve_same_turn.md`)
+// means the orchestrator usually wants only the unresolved set.
+// Filtering is client-side; `totalCount` reflects the GraphQL
+// totalCount (all threads), not the filtered length, so the
+// caller has an honest signal even when a page has no unresolved
+// threads.
+
+import type { GraphqlClient } from "../../graphql/client.js";
+import type { ToolEntry } from "../../registry.js";
+import { validate } from "../../validation/validator.js";
+import { parseRepoSlug, repoSlugSchema } from "./_shared.js";
+
+const COMMENTS_PER_THREAD_DEFAULT = 10;
+const COMMENTS_PER_THREAD_MAX = 50;
+
+const inputSchema = {
+  type: "object",
+  required: ["repo", "number"],
+  properties: {
+    repo: repoSlugSchema,
+    number: { type: "integer", minimum: 1 },
+    cursor: {
+      type: "string",
+      minLength: 1,
+      description:
+        "Opaque pagination cursor from a previous call's " +
+        "`pageInfo.endCursor`. Omit on the first call.",
+    },
+    page_size: {
+      type: "integer",
+      minimum: 1,
+      maximum: 100,
+      description:
+        "Threads per page. GitHub caps at 100; we mirror that.",
+    },
+    comments_per_thread: {
+      type: "integer",
+      minimum: 1,
+      maximum: COMMENTS_PER_THREAD_MAX,
+      description:
+        "How many comments to surface per thread (default 10, " +
+        "max 50). Threads with more than this set " +
+        "`comments_truncated: true`; fetch the full set via the " +
+        "GitHub API directly if needed.",
+    },
+    include_resolved: {
+      type: "boolean",
+      description:
+        "Default false: filter resolved threads out client-side " +
+        "(the methodology's same-turn-resolve rule means the " +
+        "agent usually only cares about open threads). Set true " +
+        "to return every thread on the page regardless of " +
+        "resolution state. `totalCount` is unaffected: it is the " +
+        "GraphQL totalCount across resolved + unresolved threads.",
+    },
+  },
+  additionalProperties: false,
+} as const;
+
+const commentSchema = {
+  type: "object",
+  required: ["author", "body", "path", "line", "created_at", "url"],
+  properties: {
+    author: { type: ["string", "null"] },
+    body: { type: "string" },
+    path: { type: ["string", "null"] },
+    line: { type: ["integer", "null"] },
+    created_at: { type: "string" },
+    url: { type: "string" },
+  },
+  additionalProperties: false,
+} as const;
+
+const threadSchema = {
+  type: "object",
+  required: [
+    "id",
+    "is_resolved",
+    "path",
+    "line",
+    "diff_side",
+    "comments_total_count",
+    "comments_truncated",
+    "comments",
+  ],
+  properties: {
+    id: { type: "string" },
+    is_resolved: { type: "boolean" },
+    path: { type: ["string", "null"] },
+    line: { type: ["integer", "null"] },
+    diff_side: {
+      type: ["string", "null"],
+      enum: ["LEFT", "RIGHT", null],
+    },
+    comments_total_count: { type: "integer", minimum: 0 },
+    comments_truncated: { type: "boolean" },
+    comments: { type: "array", items: commentSchema },
+  },
+  additionalProperties: false,
+} as const;
+
+const outputSchema = {
+  type: "object",
+  required: ["totalCount", "pageInfo", "threads"],
+  properties: {
+    totalCount: { type: "integer", minimum: 0 },
+    pageInfo: {
+      type: "object",
+      required: ["hasNextPage", "endCursor"],
+      properties: {
+        hasNextPage: { type: "boolean" },
+        endCursor: { type: ["string", "null"] },
+      },
+      additionalProperties: false,
+    },
+    threads: { type: "array", items: threadSchema },
+  },
+  additionalProperties: false,
+} as const;
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+interface Input {
+  repo: string;
+  number: number;
+  cursor?: string;
+  page_size?: number;
+  comments_per_thread?: number;
+  include_resolved?: boolean;
+}
+
+interface RawComment {
+  author: { login: string } | null;
+  body: string;
+  path: string | null;
+  line: number | null;
+  originalLine: number | null;
+  createdAt: string;
+  url: string;
+}
+
+interface RawThread {
+  id: string;
+  isResolved: boolean;
+  path: string | null;
+  line: number | null;
+  originalLine: number | null;
+  startLine: number | null;
+  originalStartLine: number | null;
+  diffSide: "LEFT" | "RIGHT" | null;
+  comments: {
+    totalCount: number;
+    pageInfo: { hasNextPage: boolean };
+    nodes: RawComment[];
+  };
+}
+
+interface Response {
+  repository: {
+    pullRequest: {
+      reviewThreads: {
+        totalCount: number;
+        pageInfo: { hasNextPage: boolean; endCursor: string | null };
+        nodes: RawThread[];
+      };
+    } | null;
+  } | null;
+}
+
+interface CommentSummary {
+  author: string | null;
+  body: string;
+  path: string | null;
+  line: number | null;
+  created_at: string;
+  url: string;
+}
+
+interface ThreadSummary {
+  id: string;
+  is_resolved: boolean;
+  path: string | null;
+  line: number | null;
+  diff_side: "LEFT" | "RIGHT" | null;
+  comments_total_count: number;
+  comments_truncated: boolean;
+  comments: CommentSummary[];
+}
+
+interface Output {
+  totalCount: number;
+  pageInfo: { hasNextPage: boolean; endCursor: string | null };
+  threads: ThreadSummary[];
+}
+
+export function registerPRReviewThreadsListTool(
+  register: RegisterToolFn,
+  graphql: GraphqlClient,
+): void {
+  register("gh.pr_review_threads_list", {
+    description:
+      "Paginated list of a PR's review threads (the conversation " +
+      "containers around inline review comments). Returns the " +
+      "thread `id` that `gh.pr_review_thread_resolve` consumes, " +
+      "plus a per-thread preview of comments (path, line, author, " +
+      "body, timestamp). Caller drives pagination via " +
+      "`cursor: endCursor`. `include_resolved` defaults to false " +
+      "because the methodology's same-turn-resolve rule means the " +
+      "agent usually only cares about open threads — `totalCount` " +
+      "still reflects the GraphQL total (all threads).",
+    inputSchema,
+    handler: async (raw) => {
+      const args = validate<Input>(
+        inputSchema,
+        raw,
+        "gh.pr_review_threads_list input",
+      );
+      const coords = parseRepoSlug(
+        args.repo,
+        "gh.pr_review_threads_list input",
+      );
+      const data = await graphql<Response>("pr/review_threads_list", {
+        owner: coords.owner,
+        name: coords.name,
+        number: args.number,
+        first: args.page_size ?? 100,
+        after: args.cursor ?? null,
+        commentsFirst:
+          args.comments_per_thread ?? COMMENTS_PER_THREAD_DEFAULT,
+      });
+      // Same "repo vs PR missing" disambiguation as gh.pr_view.
+      if (!data.repository) {
+        throw new Error(
+          `mcp-github: gh.pr_review_threads_list: repository '${coords.owner}/${coords.name}' not found or token lacks read access`,
+        );
+      }
+      const pr = data.repository.pullRequest;
+      if (!pr) {
+        throw new Error(
+          `mcp-github: gh.pr_review_threads_list: PR ${coords.owner}/${coords.name}#${args.number} not found`,
+        );
+      }
+      const includeResolved = args.include_resolved ?? false;
+      const filtered = includeResolved
+        ? pr.reviewThreads.nodes
+        : pr.reviewThreads.nodes.filter((n) => !n.isResolved);
+      const threads: ThreadSummary[] = filtered.map(summariseThread);
+      const out: Output = {
+        totalCount: pr.reviewThreads.totalCount,
+        pageInfo: pr.reviewThreads.pageInfo,
+        threads,
+      };
+      return validate<Output>(
+        outputSchema,
+        out,
+        "gh.pr_review_threads_list output",
+      );
+    },
+  });
+}
+
+// Map one raw thread onto the summarised shape. Line numbers fall
+// back to `originalLine` when GitHub reports a null `line` (this
+// happens for outdated threads where the targeted line no longer
+// exists on the diff). The caller still gets a positional signal
+// rather than a bare null.
+function summariseThread(raw: RawThread): ThreadSummary {
+  return {
+    id: raw.id,
+    is_resolved: raw.isResolved,
+    path: raw.path,
+    line: raw.line ?? raw.originalLine,
+    diff_side: raw.diffSide,
+    comments_total_count: raw.comments.totalCount,
+    comments_truncated: raw.comments.pageInfo.hasNextPage,
+    comments: raw.comments.nodes.map(summariseComment),
+  };
+}
+
+function summariseComment(raw: RawComment): CommentSummary {
+  return {
+    author: raw.author?.login ?? null,
+    body: raw.body,
+    path: raw.path,
+    line: raw.line ?? raw.originalLine,
+    created_at: raw.createdAt,
+    url: raw.url,
+  };
+}

--- a/src/tools/pr/review_threads_list.ts
+++ b/src/tools/pr/review_threads_list.ts
@@ -11,8 +11,12 @@
 //
 // Pagination follows the codebase-wide convention from
 // `gh.issue_list` / `gh.pr_list` / `gh.label_list`: input uses
-// `perPage` + `after`, output exposes `hasNextPage` + `endCursor`
-// at the top level (no `pageInfo` wrapper). Pagination is
+// `perPage` + `after`, output exposes `items` and flat
+// `hasNextPage` / `endCursor` at the top level. We also surface
+// `total` (the GraphQL totalCount) like `gh.issue_search` does
+// — useful because the client-side `include_resolved` filter
+// would otherwise hide the unfiltered count, and a long-lived
+// PR can accumulate hundreds of threads. Pagination is
 // caller-driven; large PRs can have hundreds of threads and the
 // methodology often only cares about the first page (the agent
 // fixes the visible set, pushes, and the loop repeats).
@@ -234,11 +238,14 @@ export function registerPRReviewThreadsListTool(
       "thread's GraphQL `id` (suitable for `resolveReviewThread`) " +
       "plus a per-thread preview of comments (path, line, author, " +
       "body, timestamp). Pagination uses `perPage` / `after` on " +
-      "input and `hasNextPage` / `endCursor` at top of output, " +
-      "matching the other list tools. `include_resolved` defaults " +
-      "to false because the methodology's same-turn-resolve rule " +
-      "means the agent usually only cares about open threads — " +
-      "`total` still reflects the GraphQL total (all threads).",
+      "input and the flat `hasNextPage` / `endCursor` shape on " +
+      "output, matching the other list tools; we also surface " +
+      "`total` (the GraphQL totalCount) like `gh.issue_search` " +
+      "does, since the client-side `include_resolved` filter " +
+      "would otherwise hide the unfiltered count. " +
+      "`include_resolved` defaults to false because the " +
+      "methodology's same-turn-resolve rule means the agent " +
+      "usually only cares about open threads.",
     inputSchema,
     handler: async (raw) => {
       const args = validate<Input>(

--- a/src/tools/pr/review_threads_list.ts
+++ b/src/tools/pr/review_threads_list.ts
@@ -36,7 +36,7 @@ import type { ToolEntry } from "../../registry.js";
 import { validate } from "../../validation/validator.js";
 import { parseRepoSlug, repoSlugSchema } from "./_shared.js";
 
-const PER_PAGE_DEFAULT = 100;
+const PER_PAGE_DEFAULT = 30;
 const PER_PAGE_MAX = 100;
 const COMMENTS_PER_THREAD_DEFAULT = 10;
 const COMMENTS_PER_THREAD_MAX = 50;
@@ -132,9 +132,9 @@ const threadSchema = {
 
 const outputSchema = {
   type: "object",
-  required: ["threads", "total", "hasNextPage", "endCursor"],
+  required: ["items", "total", "hasNextPage", "endCursor"],
   properties: {
-    threads: { type: "array", items: threadSchema },
+    items: { type: "array", items: threadSchema },
     total: {
       type: "integer",
       minimum: 0,
@@ -216,7 +216,7 @@ interface ThreadSummary {
 }
 
 interface Output {
-  threads: ThreadSummary[];
+  items: ThreadSummary[];
   total: number;
   hasNextPage: boolean;
   endCursor: string | null;
@@ -274,9 +274,8 @@ export function registerPRReviewThreadsListTool(
       const filtered = includeResolved
         ? pr.reviewThreads.nodes
         : pr.reviewThreads.nodes.filter((n) => !n.isResolved);
-      const threads: ThreadSummary[] = filtered.map(summariseThread);
       const out: Output = {
-        threads,
+        items: filtered.map(summariseThread),
         total: pr.reviewThreads.totalCount,
         hasNextPage: pr.reviewThreads.pageInfo.hasNextPage,
         endCursor: pr.reviewThreads.pageInfo.endCursor,

--- a/tests/smoke/server-lists-tools.mjs
+++ b/tests/smoke/server-lists-tools.mjs
@@ -9,6 +9,14 @@
 // + tool registration chain end-to-end without pulling in the
 // unit-test framework.
 //
+<<<<<<< HEAD
+=======
+// The EXPECTED_TOOLS array below is the authoritative list of
+// the current tool surface; this header used to also carry a
+// human-readable count, but that drifted on every PR. Read the
+// array if you want the current set.
+//
+>>>>>>> 564a1df (fix(A2): rename threads → items + drop default perPage to 30 (#28 round-2))
 // Wire format: the MCP SDK's StdioServerTransport uses newline-
 // delimited JSON-RPC (one JSON message per `\n`-terminated line),
 // not LSP-style Content-Length framing. Confirmed in the SDK

--- a/tests/smoke/server-lists-tools.mjs
+++ b/tests/smoke/server-lists-tools.mjs
@@ -55,6 +55,7 @@ const EXPECTED_TOOLS = [
   "gh.workflow_run_view",
   "gh.workflow_run_cancel",
   "gh.workflow_run_jobs",
+  "gh.pr_review_threads_list",
 ];
 
 function frame(payload) {

--- a/tests/smoke/server-lists-tools.mjs
+++ b/tests/smoke/server-lists-tools.mjs
@@ -9,14 +9,6 @@
 // + tool registration chain end-to-end without pulling in the
 // unit-test framework.
 //
-<<<<<<< HEAD
-=======
-// The EXPECTED_TOOLS array below is the authoritative list of
-// the current tool surface; this header used to also carry a
-// human-readable count, but that drifted on every PR. Read the
-// array if you want the current set.
-//
->>>>>>> 564a1df (fix(A2): rename threads → items + drop default perPage to 30 (#28 round-2))
 // Wire format: the MCP SDK's StdioServerTransport uses newline-
 // delimited JSON-RPC (one JSON message per `\n`-terminated line),
 // not LSP-style Content-Length framing. Confirmed in the SDK

--- a/tests/unit/tools/pr/review_threads_list.test.ts
+++ b/tests/unit/tools/pr/review_threads_list.test.ts
@@ -60,8 +60,9 @@ function rawThread(overrides: Record<string, unknown> = {}) {
 test("gh.pr_review_threads_list: default include_resolved=false filters resolved out", async () => {
   const { graphql, calls } = stubGraphqlClient({
     "pr/review_threads_list": (vars: Record<string, unknown>) => {
-      // Defaults: first=100, after=null, commentsFirst=10.
-      assert.equal(vars.first, 100);
+      // Defaults: first=30 (matches other list tools),
+      // after=null, commentsFirst=10.
+      assert.equal(vars.first, 30);
       assert.equal(vars.after, null);
       assert.equal(vars.commentsFirst, 10);
       return {
@@ -90,7 +91,7 @@ test("gh.pr_review_threads_list: default include_resolved=false filters resolved
     total: number;
     hasNextPage: boolean;
     endCursor: string | null;
-    threads: Array<{ id: string }>;
+    items: Array<{ id: string }>;
   };
   // total reflects the GraphQL totalCount (3), not the filtered
   // length (2) — caller still sees there's more than the
@@ -98,9 +99,9 @@ test("gh.pr_review_threads_list: default include_resolved=false filters resolved
   assert.equal(out.total, 3);
   assert.equal(out.hasNextPage, false);
   assert.equal(out.endCursor, "Y3Vy");
-  assert.equal(out.threads.length, 2);
+  assert.equal(out.items.length, 2);
   assert.deepEqual(
-    out.threads.map((t) => t.id),
+    out.items.map((t) => t.id),
     ["RT_open_1", "RT_open_2"],
   );
   assert.equal(calls.length, 1);
@@ -129,9 +130,9 @@ test("gh.pr_review_threads_list: include_resolved=true returns every thread", as
     repo: "owner/repo",
     number: 7,
     include_resolved: true,
-  })) as { threads: Array<{ id: string; is_resolved: boolean }> };
+  })) as { items: Array<{ id: string; is_resolved: boolean }> };
   assert.deepEqual(
-    out.threads.map((t) => ({ id: t.id, is_resolved: t.is_resolved })),
+    out.items.map((t) => ({ id: t.id, is_resolved: t.is_resolved })),
     [
       { id: "RT_open", is_resolved: false },
       { id: "RT_resolved", is_resolved: true },
@@ -229,14 +230,14 @@ test("gh.pr_review_threads_list: comments_truncated=true when the per-thread com
     repo: "owner/repo",
     number: 7,
   })) as {
-    threads: Array<{
+    items: Array<{
       comments_truncated: boolean;
       comments_total_count: number;
     }>;
   };
-  assert.equal(out.threads.length, 1);
-  assert.equal(out.threads[0]?.comments_truncated, true);
-  assert.equal(out.threads[0]?.comments_total_count, 25);
+  assert.equal(out.items.length, 1);
+  assert.equal(out.items[0]?.comments_truncated, true);
+  assert.equal(out.items[0]?.comments_total_count, 25);
 });
 
 test("gh.pr_review_threads_list: outdated thread (null line) falls back to originalLine", async () => {
@@ -278,9 +279,9 @@ test("gh.pr_review_threads_list: outdated thread (null line) falls back to origi
   const out = (await reg.entry.handler({
     repo: "owner/repo",
     number: 7,
-  })) as { threads: Array<{ line: number | null; comments: Array<{ line: number | null }> }> };
-  assert.equal(out.threads[0]?.line, 15);
-  assert.equal(out.threads[0]?.comments[0]?.line, 15);
+  })) as { items: Array<{ line: number | null; comments: Array<{ line: number | null }> }> };
+  assert.equal(out.items[0]?.line, 15);
+  assert.equal(out.items[0]?.comments[0]?.line, 15);
 });
 
 test("gh.pr_review_threads_list: repo missing throws repository-shaped error", async () => {

--- a/tests/unit/tools/pr/review_threads_list.test.ts
+++ b/tests/unit/tools/pr/review_threads_list.test.ts
@@ -1,8 +1,10 @@
 // tests/unit/tools/pr/review_threads_list.test.ts
 //
 // gh.pr_review_threads_list: pin the default-unresolved filter,
-// the cursor / page_size pass-through, the comments_per_thread
-// behaviour incl. truncation, and the not-found error shapes.
+// the after/perPage pass-through, the comments_per_thread
+// behaviour incl. truncation, the top-level pagination output
+// shape (hasNextPage/endCursor at the root, matching the other
+// list tools), and the not-found error shapes.
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
@@ -35,8 +37,6 @@ function rawThread(overrides: Record<string, unknown> = {}) {
     path: "src/foo.ts",
     line: 42,
     originalLine: 42,
-    startLine: null,
-    originalStartLine: null,
     diffSide: "RIGHT" as const,
     comments: {
       totalCount: 1,
@@ -86,11 +86,18 @@ test("gh.pr_review_threads_list: default include_resolved=false filters resolved
   const out = (await reg.entry.handler({
     repo: "owner/repo",
     number: 7,
-  })) as { totalCount: number; threads: Array<{ id: string }> };
-  // totalCount reflects the GraphQL total (3), not the filtered
+  })) as {
+    total: number;
+    hasNextPage: boolean;
+    endCursor: string | null;
+    threads: Array<{ id: string }>;
+  };
+  // total reflects the GraphQL totalCount (3), not the filtered
   // length (2) — caller still sees there's more than the
   // filter pass-through.
-  assert.equal(out.totalCount, 3);
+  assert.equal(out.total, 3);
+  assert.equal(out.hasNextPage, false);
+  assert.equal(out.endCursor, "Y3Vy");
   assert.equal(out.threads.length, 2);
   assert.deepEqual(
     out.threads.map((t) => t.id),
@@ -132,7 +139,7 @@ test("gh.pr_review_threads_list: include_resolved=true returns every thread", as
   );
 });
 
-test("gh.pr_review_threads_list: cursor + page_size + comments_per_thread pass through to GraphQL vars", async () => {
+test("gh.pr_review_threads_list: after + perPage + comments_per_thread pass through to GraphQL vars", async () => {
   const { graphql } = stubGraphqlClient({
     "pr/review_threads_list": (vars: Record<string, unknown>) => {
       assert.equal(vars.first, 25);
@@ -156,10 +163,41 @@ test("gh.pr_review_threads_list: cursor + page_size + comments_per_thread pass t
   await reg.entry.handler({
     repo: "owner/repo",
     number: 7,
-    page_size: 25,
-    cursor: "PAGE2_CURSOR",
+    perPage: 25,
+    after: "PAGE2_CURSOR",
     comments_per_thread: 3,
   });
+});
+
+test("gh.pr_review_threads_list: hasNextPage + endCursor surface at the top of the output", async () => {
+  // Pin the pagination output contract that other list tools also
+  // follow (flat hasNextPage/endCursor, not nested under pageInfo).
+  const { graphql } = stubGraphqlClient({
+    "pr/review_threads_list": () => ({
+      repository: {
+        pullRequest: {
+          reviewThreads: {
+            totalCount: 250,
+            pageInfo: { hasNextPage: true, endCursor: "NEXT_CURSOR" },
+            nodes: [],
+          },
+        },
+      },
+    }),
+  });
+  const reg = captureRegistration();
+  registerPRReviewThreadsListTool(reg.register, graphql);
+  const out = (await reg.entry.handler({
+    repo: "owner/repo",
+    number: 7,
+  })) as {
+    total: number;
+    hasNextPage: boolean;
+    endCursor: string | null;
+  };
+  assert.equal(out.total, 250);
+  assert.equal(out.hasNextPage, true);
+  assert.equal(out.endCursor, "NEXT_CURSOR");
 });
 
 test("gh.pr_review_threads_list: comments_truncated=true when the per-thread comment page has more results", async () => {
@@ -271,12 +309,12 @@ test("gh.pr_review_threads_list: PR missing throws PR-shaped error", async () =>
   );
 });
 
-test("gh.pr_review_threads_list: rejects page_size > 100 at the input boundary", async () => {
+test("gh.pr_review_threads_list: rejects perPage > 100 at the input boundary", async () => {
   const { graphql } = stubGraphqlClient({});
   const reg = captureRegistration();
   registerPRReviewThreadsListTool(reg.register, graphql);
   await assert.rejects(
-    reg.entry.handler({ repo: "owner/repo", number: 7, page_size: 200 }),
+    reg.entry.handler({ repo: "owner/repo", number: 7, perPage: 200 }),
     /gh\.pr_review_threads_list input/,
   );
 });

--- a/tests/unit/tools/pr/review_threads_list.test.ts
+++ b/tests/unit/tools/pr/review_threads_list.test.ts
@@ -1,0 +1,296 @@
+// tests/unit/tools/pr/review_threads_list.test.ts
+//
+// gh.pr_review_threads_list: pin the default-unresolved filter,
+// the cursor / page_size pass-through, the comments_per_thread
+// behaviour incl. truncation, and the not-found error shapes.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { registerPRReviewThreadsListTool } from "../../../../src/tools/pr/review_threads_list.ts";
+import type { ToolEntry } from "../../../../src/registry.ts";
+import { stubGraphqlClient } from "./_fixtures.ts";
+
+function captureRegistration() {
+  let entry: ToolEntry | undefined;
+  const register = (name: string, e: ToolEntry) => {
+    if (name !== "gh.pr_review_threads_list") {
+      throw new Error(`unexpected: ${name}`);
+    }
+    entry = e;
+  };
+  return {
+    register,
+    get entry(): ToolEntry {
+      if (!entry) throw new Error("not registered");
+      return entry;
+    },
+  };
+}
+
+function rawThread(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "RT_1",
+    isResolved: false,
+    path: "src/foo.ts",
+    line: 42,
+    originalLine: 42,
+    startLine: null,
+    originalStartLine: null,
+    diffSide: "RIGHT" as const,
+    comments: {
+      totalCount: 1,
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          author: { login: "alice" },
+          body: "nit: rename this",
+          path: "src/foo.ts",
+          line: 42,
+          originalLine: 42,
+          createdAt: "2026-04-01T00:00:00Z",
+          url: "https://github.com/owner/repo/pull/7#discussion_r1",
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+test("gh.pr_review_threads_list: default include_resolved=false filters resolved out", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "pr/review_threads_list": (vars: Record<string, unknown>) => {
+      // Defaults: first=100, after=null, commentsFirst=10.
+      assert.equal(vars.first, 100);
+      assert.equal(vars.after, null);
+      assert.equal(vars.commentsFirst, 10);
+      return {
+        repository: {
+          pullRequest: {
+            reviewThreads: {
+              totalCount: 3,
+              pageInfo: { hasNextPage: false, endCursor: "Y3Vy" },
+              nodes: [
+                rawThread({ id: "RT_open_1", isResolved: false }),
+                rawThread({ id: "RT_resolved", isResolved: true }),
+                rawThread({ id: "RT_open_2", isResolved: false }),
+              ],
+            },
+          },
+        },
+      };
+    },
+  });
+  const reg = captureRegistration();
+  registerPRReviewThreadsListTool(reg.register, graphql);
+  const out = (await reg.entry.handler({
+    repo: "owner/repo",
+    number: 7,
+  })) as { totalCount: number; threads: Array<{ id: string }> };
+  // totalCount reflects the GraphQL total (3), not the filtered
+  // length (2) — caller still sees there's more than the
+  // filter pass-through.
+  assert.equal(out.totalCount, 3);
+  assert.equal(out.threads.length, 2);
+  assert.deepEqual(
+    out.threads.map((t) => t.id),
+    ["RT_open_1", "RT_open_2"],
+  );
+  assert.equal(calls.length, 1);
+});
+
+test("gh.pr_review_threads_list: include_resolved=true returns every thread", async () => {
+  const { graphql } = stubGraphqlClient({
+    "pr/review_threads_list": () => ({
+      repository: {
+        pullRequest: {
+          reviewThreads: {
+            totalCount: 2,
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [
+              rawThread({ id: "RT_open", isResolved: false }),
+              rawThread({ id: "RT_resolved", isResolved: true }),
+            ],
+          },
+        },
+      },
+    }),
+  });
+  const reg = captureRegistration();
+  registerPRReviewThreadsListTool(reg.register, graphql);
+  const out = (await reg.entry.handler({
+    repo: "owner/repo",
+    number: 7,
+    include_resolved: true,
+  })) as { threads: Array<{ id: string; is_resolved: boolean }> };
+  assert.deepEqual(
+    out.threads.map((t) => ({ id: t.id, is_resolved: t.is_resolved })),
+    [
+      { id: "RT_open", is_resolved: false },
+      { id: "RT_resolved", is_resolved: true },
+    ],
+  );
+});
+
+test("gh.pr_review_threads_list: cursor + page_size + comments_per_thread pass through to GraphQL vars", async () => {
+  const { graphql } = stubGraphqlClient({
+    "pr/review_threads_list": (vars: Record<string, unknown>) => {
+      assert.equal(vars.first, 25);
+      assert.equal(vars.after, "PAGE2_CURSOR");
+      assert.equal(vars.commentsFirst, 3);
+      return {
+        repository: {
+          pullRequest: {
+            reviewThreads: {
+              totalCount: 0,
+              pageInfo: { hasNextPage: false, endCursor: null },
+              nodes: [],
+            },
+          },
+        },
+      };
+    },
+  });
+  const reg = captureRegistration();
+  registerPRReviewThreadsListTool(reg.register, graphql);
+  await reg.entry.handler({
+    repo: "owner/repo",
+    number: 7,
+    page_size: 25,
+    cursor: "PAGE2_CURSOR",
+    comments_per_thread: 3,
+  });
+});
+
+test("gh.pr_review_threads_list: comments_truncated=true when the per-thread comment page has more results", async () => {
+  const { graphql } = stubGraphqlClient({
+    "pr/review_threads_list": () => ({
+      repository: {
+        pullRequest: {
+          reviewThreads: {
+            totalCount: 1,
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [
+              rawThread({
+                id: "RT_chatty",
+                comments: {
+                  totalCount: 25,
+                  pageInfo: { hasNextPage: true },
+                  nodes: rawThread().comments.nodes,
+                },
+              }),
+            ],
+          },
+        },
+      },
+    }),
+  });
+  const reg = captureRegistration();
+  registerPRReviewThreadsListTool(reg.register, graphql);
+  const out = (await reg.entry.handler({
+    repo: "owner/repo",
+    number: 7,
+  })) as {
+    threads: Array<{
+      comments_truncated: boolean;
+      comments_total_count: number;
+    }>;
+  };
+  assert.equal(out.threads.length, 1);
+  assert.equal(out.threads[0]?.comments_truncated, true);
+  assert.equal(out.threads[0]?.comments_total_count, 25);
+});
+
+test("gh.pr_review_threads_list: outdated thread (null line) falls back to originalLine", async () => {
+  const { graphql } = stubGraphqlClient({
+    "pr/review_threads_list": () => ({
+      repository: {
+        pullRequest: {
+          reviewThreads: {
+            totalCount: 1,
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [
+              rawThread({
+                line: null,
+                originalLine: 15,
+                comments: {
+                  totalCount: 1,
+                  pageInfo: { hasNextPage: false },
+                  nodes: [
+                    {
+                      author: { login: "alice" },
+                      body: "outdated",
+                      path: "src/foo.ts",
+                      line: null,
+                      originalLine: 15,
+                      createdAt: "2026-04-01T00:00:00Z",
+                      url: "https://github.com/owner/repo/pull/7#discussion_r1",
+                    },
+                  ],
+                },
+              }),
+            ],
+          },
+        },
+      },
+    }),
+  });
+  const reg = captureRegistration();
+  registerPRReviewThreadsListTool(reg.register, graphql);
+  const out = (await reg.entry.handler({
+    repo: "owner/repo",
+    number: 7,
+  })) as { threads: Array<{ line: number | null; comments: Array<{ line: number | null }> }> };
+  assert.equal(out.threads[0]?.line, 15);
+  assert.equal(out.threads[0]?.comments[0]?.line, 15);
+});
+
+test("gh.pr_review_threads_list: repo missing throws repository-shaped error", async () => {
+  const { graphql } = stubGraphqlClient({
+    "pr/review_threads_list": () => ({ repository: null }),
+  });
+  const reg = captureRegistration();
+  registerPRReviewThreadsListTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", number: 7 }),
+    /repository 'owner\/repo' not found/,
+  );
+});
+
+test("gh.pr_review_threads_list: PR missing throws PR-shaped error", async () => {
+  const { graphql } = stubGraphqlClient({
+    "pr/review_threads_list": () => ({
+      repository: { pullRequest: null },
+    }),
+  });
+  const reg = captureRegistration();
+  registerPRReviewThreadsListTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", number: 99 }),
+    /PR owner\/repo#99 not found/,
+  );
+});
+
+test("gh.pr_review_threads_list: rejects page_size > 100 at the input boundary", async () => {
+  const { graphql } = stubGraphqlClient({});
+  const reg = captureRegistration();
+  registerPRReviewThreadsListTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", number: 7, page_size: 200 }),
+    /gh\.pr_review_threads_list input/,
+  );
+});
+
+test("gh.pr_review_threads_list: rejects comments_per_thread > 50 at the input boundary", async () => {
+  const { graphql } = stubGraphqlClient({});
+  const reg = captureRegistration();
+  registerPRReviewThreadsListTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      repo: "owner/repo",
+      number: 7,
+      comments_per_thread: 100,
+    }),
+    /gh\.pr_review_threads_list input/,
+  );
+});


### PR DESCRIPTION
## Summary
- New tool `gh.pr_review_threads_list` — paginated review threads for a PR (the conversation containers around inline review comments).
- Returns each thread's GraphQL `id` (suitable for GitHub's `resolveReviewThread` mutation) plus a per-thread comment preview: path, line, author, body, timestamp, url.
- Caller drives pagination via `after: endCursor` and `perPage` on input; output exposes `items`, `total`, `hasNextPage`, `endCursor` at the top level, matching `gh.pr_list` / `gh.issue_list` / `gh.label_list`.
- `include_resolved` defaults to false because the methodology's same-turn-resolve rule (memory \`feedback_pr_thread_resolve_same_turn\`) means the agent usually only cares about open threads. `total` stays the GraphQL totalCount across resolved + unresolved so the caller has an honest signal even when filtering.
- Outdated threads (`line: null`) fall back to `originalLine` so the caller still has a positional anchor.

## Test plan
- [x] `npm run lint`
- [x] `npm test` — 10 unit tests pin: default include_resolved filter; explicit include_resolved=true; after / perPage / comments_per_thread pass-through; flat hasNextPage / endCursor at top of output; comments_truncated flag; outdated-thread line fallback; repo-missing vs PR-missing error shapes; perPage > 100 + comments_per_thread > 50 schema rejections.