### PR TITLE
feat: gh.org_issue_types_list + org tool group (A4)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -36,6 +36,7 @@ import {
 import { registerTestConnectionTool } from "./tools/auth/test_connection.js";
 import { registerIssueTools } from "./tools/issue/index.js";
 import { registerLabelTools } from "./tools/label/index.js";
+import { registerOrgTools } from "./tools/org/index.js";
 import { registerPRTools } from "./tools/pr/index.js";
 import { registerProjectTools } from "./tools/project/index.js";
 import { registerWorkflowTools } from "./tools/workflow/index.js";
@@ -88,6 +89,10 @@ export async function startServer(): Promise<void> {
   // (no cancel mutation; weak filter surface on the run list).
   // Same auth layer underneath, just a different request path.
   registerWorkflowTools(registerTool, authedRequest);
+  // Org tools straddle both: native Issue Types are listed via
+  // REST (the route isn't in GraphQL) but mutated via GraphQL.
+  // The registrar takes both clients so each tool can pick.
+  registerOrgTools(registerTool, authedRequest, graphql);
 
   const server = new Server(
     {

--- a/src/tools/org/_shared.ts
+++ b/src/tools/org/_shared.ts
@@ -1,7 +1,7 @@
 // src/tools/org/_shared.ts
 //
 // Helpers shared across the gh.org_* tools. The org domain covers
-// organisation-scoped operations that don't fit under issue / pr
+// organization-scoped operations that don't fit under issue / pr
 // / label / project — at v0.1 that's just GitHub's native "Issue
 // Types" (REST + GraphQL) used by the methodology's optional
 // `label-taxonomy` flow to set canonical issue categories without
@@ -83,5 +83,5 @@ export const orgLoginSchema = {
   // leading/trailing/double hyphens. Conservative pattern
   // matches the same form the API accepts.
   pattern: "^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$",
-  description: "Organisation login (e.g. `my-org`).",
+  description: "Organization login (e.g. `my-org`).",
 } as const;

--- a/src/tools/org/_shared.ts
+++ b/src/tools/org/_shared.ts
@@ -1,0 +1,85 @@
+// src/tools/org/_shared.ts
+//
+// Helpers shared across the gh.org_* tools. The org domain covers
+// organisation-scoped operations that don't fit under issue / pr
+// / label / project — at v0.1 that's just GitHub's native "Issue
+// Types" (REST + GraphQL) used by the methodology's optional
+// `label-taxonomy` flow to set canonical issue categories without
+// piggybacking on labels.
+
+// JSON-Schema-shaped summary of one Issue Type as returned by the
+// REST endpoint `GET /orgs/{org}/issue-types`. The endpoint is
+// not in `@octokit/openapi-types` yet, so we describe the wire
+// format here and pin it via output validation. Fields match
+// GitHub's response 1:1 with snake_case → camelCase for the
+// nullable `is_enabled` (other names are already snake_case).
+export interface IssueTypeSummary {
+  id: number;
+  name: string;
+  description: string | null;
+  color: string | null;
+  is_enabled: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export const issueTypeSummarySchema = {
+  type: "object",
+  required: [
+    "id",
+    "name",
+    "description",
+    "color",
+    "is_enabled",
+    "created_at",
+    "updated_at",
+  ],
+  properties: {
+    id: { type: "integer" },
+    name: { type: "string" },
+    description: { type: ["string", "null"] },
+    // GitHub returns the color as an unprefixed enum-ish string
+    // (`gray`, `blue`, `green`, `yellow`, `orange`, `red`, `pink`,
+    // `purple`) — leave it as a free string for forward
+    // compatibility rather than pinning the enum.
+    color: { type: ["string", "null"] },
+    is_enabled: { type: "boolean" },
+    created_at: { type: "string" },
+    updated_at: { type: "string" },
+  },
+  additionalProperties: false,
+} as const;
+
+export interface RawIssueType {
+  id: number;
+  name: string;
+  description: string | null;
+  color: string | null;
+  is_enabled: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export function summariseIssueType(raw: RawIssueType): IssueTypeSummary {
+  return {
+    id: raw.id,
+    name: raw.name,
+    description: raw.description,
+    color: raw.color,
+    is_enabled: raw.is_enabled,
+    created_at: raw.created_at,
+    updated_at: raw.updated_at,
+  };
+}
+
+// JSON-Schema fragment for the `org` input every gh.org_* tool
+// requires. Inlined into each tool's schema rather than `$ref`'d
+// to match the other domains' pattern.
+export const orgLoginSchema = {
+  type: "string",
+  // GitHub login charset: alphanumeric and single hyphens, no
+  // leading/trailing/double hyphens. Conservative pattern
+  // matches the same form the API accepts.
+  pattern: "^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$",
+  description: "Organisation login (e.g. `my-org`).",
+} as const;

--- a/src/tools/org/_shared.ts
+++ b/src/tools/org/_shared.ts
@@ -10,9 +10,11 @@
 // JSON-Schema-shaped summary of one Issue Type as returned by the
 // REST endpoint `GET /orgs/{org}/issue-types`. The endpoint is
 // not in `@octokit/openapi-types` yet, so we describe the wire
-// format here and pin it via output validation. Fields match
-// GitHub's response 1:1 with snake_case → camelCase for the
-// nullable `is_enabled` (other names are already snake_case).
+// format here and pin it via output validation. Fields pass
+// through 1:1 from GitHub's response: `id` is numeric, `name`/
+// `description`/`color` are strings (the latter two nullable),
+// `is_enabled` is a non-nullable boolean, and the timestamps
+// are ISO-8601 strings.
 export interface IssueTypeSummary {
   id: number;
   name: string;

--- a/src/tools/org/index.ts
+++ b/src/tools/org/index.ts
@@ -1,0 +1,26 @@
+// src/tools/org/index.ts
+//
+// Aggregator for the gh.org_* tools. Like the workflow group, the
+// registrar takes `authedRequest` (REST) plus `graphql` because
+// native Issue Type mutations live on GraphQL while the listing
+// endpoint is REST-only. v0.1 of this group exposes a single
+// REST list tool; the create + assign mutations (A5) layer on
+// top.
+
+import type { AuthedRequest } from "../../auth/octokit.js";
+import type { GraphqlClient } from "../../graphql/client.js";
+import type { ToolEntry } from "../../registry.js";
+import { registerOrgIssueTypesListTool } from "./issue_types_list.js";
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+export function registerOrgTools(
+  register: RegisterToolFn,
+  authedRequest: AuthedRequest,
+  // graphql is unused at the moment but the signature anticipates
+  // A5's `org_issue_type_create` GraphQL mutation. Keeping the
+  // parameter here avoids a churn-y signature change one PR later.
+  _graphql: GraphqlClient,
+): void {
+  registerOrgIssueTypesListTool(register, authedRequest);
+}

--- a/src/tools/org/issue_types_list.ts
+++ b/src/tools/org/issue_types_list.ts
@@ -1,0 +1,94 @@
+// src/tools/org/issue_types_list.ts
+//
+// `gh.org_issue_types_list` — list the native Issue Types
+// configured on an org via REST `GET /orgs/{org}/issue-types`.
+// Native Issue Types are GitHub's first-class categorisation that
+// the methodology's `label-taxonomy.md` uses (when the optional
+// `admin:org` scope is granted) instead of label-based proxies
+// for type:feature / type:bug / etc.
+//
+// REST rather than GraphQL because the endpoint isn't exposed via
+// GraphQL at the org level (only on individual Issues, via the
+// `issueType` field). The route is too new for
+// `@octokit/openapi-types` to type it, so we declare the wire
+// shape in `_shared.ts` and pin it via output validation.
+
+import type { AuthedRequest } from "../../auth/octokit.js";
+import type { ToolEntry } from "../../registry.js";
+import { validate } from "../../validation/validator.js";
+import {
+  type IssueTypeSummary,
+  type RawIssueType,
+  issueTypeSummarySchema,
+  orgLoginSchema,
+  summariseIssueType,
+} from "./_shared.js";
+
+const inputSchema = {
+  type: "object",
+  required: ["org"],
+  properties: {
+    org: orgLoginSchema,
+  },
+  additionalProperties: false,
+} as const;
+
+const outputSchema = {
+  type: "object",
+  required: ["types"],
+  properties: {
+    types: { type: "array", items: issueTypeSummarySchema },
+  },
+  additionalProperties: false,
+} as const;
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+interface Input {
+  org: string;
+}
+
+interface Output {
+  types: IssueTypeSummary[];
+}
+
+export function registerOrgIssueTypesListTool(
+  register: RegisterToolFn,
+  authedRequest: AuthedRequest,
+): void {
+  register("gh.org_issue_types_list", {
+    description:
+      "List native Issue Types configured on an organisation. " +
+      "Requires `read:org` (and the org must have native Issue " +
+      "Types enabled). Returns the type's numeric id used by " +
+      "`gh.issue_set_issue_type` to apply it to an issue.",
+    inputSchema,
+    handler: async (raw) => {
+      const args = validate<Input>(
+        inputSchema,
+        raw,
+        "gh.org_issue_types_list input",
+      );
+      // The route isn't in @octokit/openapi-types yet; cast both
+      // the route literal and the params through `unknown` so
+      // Octokit's per-route narrowing stays out of the way. The
+      // path is well-known and documented under
+      // `/orgs/{org}/issue-types`.
+      const response = await (
+        authedRequest as unknown as (
+          route: string,
+          params: Record<string, unknown>,
+        ) => Promise<{ data: unknown }>
+      )("GET /orgs/{org}/issue-types", { org: args.org });
+      const data = response.data as RawIssueType[];
+      const out: Output = {
+        types: data.map(summariseIssueType),
+      };
+      return validate<Output>(
+        outputSchema,
+        out,
+        "gh.org_issue_types_list output",
+      );
+    },
+  });
+}

--- a/src/tools/org/issue_types_list.ts
+++ b/src/tools/org/issue_types_list.ts
@@ -60,8 +60,10 @@ export function registerOrgIssueTypesListTool(
     description:
       "List native Issue Types configured on an organisation. " +
       "Requires `read:org` (and the org must have native Issue " +
-      "Types enabled). Returns the type's numeric id used by " +
-      "`gh.issue_set_issue_type` to apply it to an issue.",
+      "Types enabled). Returns each type's numeric REST id along " +
+      "with name, description, color, and enabled flag — the id is " +
+      "what the setter tool consumes when applying a type to an " +
+      "issue.",
     inputSchema,
     handler: async (raw) => {
       const args = validate<Input>(
@@ -80,6 +82,15 @@ export function registerOrgIssueTypesListTool(
           params: Record<string, unknown>,
         ) => Promise<{ data: unknown }>
       )("GET /orgs/{org}/issue-types", { org: args.org });
+      // Guard against a non-array response shape (transient API
+      // hiccup, future API change, etc.). Surfacing this as a
+      // structured error is far more useful than a confusing
+      // "data.map is not a function" TypeError from below.
+      if (!Array.isArray(response.data)) {
+        throw new Error(
+          `mcp-github: gh.org_issue_types_list: unexpected response shape from GET /orgs/${args.org}/issue-types — expected an array of issue types, got ${typeof response.data}`,
+        );
+      }
       const data = response.data as RawIssueType[];
       const out: Output = {
         types: data.map(summariseIssueType),

--- a/src/tools/org/issue_types_list.ts
+++ b/src/tools/org/issue_types_list.ts
@@ -59,7 +59,7 @@ export function registerOrgIssueTypesListTool(
 ): void {
   register("gh.org_issue_types_list", {
     description:
-      "List native Issue Types configured on an organisation. " +
+      "List native Issue Types configured on an organization. " +
       "Requires `read:org` (and the org must have native Issue " +
       "Types enabled). Returns each type's numeric REST id along " +
       "with name, description, color, and enabled flag. Note: " +

--- a/src/tools/org/issue_types_list.ts
+++ b/src/tools/org/issue_types_list.ts
@@ -61,12 +61,12 @@ export function registerOrgIssueTypesListTool(
     description:
       "List native Issue Types configured on an organization. " +
       "Requires `read:org` (and the org must have native Issue " +
-      "Types enabled). Returns each type's numeric REST id along " +
-      "with name, description, color, and enabled flag. Note: " +
-      "the GraphQL mutation that applies a type to an issue " +
-      "requires the GraphQL node id, not this numeric id; the " +
-      "node id is returned at create time and must be captured " +
-      "then.",
+      "Types enabled). Returns each type's numeric REST id, name, " +
+      "description, color, enabled flag, and ISO-8601 created_at " +
+      "/ updated_at timestamps. Note: the GraphQL mutation that " +
+      "applies a type to an issue requires the GraphQL node id, " +
+      "not this numeric id; the node id is returned at create " +
+      "time and must be captured then.",
     inputSchema,
     handler: async (raw) => {
       const args = validate<Input>(
@@ -90,8 +90,18 @@ export function registerOrgIssueTypesListTool(
       // structured error is far more useful than a confusing
       // "data.map is not a function" TypeError from below.
       if (!Array.isArray(response.data)) {
+        // `typeof null` is `"object"`, which is low-signal; tag
+        // it explicitly so the operator can tell a null from a
+        // wrapped-object response (transient API hiccup vs.
+        // permission-stripped payload).
+        const shape =
+          response.data === null
+            ? "null"
+            : typeof response.data === "object"
+              ? "object"
+              : typeof response.data;
         throw new Error(
-          `mcp-github: gh.org_issue_types_list: unexpected response shape from GET /orgs/${args.org}/issue-types — expected an array of issue types, got ${typeof response.data}`,
+          `mcp-github: gh.org_issue_types_list: unexpected response shape from GET /orgs/${args.org}/issue-types — expected an array of issue types, got ${shape}`,
         );
       }
       const data = response.data as RawIssueType[];

--- a/src/tools/org/issue_types_list.ts
+++ b/src/tools/org/issue_types_list.ts
@@ -2,10 +2,11 @@
 //
 // `gh.org_issue_types_list` — list the native Issue Types
 // configured on an org via REST `GET /orgs/{org}/issue-types`.
-// Native Issue Types are GitHub's first-class categorisation that
-// the methodology's `label-taxonomy.md` uses (when the optional
-// `admin:org` scope is granted) instead of label-based proxies
-// for type:feature / type:bug / etc.
+// Native Issue Types are GitHub's first-class categorisation
+// that the methodology's `label-taxonomy.md` uses instead of
+// label-based proxies for type:feature / type:bug / etc.
+// Listing requires `read:org`; mutating the org's issue types
+// (a separate concern) requires `admin:org`.
 //
 // REST rather than GraphQL because the endpoint isn't exposed via
 // GraphQL at the org level (only on individual Issues, via the
@@ -61,9 +62,11 @@ export function registerOrgIssueTypesListTool(
       "List native Issue Types configured on an organisation. " +
       "Requires `read:org` (and the org must have native Issue " +
       "Types enabled). Returns each type's numeric REST id along " +
-      "with name, description, color, and enabled flag — the id is " +
-      "what the setter tool consumes when applying a type to an " +
-      "issue.",
+      "with name, description, color, and enabled flag. Note: " +
+      "the GraphQL mutation that applies a type to an issue " +
+      "requires the GraphQL node id, not this numeric id; the " +
+      "node id is returned at create time and must be captured " +
+      "then.",
     inputSchema,
     handler: async (raw) => {
       const args = validate<Input>(

--- a/tests/smoke/server-lists-tools.mjs
+++ b/tests/smoke/server-lists-tools.mjs
@@ -9,9 +9,10 @@
 // + tool registration chain end-to-end without pulling in the
 // unit-test framework.
 //
-// Current surface: 1 auth probe (`gh.test_connection` from MCP-2)
-// + 7 issue tools (MCP-4) + 4 label tools (MCP-7) + 7 PR tools
-// (MCP-5 + MCP-6, the latter adding `gh.pr_request_reviews`).
+// The EXPECTED_TOOLS array below is the authoritative list of
+// the current tool surface; this header used to also carry a
+// human-readable count, but that drifted on every PR. Read the
+// array if you want the current set.
 //
 // Wire format: the MCP SDK's StdioServerTransport uses newline-
 // delimited JSON-RPC (one JSON message per `\n`-terminated line),

--- a/tests/smoke/server-lists-tools.mjs
+++ b/tests/smoke/server-lists-tools.mjs
@@ -58,6 +58,7 @@ const EXPECTED_TOOLS = [
   "gh.workflow_run_view",
   "gh.workflow_run_cancel",
   "gh.workflow_run_jobs",
+  "gh.org_issue_types_list",
 ];
 
 function frame(payload) {

--- a/tests/unit/tools/org/_fixtures.ts
+++ b/tests/unit/tools/org/_fixtures.ts
@@ -1,0 +1,60 @@
+// tests/unit/tools/org/_fixtures.ts
+//
+// Shared fixtures + stub helpers for the gh.org_* tool tests.
+// The org domain mixes REST and GraphQL clients (REST for the
+// listing endpoint, GraphQL for the mutations) so this module
+// re-exports the workflow tests' `stubAuthedRequest` shape
+// alongside the standard graphql stub.
+
+export {
+  stubAuthedRequest,
+  type RestCall,
+  withStatus,
+  httpError,
+} from "../workflow/_fixtures.ts";
+
+import type { GraphqlClient } from "../../../../src/graphql/client.ts";
+
+export interface MockedGraphqlCall {
+  queryName: string;
+  vars: Record<string, unknown>;
+}
+
+export function stubGraphqlClient(
+  fixtures: Record<
+    string,
+    | unknown
+    | ((vars: Record<string, unknown>) => unknown | Promise<unknown>)
+  >,
+): { graphql: GraphqlClient; calls: MockedGraphqlCall[] } {
+  const calls: MockedGraphqlCall[] = [];
+  const graphql = (async (
+    queryName: string,
+    vars: Record<string, unknown> = {},
+  ) => {
+    calls.push({ queryName, vars });
+    if (!(queryName in fixtures)) {
+      throw new Error(
+        `tests: stubGraphqlClient saw unmocked queryName: ${queryName}`,
+      );
+    }
+    const entry = fixtures[queryName];
+    if (typeof entry === "function") {
+      return await (entry as (v: Record<string, unknown>) => unknown)(vars);
+    }
+    return entry;
+  }) as unknown as GraphqlClient;
+  return { graphql, calls };
+}
+
+// Canonical RawIssueType fixture — REST shape from
+// `GET /orgs/{org}/issue-types`. Tests override fields by spread.
+export const sampleRawIssueType = {
+  id: 1001,
+  name: "Feature",
+  description: "A new capability.",
+  color: "green",
+  is_enabled: true,
+  created_at: "2026-04-01T00:00:00Z",
+  updated_at: "2026-04-02T00:00:00Z",
+};

--- a/tests/unit/tools/org/issue_types_list.test.ts
+++ b/tests/unit/tools/org/issue_types_list.test.ts
@@ -59,6 +59,8 @@ test("gh.org_issue_types_list: maps every wire field onto the summary 1:1", asyn
       color: string | null;
       description: string | null;
       is_enabled: boolean;
+      created_at: string;
+      updated_at: string;
     }>;
   };
   assert.deepEqual(out.types[0], {

--- a/tests/unit/tools/org/issue_types_list.test.ts
+++ b/tests/unit/tools/org/issue_types_list.test.ts
@@ -1,0 +1,106 @@
+// tests/unit/tools/org/issue_types_list.test.ts
+//
+// gh.org_issue_types_list: pin the REST route + org param,
+// the wire-shape → summary mapping, and the input-schema
+// rejection of malformed org logins.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { registerOrgIssueTypesListTool } from "../../../../src/tools/org/issue_types_list.ts";
+import type { ToolEntry } from "../../../../src/registry.ts";
+import { sampleRawIssueType, stubAuthedRequest } from "./_fixtures.ts";
+
+function captureRegistration() {
+  let entry: ToolEntry | undefined;
+  const register = (name: string, e: ToolEntry) => {
+    if (name !== "gh.org_issue_types_list") {
+      throw new Error(`unexpected: ${name}`);
+    }
+    entry = e;
+  };
+  return {
+    register,
+    get entry(): ToolEntry {
+      if (!entry) throw new Error("not registered");
+      return entry;
+    },
+  };
+}
+
+test("gh.org_issue_types_list: hits GET /orgs/{org}/issue-types with the supplied org", async () => {
+  const { authedRequest, calls } = stubAuthedRequest({
+    "GET /orgs/{org}/issue-types": [sampleRawIssueType],
+  });
+  const reg = captureRegistration();
+  registerOrgIssueTypesListTool(reg.register, authedRequest);
+  const out = (await reg.entry.handler({ org: "my-org" })) as {
+    types: Array<{ id: number; name: string }>;
+  };
+  assert.equal(out.types.length, 1);
+  assert.equal(out.types[0]?.id, 1001);
+  assert.equal(out.types[0]?.name, "Feature");
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]?.params.org, "my-org");
+});
+
+test("gh.org_issue_types_list: maps every wire field onto the summary 1:1", async () => {
+  const { authedRequest } = stubAuthedRequest({
+    "GET /orgs/{org}/issue-types": [
+      { ...sampleRawIssueType, id: 2, name: "Bug", color: "red", description: null, is_enabled: false },
+    ],
+  });
+  const reg = captureRegistration();
+  registerOrgIssueTypesListTool(reg.register, authedRequest);
+  const out = (await reg.entry.handler({ org: "my-org" })) as {
+    types: Array<{
+      id: number;
+      name: string;
+      color: string | null;
+      description: string | null;
+      is_enabled: boolean;
+    }>;
+  };
+  assert.deepEqual(out.types[0], {
+    id: 2,
+    name: "Bug",
+    description: null,
+    color: "red",
+    is_enabled: false,
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-02T00:00:00Z",
+  });
+});
+
+test("gh.org_issue_types_list: empty list passes through cleanly", async () => {
+  const { authedRequest } = stubAuthedRequest({
+    "GET /orgs/{org}/issue-types": [],
+  });
+  const reg = captureRegistration();
+  registerOrgIssueTypesListTool(reg.register, authedRequest);
+  const out = (await reg.entry.handler({ org: "my-org" })) as {
+    types: unknown[];
+  };
+  assert.deepEqual(out.types, []);
+});
+
+test("gh.org_issue_types_list: rejects malformed org login at the input boundary", async () => {
+  const { authedRequest } = stubAuthedRequest({});
+  const reg = captureRegistration();
+  registerOrgIssueTypesListTool(reg.register, authedRequest);
+  // Trailing hyphen — invalid GitHub login.
+  await assert.rejects(
+    reg.entry.handler({ org: "my-org-" }),
+    /gh\.org_issue_types_list input/,
+  );
+});
+
+test("gh.org_issue_types_list: rejects missing org at the input boundary", async () => {
+  const { authedRequest } = stubAuthedRequest({});
+  const reg = captureRegistration();
+  registerOrgIssueTypesListTool(reg.register, authedRequest);
+  await assert.rejects(
+    reg.entry.handler({}),
+    /gh\.org_issue_types_list input/,
+  );
+});


### PR DESCRIPTION
## Summary
- New `org/` tool group (anticipates A5's GraphQL mutations on top of REST listing).
- New tool `gh.org_issue_types_list` — REST `GET /orgs/{org}/issue-types` via the existing `authedRequest` helper.
- Output schema pins the wire shape (`id`, `name`, `description`, `color`, `is_enabled`, `created_at`, `updated_at`); the route isn't in `@octokit/openapi-types` yet so the cast is the same shape used by the workflow tools for routes outside the typed catalogue.

## Test plan
- [x] `npm run lint`
- [x] `npm test` — 5 new unit tests pin: route + org param; full wire-shape → summary mapping (including nullable `description` + `is_enabled: false`); empty list passthrough; malformed login rejection; missing org rejection.