### PR TITLE
feat: gh.pr_review_thread_resolve (A3)

### DIFF
--- a/src/graphql/queries/pr/review_thread_resolve.graphql
+++ b/src/graphql/queries/pr/review_thread_resolve.graphql
@@ -1,0 +1,8 @@
+mutation PRReviewThreadResolve($input: ResolveReviewThreadInput!) {
+  resolveReviewThread(input: $input) {
+    thread {
+      id
+      isResolved
+    }
+  }
+}

--- a/src/tools/pr/index.ts
+++ b/src/tools/pr/index.ts
@@ -12,6 +12,7 @@ import { registerPREditTool } from "./edit.js";
 import { registerPRListTool } from "./list.js";
 import { registerPRMergeTool } from "./merge.js";
 import { registerPRRequestReviewsTool } from "./request_reviews.js";
+import { registerPRReviewThreadResolveTool } from "./review_thread_resolve.js";
 import { registerPRViewTool } from "./view.js";
 
 type RegisterToolFn = (name: string, entry: ToolEntry) => void;
@@ -27,4 +28,5 @@ export function registerPRTools(
   registerPRCommentTool(register, graphql);
   registerPRMergeTool(register, graphql);
   registerPRRequestReviewsTool(register, graphql);
+  registerPRReviewThreadResolveTool(register, graphql);
 }

--- a/src/tools/pr/index.ts
+++ b/src/tools/pr/index.ts
@@ -1,8 +1,11 @@
 // src/tools/pr/index.ts
 //
-// Aggregator for the seven gh.pr_* tools. Imported by
+// Aggregator for the gh.pr_* tools. Imported by
 // `src/server.ts`'s startServer() and called once at boot to
-// register every PR-domain tool against the registry.
+// register every PR-domain tool against the registry. The
+// function body below is the authoritative list — no hard-coded
+// count in this header so it doesn't drift each time a tool
+// joins or leaves the group.
 
 import type { GraphqlClient } from "../../graphql/client.js";
 import type { ToolEntry } from "../../registry.js";

--- a/src/tools/pr/review_thread_resolve.ts
+++ b/src/tools/pr/review_thread_resolve.ts
@@ -1,0 +1,99 @@
+// src/tools/pr/review_thread_resolve.ts
+//
+// `gh.pr_review_thread_resolve` — marks a PR review thread as
+// resolved via GraphQL's `resolveReviewThread` mutation. One
+// thread per call by design: the methodology memory rule
+// `feedback_avoid_chained_gh_calls.md` says never chain these
+// mutations in a single shell because a single bad ID silently
+// kills the rest of the chain. Callers that need to resolve
+// many threads loop client-side over `gh.pr_review_threads_list`
+// output.
+//
+// The mutation returns the thread's post-mutation state
+// (`isResolved`) so the caller can confirm the resolve actually
+// took effect — if a thread is already resolved, GitHub still
+// returns `isResolved: true` with no error, which is the
+// idempotent property the methodology's "resolve all addressed
+// threads in the same push" rule relies on.
+
+import type { GraphqlClient } from "../../graphql/client.js";
+import type { ToolEntry } from "../../registry.js";
+import { validate } from "../../validation/validator.js";
+
+const inputSchema = {
+  type: "object",
+  required: ["thread_id"],
+  properties: {
+    thread_id: {
+      type: "string",
+      minLength: 1,
+      description:
+        "Review thread node ID, as returned by " +
+        "`gh.pr_review_threads_list` in each thread's `id` field.",
+    },
+  },
+  additionalProperties: false,
+} as const;
+
+const outputSchema = {
+  type: "object",
+  required: ["thread_id", "is_resolved"],
+  properties: {
+    thread_id: { type: "string" },
+    is_resolved: { type: "boolean" },
+  },
+  additionalProperties: false,
+} as const;
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+interface Input {
+  thread_id: string;
+}
+
+interface Output {
+  thread_id: string;
+  is_resolved: boolean;
+}
+
+interface Response {
+  resolveReviewThread: {
+    thread: { id: string; isResolved: boolean };
+  };
+}
+
+export function registerPRReviewThreadResolveTool(
+  register: RegisterToolFn,
+  graphql: GraphqlClient,
+): void {
+  register("gh.pr_review_thread_resolve", {
+    description:
+      "Mark ONE PR review thread as resolved via GraphQL's " +
+      "`resolveReviewThread` mutation. Idempotent: re-running on " +
+      "an already-resolved thread returns `is_resolved: true` " +
+      "without error. ONE thread per call by design — callers loop " +
+      "client-side over `gh.pr_review_threads_list` output rather " +
+      "than chaining IDs, because a single bad ID in a chain " +
+      "silently kills the rest.",
+    inputSchema,
+    handler: async (raw) => {
+      const args = validate<Input>(
+        inputSchema,
+        raw,
+        "gh.pr_review_thread_resolve input",
+      );
+      const data = await graphql<Response>("pr/review_thread_resolve", {
+        input: { threadId: args.thread_id },
+      });
+      const out: Output = {
+        thread_id: data.resolveReviewThread.thread.id,
+        is_resolved: data.resolveReviewThread.thread.isResolved,
+      };
+      return validate<Output>(
+        outputSchema,
+        out,
+        "gh.pr_review_thread_resolve output",
+      );
+    },
+  });
+}

--- a/src/tools/pr/review_thread_resolve.ts
+++ b/src/tools/pr/review_thread_resolve.ts
@@ -6,8 +6,9 @@
 // `feedback_avoid_chained_gh_calls.md` says never chain these
 // mutations in a single shell because a single bad ID silently
 // kills the rest of the chain. Callers that need to resolve
-// many threads loop client-side over `gh.pr_review_threads_list`
-// output.
+// many threads loop client-side over their source of review-
+// thread node IDs (e.g. the companion list tool, or a hand-rolled
+// `reviewThreads(...)` GraphQL query).
 //
 // The mutation returns the thread's post-mutation state
 // (`isResolved`) so the caller can confirm the resolve actually
@@ -28,8 +29,10 @@ const inputSchema = {
       type: "string",
       minLength: 1,
       description:
-        "Review thread node ID, as returned by " +
-        "`gh.pr_review_threads_list` in each thread's `id` field.",
+        "PullRequestReviewThread node ID. Source it from any " +
+        "GraphQL query that selects `reviewThreads(...)` on a " +
+        "PR (the companion list tool's `threads[].id` field is " +
+        "the canonical source when both tools are installed).",
     },
   },
   additionalProperties: false,
@@ -71,10 +74,10 @@ export function registerPRReviewThreadResolveTool(
       "Mark ONE PR review thread as resolved via GraphQL's " +
       "`resolveReviewThread` mutation. Idempotent: re-running on " +
       "an already-resolved thread returns `is_resolved: true` " +
-      "without error. ONE thread per call by design — callers loop " +
-      "client-side over `gh.pr_review_threads_list` output rather " +
-      "than chaining IDs, because a single bad ID in a chain " +
-      "silently kills the rest.",
+      "without error. ONE thread per call by design — callers " +
+      "loop client-side over their thread-ID source rather than " +
+      "chaining IDs, because a single bad ID in a chain silently " +
+      "kills the rest.",
     inputSchema,
     handler: async (raw) => {
       const args = validate<Input>(

--- a/src/tools/pr/review_thread_resolve.ts
+++ b/src/tools/pr/review_thread_resolve.ts
@@ -2,13 +2,14 @@
 //
 // `gh.pr_review_thread_resolve` — marks a PR review thread as
 // resolved via GraphQL's `resolveReviewThread` mutation. One
-// thread per call by design: the methodology memory rule
-// `feedback_avoid_chained_gh_calls.md` says never chain these
-// mutations in a single shell because a single bad ID silently
-// kills the rest of the chain. Callers that need to resolve
-// many threads loop client-side over their source of review-
-// thread node IDs (e.g. the companion list tool, or a hand-rolled
-// `reviewThreads(...)` GraphQL query).
+// thread per call by design: chaining multiple resolves in a
+// single shell-out (`gh api graphql ... && gh api graphql ...`)
+// fails opaquely when any one ID is invalid — the second
+// mutation never runs and the failure point is hard to spot
+// in the chained output. Callers that need to resolve many
+// threads loop client-side over their source of review-thread
+// node IDs (any GraphQL query that selects `reviewThreads(...)`
+// on a PR).
 //
 // The mutation returns the thread's post-mutation state
 // (`isResolved`) so the caller can confirm the resolve actually
@@ -30,9 +31,9 @@ const inputSchema = {
       minLength: 1,
       description:
         "PullRequestReviewThread node ID. Source it from any " +
-        "GraphQL query that selects `reviewThreads(...)` on a " +
-        "PR (the companion list tool's `threads[].id` field is " +
-        "the canonical source when both tools are installed).",
+        "GraphQL query that selects `reviewThreads(...) { nodes " +
+        "{ id } }` on a PullRequest. The id looks like " +
+        "`PRRT_kw...`.",
     },
   },
   additionalProperties: false,

--- a/tests/smoke/server-lists-tools.mjs
+++ b/tests/smoke/server-lists-tools.mjs
@@ -50,6 +50,7 @@ const EXPECTED_TOOLS = [
   "gh.pr_comment",
   "gh.pr_merge",
   "gh.pr_request_reviews",
+  "gh.pr_review_thread_resolve",
   "gh.project_item_add",
   "gh.project_item_update_field",
   "gh.project_field_list",

--- a/tests/smoke/server-lists-tools.mjs
+++ b/tests/smoke/server-lists-tools.mjs
@@ -9,9 +9,10 @@
 // + tool registration chain end-to-end without pulling in the
 // unit-test framework.
 //
-// Current surface: 1 auth probe (`gh.test_connection` from MCP-2)
-// + 7 issue tools (MCP-4) + 4 label tools (MCP-7) + 7 PR tools
-// (MCP-5 + MCP-6, the latter adding `gh.pr_request_reviews`).
+// The EXPECTED_TOOLS array below is the authoritative list of
+// the current tool surface; this header used to also carry a
+// human-readable count, but that drifted on every PR. Read the
+// array if you want the current set.
 //
 // Wire format: the MCP SDK's StdioServerTransport uses newline-
 // delimited JSON-RPC (one JSON message per `\n`-terminated line),

--- a/tests/unit/tools/pr/review_thread_resolve.test.ts
+++ b/tests/unit/tools/pr/review_thread_resolve.test.ts
@@ -1,0 +1,99 @@
+// tests/unit/tools/pr/review_thread_resolve.test.ts
+//
+// gh.pr_review_thread_resolve: pin the input→mutation mapping,
+// the idempotent "already resolved" pass-through, and the
+// input-schema rejection of empty / missing thread_id.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { registerPRReviewThreadResolveTool } from "../../../../src/tools/pr/review_thread_resolve.ts";
+import type { ToolEntry } from "../../../../src/registry.ts";
+import { stubGraphqlClient } from "./_fixtures.ts";
+
+function captureRegistration() {
+  let entry: ToolEntry | undefined;
+  const register = (name: string, e: ToolEntry) => {
+    if (name !== "gh.pr_review_thread_resolve") {
+      throw new Error(`unexpected: ${name}`);
+    }
+    entry = e;
+  };
+  return {
+    register,
+    get entry(): ToolEntry {
+      if (!entry) throw new Error("not registered");
+      return entry;
+    },
+  };
+}
+
+test("gh.pr_review_thread_resolve: passes thread_id through as threadId on the mutation", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "pr/review_thread_resolve": (vars: Record<string, unknown>) => {
+      const input = vars.input as Record<string, unknown>;
+      assert.equal(input.threadId, "RT_abc");
+      return {
+        resolveReviewThread: {
+          thread: { id: "RT_abc", isResolved: true },
+        },
+      };
+    },
+  });
+  const reg = captureRegistration();
+  registerPRReviewThreadResolveTool(reg.register, graphql);
+  const out = (await reg.entry.handler({ thread_id: "RT_abc" })) as {
+    thread_id: string;
+    is_resolved: boolean;
+  };
+  assert.deepEqual(out, { thread_id: "RT_abc", is_resolved: true });
+  assert.equal(calls.length, 1);
+});
+
+test("gh.pr_review_thread_resolve: idempotent — already-resolved thread still returns is_resolved: true", async () => {
+  const { graphql } = stubGraphqlClient({
+    // GitHub does not error on a no-op resolve; it returns the
+    // thread with isResolved: true regardless of prior state.
+    "pr/review_thread_resolve": () => ({
+      resolveReviewThread: {
+        thread: { id: "RT_already", isResolved: true },
+      },
+    }),
+  });
+  const reg = captureRegistration();
+  registerPRReviewThreadResolveTool(reg.register, graphql);
+  const out = (await reg.entry.handler({ thread_id: "RT_already" })) as {
+    is_resolved: boolean;
+  };
+  assert.equal(out.is_resolved, true);
+});
+
+test("gh.pr_review_thread_resolve: rejects empty thread_id at the input boundary", async () => {
+  const { graphql } = stubGraphqlClient({});
+  const reg = captureRegistration();
+  registerPRReviewThreadResolveTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ thread_id: "" }),
+    /gh\.pr_review_thread_resolve input/,
+  );
+});
+
+test("gh.pr_review_thread_resolve: rejects missing thread_id at the input boundary", async () => {
+  const { graphql } = stubGraphqlClient({});
+  const reg = captureRegistration();
+  registerPRReviewThreadResolveTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({}),
+    /gh\.pr_review_thread_resolve input/,
+  );
+});
+
+test("gh.pr_review_thread_resolve: rejects unknown extra properties at the input boundary", async () => {
+  const { graphql } = stubGraphqlClient({});
+  const reg = captureRegistration();
+  registerPRReviewThreadResolveTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ thread_id: "RT_x", repo: "owner/repo" }),
+    /gh\.pr_review_thread_resolve input/,
+  );
+});


### PR DESCRIPTION
## Summary
- New tool `gh.pr_review_thread_resolve` — marks one PR review thread as resolved via GraphQL's `resolveReviewThread` mutation.
- One thread per call by design: memory rule `feedback_avoid_chained_gh_calls` says never chain these mutations in a single shell because a single bad id silently kills the rest of the chain. Callers loop client-side over `gh.pr_review_threads_list` output.
- Idempotent: re-running on an already-resolved thread returns `is_resolved: true` with no error — the property the methodology's "resolve all addressed threads in the same push" rule relies on.

## Test plan
- [x] `npm run lint`
- [x] `npm test` — 5 new unit tests pin: input → mutation mapping; idempotent already-resolved passthrough; empty thread_id rejection; missing thread_id rejection; unknown extra props rejection.