### PR TITLE
feat: gh.issue_parent_get + gh.issue_sub_issues_list (A6)

### DIFF
--- a/src/graphql/queries/issue/parent_get.graphql
+++ b/src/graphql/queries/issue/parent_get.graphql
@@ -1,0 +1,19 @@
+query IssueParentGet($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    issue(number: $number) {
+      parent {
+        id
+        number
+        title
+        url
+        state
+        repository {
+          owner {
+            login
+          }
+          name
+        }
+      }
+    }
+  }
+}

--- a/src/graphql/queries/issue/parent_get_by_id.graphql
+++ b/src/graphql/queries/issue/parent_get_by_id.graphql
@@ -1,0 +1,19 @@
+query IssueParentGetById($issueId: ID!) {
+  node(id: $issueId) {
+    ... on Issue {
+      parent {
+        id
+        number
+        title
+        url
+        state
+        repository {
+          owner {
+            login
+          }
+          name
+        }
+      }
+    }
+  }
+}

--- a/src/graphql/queries/issue/parent_get_by_id.graphql
+++ b/src/graphql/queries/issue/parent_get_by_id.graphql
@@ -1,5 +1,6 @@
 query IssueParentGetById($issueId: ID!) {
   node(id: $issueId) {
+    __typename
     ... on Issue {
       parent {
         id

--- a/src/graphql/queries/issue/sub_issues_list.graphql
+++ b/src/graphql/queries/issue/sub_issues_list.graphql
@@ -1,0 +1,32 @@
+query IssueSubIssuesList(
+  $owner: String!
+  $name: String!
+  $number: Int!
+  $first: Int!
+  $after: String
+) {
+  repository(owner: $owner, name: $name) {
+    issue(number: $number) {
+      subIssues(first: $first, after: $after) {
+        totalCount
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          id
+          number
+          title
+          url
+          state
+          repository {
+            owner {
+              login
+            }
+            name
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/graphql/queries/issue/sub_issues_list_by_id.graphql
+++ b/src/graphql/queries/issue/sub_issues_list_by_id.graphql
@@ -1,0 +1,30 @@
+query IssueSubIssuesListById(
+  $issueId: ID!
+  $first: Int!
+  $after: String
+) {
+  node(id: $issueId) {
+    ... on Issue {
+      subIssues(first: $first, after: $after) {
+        totalCount
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          id
+          number
+          title
+          url
+          state
+          repository {
+            owner {
+              login
+            }
+            name
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/graphql/queries/issue/sub_issues_list_by_id.graphql
+++ b/src/graphql/queries/issue/sub_issues_list_by_id.graphql
@@ -4,6 +4,7 @@ query IssueSubIssuesListById(
   $after: String
 ) {
   node(id: $issueId) {
+    __typename
     ... on Issue {
       subIssues(first: $first, after: $after) {
         totalCount

--- a/src/tools/issue/index.ts
+++ b/src/tools/issue/index.ts
@@ -1,10 +1,13 @@
 // src/tools/issue/index.ts
 //
-// Aggregator for the seven `gh.issue_*` tools. Imported by
+// Aggregator for the gh.issue_* tools. Imported by
 // `src/server.ts`'s `startServer()` and called once at boot to
 // register every issue-domain tool against the registry. Each
 // individual tool lives in its own file to keep the per-tool
 // schemas + handlers manageable; this file just orchestrates.
+// The function body below is the authoritative list — no
+// hard-coded count in this header so it doesn't drift each time
+// a tool joins or leaves the group.
 
 import type { GraphqlClient } from "../../graphql/client.js";
 import type { ToolEntry } from "../../registry.js";

--- a/src/tools/issue/index.ts
+++ b/src/tools/issue/index.ts
@@ -13,7 +13,9 @@ import { registerIssueCommentTool } from "./comment.js";
 import { registerIssueCreateTool } from "./create.js";
 import { registerIssueEditTool } from "./edit.js";
 import { registerIssueListTool } from "./list.js";
+import { registerIssueParentGetTool } from "./parent_get.js";
 import { registerIssueSearchTool } from "./search.js";
+import { registerIssueSubIssuesListTool } from "./sub_issues_list.js";
 import { registerIssueViewTool } from "./view.js";
 
 type RegisterToolFn = (name: string, entry: ToolEntry) => void;
@@ -29,4 +31,6 @@ export function registerIssueTools(
   registerIssueCloseTool(register, graphql);
   registerIssueCommentTool(register, graphql);
   registerIssueSearchTool(register, graphql);
+  registerIssueParentGetTool(register, graphql);
+  registerIssueSubIssuesListTool(register, graphql);
 }

--- a/src/tools/issue/parent_get.ts
+++ b/src/tools/issue/parent_get.ts
@@ -14,8 +14,10 @@ import type { ToolEntry } from "../../registry.js";
 import { validate } from "../../validation/validator.js";
 import { parseRepoSlug, repoSlugSchema } from "./_shared.js";
 
-// Issue-ref schema (matches the `add_sub_issue` shape exactly):
-// either pre-resolved node_id or (repo, number), never both.
+// Issue-ref schema: either pre-resolved `node_id` or
+// `(repo, number)`, never both. `oneOf` enforces the divide so
+// a mis-shaped input fails fast at the schema boundary rather
+// than producing a confusing "issue X not found" downstream.
 const inputSchema = {
   type: "object",
   properties: {

--- a/src/tools/issue/parent_get.ts
+++ b/src/tools/issue/parent_get.ts
@@ -1,7 +1,7 @@
 // src/tools/issue/parent_get.ts
 //
 // `gh.issue_parent_get` — fetch an issue's native parent (the
-// counterpart of `gh.issue_add_sub_issue` for read-only walks).
+// read-only counterpart to the sub-issue wiring tool).
 // Returns `{ parent: { number, node_id, url, title, state, repo
 // } | null }`; null means the issue is a root in the sub-issue
 // tree (or has never been wired). Backs the methodology's
@@ -104,7 +104,13 @@ interface ByRepoResponse {
 }
 
 interface ByIdResponse {
-  node: { parent: RawParent | null } | null;
+  // Wide on purpose: `node(id)` resolves any GraphQL node type;
+  // we narrow on `__typename === "Issue"` at runtime before
+  // reading `parent`. Modelling the union with a literal/string
+  // discriminant doesn't narrow cleanly because the literal
+  // overlaps with `string`, so we keep the field-presence
+  // optional and check it after the typename guard.
+  node: { __typename: string; parent?: RawParent | null } | null;
 }
 
 export function registerIssueParentGetTool(
@@ -114,10 +120,9 @@ export function registerIssueParentGetTool(
   register("gh.issue_parent_get", {
     description:
       "Fetch an issue's native parent. Returns `{ parent: null }` " +
-      "for issues that are roots in the sub-issue tree, or that " +
-      "have never been wired with `gh.issue_add_sub_issue`. " +
-      "Accepts either a pre-resolved `node_id` or a " +
-      "`(repo, number)` pair.",
+      "for issues that are roots in the sub-issue tree, or for " +
+      "issues never wired into one. Accepts either a pre-resolved " +
+      "`node_id` or a `(repo, number)` pair.",
     inputSchema,
     handler: async (raw) => {
       const args = validate<Input>(
@@ -135,7 +140,18 @@ export function registerIssueParentGetTool(
             `mcp-github: gh.issue_parent_get: issue node_id '${args.node_id}' not found`,
           );
         }
-        parent = data.node.parent;
+        // `node(id)` resolves any GraphQL node, not just Issues.
+        // Guard against a node_id that points at a PullRequest /
+        // Project / Repository / etc. — without this, GraphQL
+        // returns `{ __typename: "..." }` with no `parent` field
+        // and `data.node.parent` would be `undefined`, crashing
+        // `summariseParent`. Surface a clean error instead.
+        if (data.node.__typename !== "Issue") {
+          throw new Error(
+            `mcp-github: gh.issue_parent_get: node_id '${args.node_id}' is a ${data.node.__typename}, not an Issue`,
+          );
+        }
+        parent = data.node.parent ?? null;
       } else {
         const coords = parseRepoSlug(
           args.repo as string,

--- a/src/tools/issue/parent_get.ts
+++ b/src/tools/issue/parent_get.ts
@@ -1,0 +1,178 @@
+// src/tools/issue/parent_get.ts
+//
+// `gh.issue_parent_get` — fetch an issue's native parent (the
+// counterpart of `gh.issue_add_sub_issue` for read-only walks).
+// Returns `{ parent: { number, node_id, url, title, state, repo
+// } | null }`; null means the issue is a root in the sub-issue
+// tree (or has never been wired). Backs the methodology's
+// parallel-validation dependency-graph audit at
+// `parallel-validation.md:79` and the validators'
+// `validate-tree.mjs` parent-chain walk.
+
+import type { GraphqlClient } from "../../graphql/client.js";
+import type { ToolEntry } from "../../registry.js";
+import { validate } from "../../validation/validator.js";
+import { parseRepoSlug, repoSlugSchema } from "./_shared.js";
+
+// Issue-ref schema (matches the `add_sub_issue` shape exactly):
+// either pre-resolved node_id or (repo, number), never both.
+const inputSchema = {
+  type: "object",
+  properties: {
+    node_id: { type: "string", minLength: 1 },
+    repo: repoSlugSchema,
+    number: { type: "integer", minimum: 1 },
+  },
+  oneOf: [
+    {
+      required: ["node_id"],
+      not: { anyOf: [{ required: ["repo"] }, { required: ["number"] }] },
+    },
+    {
+      required: ["repo", "number"],
+      not: { required: ["node_id"] },
+    },
+  ],
+  additionalProperties: false,
+} as const;
+
+const issueRefSchema = {
+  type: "object",
+  required: ["number", "node_id", "url", "title", "state", "repo"],
+  properties: {
+    number: { type: "integer" },
+    node_id: { type: "string" },
+    url: { type: "string" },
+    title: { type: "string" },
+    state: { type: "string", enum: ["OPEN", "CLOSED"] },
+    repo: {
+      type: "string",
+      description: "`owner/name` of the issue's repo.",
+    },
+  },
+  additionalProperties: false,
+} as const;
+
+const outputSchema = {
+  type: "object",
+  required: ["parent"],
+  properties: {
+    parent: {
+      oneOf: [issueRefSchema, { type: "null" }],
+    },
+  },
+  additionalProperties: false,
+} as const;
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+interface Input {
+  node_id?: string;
+  repo?: string;
+  number?: number;
+}
+
+interface RawParent {
+  id: string;
+  number: number;
+  title: string;
+  url: string;
+  state: "OPEN" | "CLOSED";
+  repository: {
+    owner: { login: string };
+    name: string;
+  };
+}
+
+interface ParentSummary {
+  number: number;
+  node_id: string;
+  url: string;
+  title: string;
+  state: "OPEN" | "CLOSED";
+  repo: string;
+}
+
+interface Output {
+  parent: ParentSummary | null;
+}
+
+interface ByRepoResponse {
+  repository: {
+    issue: { parent: RawParent | null } | null;
+  } | null;
+}
+
+interface ByIdResponse {
+  node: { parent: RawParent | null } | null;
+}
+
+export function registerIssueParentGetTool(
+  register: RegisterToolFn,
+  graphql: GraphqlClient,
+): void {
+  register("gh.issue_parent_get", {
+    description:
+      "Fetch an issue's native parent. Returns `{ parent: null }` " +
+      "for issues that are roots in the sub-issue tree, or that " +
+      "have never been wired with `gh.issue_add_sub_issue`. " +
+      "Accepts either a pre-resolved `node_id` or a " +
+      "`(repo, number)` pair.",
+    inputSchema,
+    handler: async (raw) => {
+      const args = validate<Input>(
+        inputSchema,
+        raw,
+        "gh.issue_parent_get input",
+      );
+      let parent: RawParent | null;
+      if (typeof args.node_id === "string") {
+        const data = await graphql<ByIdResponse>("issue/parent_get_by_id", {
+          issueId: args.node_id,
+        });
+        if (!data.node) {
+          throw new Error(
+            `mcp-github: gh.issue_parent_get: issue node_id '${args.node_id}' not found`,
+          );
+        }
+        parent = data.node.parent;
+      } else {
+        const coords = parseRepoSlug(
+          args.repo as string,
+          "gh.issue_parent_get input",
+        );
+        const data = await graphql<ByRepoResponse>("issue/parent_get", {
+          owner: coords.owner,
+          name: coords.name,
+          number: args.number as number,
+        });
+        if (!data.repository) {
+          throw new Error(
+            `mcp-github: gh.issue_parent_get: repository '${coords.owner}/${coords.name}' not found or token lacks read access`,
+          );
+        }
+        if (!data.repository.issue) {
+          throw new Error(
+            `mcp-github: gh.issue_parent_get: issue ${coords.owner}/${coords.name}#${args.number ?? "?"} not found`,
+          );
+        }
+        parent = data.repository.issue.parent;
+      }
+      const out: Output = {
+        parent: parent === null ? null : summariseParent(parent),
+      };
+      return validate<Output>(outputSchema, out, "gh.issue_parent_get output");
+    },
+  });
+}
+
+function summariseParent(raw: RawParent): ParentSummary {
+  return {
+    number: raw.number,
+    node_id: raw.id,
+    url: raw.url,
+    title: raw.title,
+    state: raw.state,
+    repo: `${raw.repository.owner.login}/${raw.repository.name}`,
+  };
+}

--- a/src/tools/issue/sub_issues_list.ts
+++ b/src/tools/issue/sub_issues_list.ts
@@ -1,0 +1,220 @@
+// src/tools/issue/sub_issues_list.ts
+//
+// `gh.issue_sub_issues_list` — paginated list of an issue's
+// native sub-issues. Counterpart to `gh.issue_parent_get` for
+// the downstream walk. Backs `parallel-validation.md:85`
+// (validator checks each child's body cites the parent).
+// Caller-driven pagination via `cursor: endCursor`.
+
+import type { GraphqlClient } from "../../graphql/client.js";
+import type { ToolEntry } from "../../registry.js";
+import { validate } from "../../validation/validator.js";
+import { parseRepoSlug, repoSlugSchema } from "./_shared.js";
+
+const inputSchema = {
+  type: "object",
+  properties: {
+    node_id: { type: "string", minLength: 1 },
+    repo: repoSlugSchema,
+    number: { type: "integer", minimum: 1 },
+    cursor: { type: "string", minLength: 1 },
+    page_size: { type: "integer", minimum: 1, maximum: 100 },
+    include_closed: {
+      type: "boolean",
+      description:
+        "Default true: returns every linked child regardless of " +
+        "state. Set false to filter out CLOSED children " +
+        "client-side; `totalCount` still reflects the GraphQL " +
+        "total across open + closed.",
+    },
+  },
+  oneOf: [
+    {
+      required: ["node_id"],
+      not: { anyOf: [{ required: ["repo"] }, { required: ["number"] }] },
+    },
+    {
+      required: ["repo", "number"],
+      not: { required: ["node_id"] },
+    },
+  ],
+  additionalProperties: false,
+} as const;
+
+const childSchema = {
+  type: "object",
+  required: ["number", "node_id", "url", "title", "state", "repo"],
+  properties: {
+    number: { type: "integer" },
+    node_id: { type: "string" },
+    url: { type: "string" },
+    title: { type: "string" },
+    state: { type: "string", enum: ["OPEN", "CLOSED"] },
+    repo: { type: "string" },
+  },
+  additionalProperties: false,
+} as const;
+
+const outputSchema = {
+  type: "object",
+  required: ["totalCount", "pageInfo", "children"],
+  properties: {
+    totalCount: { type: "integer", minimum: 0 },
+    pageInfo: {
+      type: "object",
+      required: ["hasNextPage", "endCursor"],
+      properties: {
+        hasNextPage: { type: "boolean" },
+        endCursor: { type: ["string", "null"] },
+      },
+      additionalProperties: false,
+    },
+    children: { type: "array", items: childSchema },
+  },
+  additionalProperties: false,
+} as const;
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+interface Input {
+  node_id?: string;
+  repo?: string;
+  number?: number;
+  cursor?: string;
+  page_size?: number;
+  include_closed?: boolean;
+}
+
+interface RawChild {
+  id: string;
+  number: number;
+  title: string;
+  url: string;
+  state: "OPEN" | "CLOSED";
+  repository: {
+    owner: { login: string };
+    name: string;
+  };
+}
+
+interface ChildSummary {
+  number: number;
+  node_id: string;
+  url: string;
+  title: string;
+  state: "OPEN" | "CLOSED";
+  repo: string;
+}
+
+interface Output {
+  totalCount: number;
+  pageInfo: { hasNextPage: boolean; endCursor: string | null };
+  children: ChildSummary[];
+}
+
+interface SubIssuesConnection {
+  totalCount: number;
+  pageInfo: { hasNextPage: boolean; endCursor: string | null };
+  nodes: RawChild[];
+}
+
+interface ByRepoResponse {
+  repository: {
+    issue: { subIssues: SubIssuesConnection } | null;
+  } | null;
+}
+
+interface ByIdResponse {
+  node: { subIssues: SubIssuesConnection } | null;
+}
+
+export function registerIssueSubIssuesListTool(
+  register: RegisterToolFn,
+  graphql: GraphqlClient,
+): void {
+  register("gh.issue_sub_issues_list", {
+    description:
+      "Paginated list of an issue's native sub-issues (the " +
+      "downstream side of the sub-issue tree). Accepts either a " +
+      "pre-resolved `node_id` or `(repo, number)`. Caller drives " +
+      "pagination via `cursor: endCursor`. `include_closed` " +
+      "defaults to true; set false to drop CLOSED children " +
+      "client-side (totalCount remains the GraphQL total).",
+    inputSchema,
+    handler: async (raw) => {
+      const args = validate<Input>(
+        inputSchema,
+        raw,
+        "gh.issue_sub_issues_list input",
+      );
+      const subIssues = await fetchConnection(graphql, args);
+      const includeClosed = args.include_closed ?? true;
+      const filtered = includeClosed
+        ? subIssues.nodes
+        : subIssues.nodes.filter((n) => n.state !== "CLOSED");
+      const out: Output = {
+        totalCount: subIssues.totalCount,
+        pageInfo: subIssues.pageInfo,
+        children: filtered.map(summariseChild),
+      };
+      return validate<Output>(
+        outputSchema,
+        out,
+        "gh.issue_sub_issues_list output",
+      );
+    },
+  });
+}
+
+async function fetchConnection(
+  graphql: GraphqlClient,
+  args: Input,
+): Promise<SubIssuesConnection> {
+  const first = args.page_size ?? 100;
+  const after = args.cursor ?? null;
+  if (typeof args.node_id === "string") {
+    const data = await graphql<ByIdResponse>(
+      "issue/sub_issues_list_by_id",
+      { issueId: args.node_id, first, after },
+    );
+    if (!data.node) {
+      throw new Error(
+        `mcp-github: gh.issue_sub_issues_list: issue node_id '${args.node_id}' not found`,
+      );
+    }
+    return data.node.subIssues;
+  }
+  const coords = parseRepoSlug(
+    args.repo as string,
+    "gh.issue_sub_issues_list input",
+  );
+  const data = await graphql<ByRepoResponse>("issue/sub_issues_list", {
+    owner: coords.owner,
+    name: coords.name,
+    number: args.number as number,
+    first,
+    after,
+  });
+  if (!data.repository) {
+    throw new Error(
+      `mcp-github: gh.issue_sub_issues_list: repository '${coords.owner}/${coords.name}' not found or token lacks read access`,
+    );
+  }
+  if (!data.repository.issue) {
+    throw new Error(
+      `mcp-github: gh.issue_sub_issues_list: issue ${coords.owner}/${coords.name}#${args.number ?? "?"} not found`,
+    );
+  }
+  return data.repository.issue.subIssues;
+}
+
+function summariseChild(raw: RawChild): ChildSummary {
+  return {
+    number: raw.number,
+    node_id: raw.id,
+    url: raw.url,
+    title: raw.title,
+    state: raw.state,
+    repo: `${raw.repository.owner.login}/${raw.repository.name}`,
+  };
+}

--- a/src/tools/issue/sub_issues_list.ts
+++ b/src/tools/issue/sub_issues_list.ts
@@ -125,7 +125,13 @@ interface ByRepoResponse {
 }
 
 interface ByIdResponse {
-  node: { subIssues: SubIssuesConnection } | null;
+  // Wide on purpose: `node(id)` resolves any GraphQL node type;
+  // we narrow on `__typename === "Issue"` at runtime before
+  // reading `subIssues`. Modelling the union with a literal/string
+  // discriminant doesn't narrow cleanly because the literal
+  // overlaps with `string`, so we keep the field-presence
+  // optional and check it after the typename guard.
+  node: { __typename: string; subIssues?: SubIssuesConnection } | null;
 }
 
 export function registerIssueSubIssuesListTool(
@@ -180,6 +186,24 @@ async function fetchConnection(
     if (!data.node) {
       throw new Error(
         `mcp-github: gh.issue_sub_issues_list: issue node_id '${args.node_id}' not found`,
+      );
+    }
+    // `node(id)` resolves any GraphQL node type; guard against a
+    // non-Issue id (PullRequest / Project / etc.). Without this,
+    // GraphQL returns `{ __typename: "..." }` and reading
+    // `subIssues.nodes` would throw a confusing TypeError.
+    if (data.node.__typename !== "Issue") {
+      throw new Error(
+        `mcp-github: gh.issue_sub_issues_list: node_id '${args.node_id}' is a ${data.node.__typename}, not an Issue`,
+      );
+    }
+    if (!data.node.subIssues) {
+      // Defence-in-depth: GraphQL guarantees subIssues is non-null
+      // on an Issue, but the typed-narrowing made this field
+      // optional. If we ever see it missing, surface a clean
+      // error rather than crashing downstream.
+      throw new Error(
+        `mcp-github: gh.issue_sub_issues_list: unexpected empty subIssues for issue node_id '${args.node_id}'`,
       );
     }
     return data.node.subIssues;

--- a/src/tools/issue/sub_issues_list.ts
+++ b/src/tools/issue/sub_issues_list.ts
@@ -7,8 +7,11 @@
 //
 // Pagination follows the codebase-wide convention from
 // `gh.issue_list` / `gh.pr_list` / `gh.label_list`: input uses
-// `perPage` + `after`, output exposes `items` + `total` +
-// flat `hasNextPage` + `endCursor` at the top level.
+// `perPage` + `after`, output exposes `items` and flat
+// `hasNextPage` / `endCursor` at the top level. We also surface
+// `total` (the GraphQL totalCount) like `gh.issue_search` does
+// — useful because the `include_closed` filter happens
+// client-side and `total` keeps the unfiltered signal honest.
 
 import type { GraphqlClient } from "../../graphql/client.js";
 import type { ToolEntry } from "../../registry.js";
@@ -164,11 +167,13 @@ export function registerIssueSubIssuesListTool(
       "Paginated list of an issue's native sub-issues (the " +
       "downstream side of the sub-issue tree). Accepts either a " +
       "pre-resolved `node_id` or `(repo, number)`. Pagination " +
-      "uses `perPage` / `after` on input and `items` / `total` / " +
-      "`hasNextPage` / `endCursor` at top of output, matching the " +
-      "other list tools. `include_closed` defaults to true; set " +
-      "false to drop CLOSED children client-side (`total` " +
-      "remains the GraphQL total).",
+      "uses `perPage` / `after` on input and the flat " +
+      "`hasNextPage` / `endCursor` shape on output, matching the " +
+      "other list tools; we also surface `total` (the GraphQL " +
+      "totalCount) like `gh.issue_search` does so the " +
+      "client-side `include_closed` filter doesn't hide how " +
+      "many children exist. `include_closed` defaults to true; " +
+      "set false to drop CLOSED children client-side.",
     inputSchema,
     handler: async (raw) => {
       const args = validate<Input>(

--- a/src/tools/issue/sub_issues_list.ts
+++ b/src/tools/issue/sub_issues_list.ts
@@ -4,12 +4,19 @@
 // native sub-issues. Counterpart to `gh.issue_parent_get` for
 // the downstream walk. Backs `parallel-validation.md:85`
 // (validator checks each child's body cites the parent).
-// Caller-driven pagination via `cursor: endCursor`.
+//
+// Pagination follows the codebase-wide convention from
+// `gh.issue_list` / `gh.pr_list` / `gh.label_list`: input uses
+// `perPage` + `after`, output exposes `items` + `total` +
+// flat `hasNextPage` + `endCursor` at the top level.
 
 import type { GraphqlClient } from "../../graphql/client.js";
 import type { ToolEntry } from "../../registry.js";
 import { validate } from "../../validation/validator.js";
 import { parseRepoSlug, repoSlugSchema } from "./_shared.js";
+
+const PER_PAGE_DEFAULT = 30;
+const PER_PAGE_MAX = 100;
 
 const inputSchema = {
   type: "object",
@@ -17,15 +24,29 @@ const inputSchema = {
     node_id: { type: "string", minLength: 1 },
     repo: repoSlugSchema,
     number: { type: "integer", minimum: 1 },
-    cursor: { type: "string", minLength: 1 },
-    page_size: { type: "integer", minimum: 1, maximum: 100 },
+    after: {
+      type: "string",
+      minLength: 1,
+      description:
+        "Opaque cursor from a previous call's `endCursor`. Omit " +
+        "on the first call. Naming matches the other paginated " +
+        "list tools (gh.issue_list / gh.pr_list / gh.label_list).",
+    },
+    perPage: {
+      type: "integer",
+      minimum: 1,
+      maximum: PER_PAGE_MAX,
+      description:
+        `Children per page (default ${PER_PAGE_DEFAULT}, max ${PER_PAGE_MAX}). ` +
+        "Naming matches the other paginated list tools.",
+    },
     include_closed: {
       type: "boolean",
       description:
         "Default true: returns every linked child regardless of " +
         "state. Set false to filter out CLOSED children " +
-        "client-side; `totalCount` still reflects the GraphQL " +
-        "total across open + closed.",
+        "client-side; `total` still reflects the GraphQL total " +
+        "across open + closed.",
     },
   },
   oneOf: [
@@ -57,19 +78,18 @@ const childSchema = {
 
 const outputSchema = {
   type: "object",
-  required: ["totalCount", "pageInfo", "children"],
+  required: ["items", "total", "hasNextPage", "endCursor"],
   properties: {
-    totalCount: { type: "integer", minimum: 0 },
-    pageInfo: {
-      type: "object",
-      required: ["hasNextPage", "endCursor"],
-      properties: {
-        hasNextPage: { type: "boolean" },
-        endCursor: { type: ["string", "null"] },
-      },
-      additionalProperties: false,
+    items: { type: "array", items: childSchema },
+    total: {
+      type: "integer",
+      minimum: 0,
+      description:
+        "GraphQL totalCount across open + closed children — " +
+        "unaffected by client-side `include_closed` filtering.",
     },
-    children: { type: "array", items: childSchema },
+    hasNextPage: { type: "boolean" },
+    endCursor: { type: ["string", "null"] },
   },
   additionalProperties: false,
 } as const;
@@ -80,8 +100,8 @@ interface Input {
   node_id?: string;
   repo?: string;
   number?: number;
-  cursor?: string;
-  page_size?: number;
+  after?: string;
+  perPage?: number;
   include_closed?: boolean;
 }
 
@@ -107,9 +127,10 @@ interface ChildSummary {
 }
 
 interface Output {
-  totalCount: number;
-  pageInfo: { hasNextPage: boolean; endCursor: string | null };
-  children: ChildSummary[];
+  items: ChildSummary[];
+  total: number;
+  hasNextPage: boolean;
+  endCursor: string | null;
 }
 
 interface SubIssuesConnection {
@@ -142,10 +163,12 @@ export function registerIssueSubIssuesListTool(
     description:
       "Paginated list of an issue's native sub-issues (the " +
       "downstream side of the sub-issue tree). Accepts either a " +
-      "pre-resolved `node_id` or `(repo, number)`. Caller drives " +
-      "pagination via `cursor: endCursor`. `include_closed` " +
-      "defaults to true; set false to drop CLOSED children " +
-      "client-side (totalCount remains the GraphQL total).",
+      "pre-resolved `node_id` or `(repo, number)`. Pagination " +
+      "uses `perPage` / `after` on input and `items` / `total` / " +
+      "`hasNextPage` / `endCursor` at top of output, matching the " +
+      "other list tools. `include_closed` defaults to true; set " +
+      "false to drop CLOSED children client-side (`total` " +
+      "remains the GraphQL total).",
     inputSchema,
     handler: async (raw) => {
       const args = validate<Input>(
@@ -159,9 +182,10 @@ export function registerIssueSubIssuesListTool(
         ? subIssues.nodes
         : subIssues.nodes.filter((n) => n.state !== "CLOSED");
       const out: Output = {
-        totalCount: subIssues.totalCount,
-        pageInfo: subIssues.pageInfo,
-        children: filtered.map(summariseChild),
+        items: filtered.map(summariseChild),
+        total: subIssues.totalCount,
+        hasNextPage: subIssues.pageInfo.hasNextPage,
+        endCursor: subIssues.pageInfo.endCursor,
       };
       return validate<Output>(
         outputSchema,
@@ -176,8 +200,8 @@ async function fetchConnection(
   graphql: GraphqlClient,
   args: Input,
 ): Promise<SubIssuesConnection> {
-  const first = args.page_size ?? 100;
-  const after = args.cursor ?? null;
+  const first = args.perPage ?? PER_PAGE_DEFAULT;
+  const after = args.after ?? null;
   if (typeof args.node_id === "string") {
     const data = await graphql<ByIdResponse>(
       "issue/sub_issues_list_by_id",

--- a/tests/smoke/server-lists-tools.mjs
+++ b/tests/smoke/server-lists-tools.mjs
@@ -58,6 +58,8 @@ const EXPECTED_TOOLS = [
   "gh.workflow_run_view",
   "gh.workflow_run_cancel",
   "gh.workflow_run_jobs",
+  "gh.issue_parent_get",
+  "gh.issue_sub_issues_list",
 ];
 
 function frame(payload) {

--- a/tests/smoke/server-lists-tools.mjs
+++ b/tests/smoke/server-lists-tools.mjs
@@ -9,9 +9,10 @@
 // + tool registration chain end-to-end without pulling in the
 // unit-test framework.
 //
-// Current surface: 1 auth probe (`gh.test_connection` from MCP-2)
-// + 7 issue tools (MCP-4) + 4 label tools (MCP-7) + 7 PR tools
-// (MCP-5 + MCP-6, the latter adding `gh.pr_request_reviews`).
+// The EXPECTED_TOOLS array below is the authoritative list of
+// the current tool surface; this header used to also carry a
+// human-readable count, but that drifted on every PR. Read the
+// array if you want the current set.
 //
 // Wire format: the MCP SDK's StdioServerTransport uses newline-
 // delimited JSON-RPC (one JSON message per `\n`-terminated line),

--- a/tests/unit/tools/issue/parent_get.test.ts
+++ b/tests/unit/tools/issue/parent_get.test.ts
@@ -98,6 +98,22 @@ test("gh.issue_parent_get: node_id pointing at a non-Issue surfaces a typed erro
   );
 });
 
+test("gh.issue_parent_get: node_id not found surfaces a not-found error", async () => {
+  // `node(id)` returns null when GitHub cannot resolve the
+  // global ID at all (deleted, never existed, or token lacks
+  // access). The handler distinguishes this from the wrong-
+  // typename case so callers see the right hint.
+  const { graphql } = stubGraphqlClient({
+    "issue/parent_get_by_id": () => ({ node: null }),
+  });
+  const reg = captureRegistration();
+  registerIssueParentGetTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ node_id: "I_missing" }),
+    /issue node_id 'I_missing' not found/,
+  );
+});
+
 test("gh.issue_parent_get: returns parent: null for a root issue", async () => {
   const { graphql } = stubGraphqlClient({
     "issue/parent_get": () => ({

--- a/tests/unit/tools/issue/parent_get.test.ts
+++ b/tests/unit/tools/issue/parent_get.test.ts
@@ -72,7 +72,9 @@ test("gh.issue_parent_get: node_id → node(id) path (no repo lookup)", async ()
   const { graphql, calls } = stubGraphqlClient({
     "issue/parent_get_by_id": (vars: Record<string, unknown>) => {
       assert.equal(vars.issueId, "I_pre");
-      return { node: { parent: sampleRawParent } };
+      return {
+        node: { __typename: "Issue", parent: sampleRawParent },
+      };
     },
   });
   const reg = captureRegistration();
@@ -80,6 +82,20 @@ test("gh.issue_parent_get: node_id → node(id) path (no repo lookup)", async ()
   await reg.entry.handler({ node_id: "I_pre" });
   assert.equal(calls.length, 1);
   assert.equal(calls[0]?.queryName, "issue/parent_get_by_id");
+});
+
+test("gh.issue_parent_get: node_id pointing at a non-Issue surfaces a typed error", async () => {
+  const { graphql } = stubGraphqlClient({
+    "issue/parent_get_by_id": () => ({
+      node: { __typename: "PullRequest" },
+    }),
+  });
+  const reg = captureRegistration();
+  registerIssueParentGetTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ node_id: "PR_x" }),
+    /is a PullRequest, not an Issue/,
+  );
 });
 
 test("gh.issue_parent_get: returns parent: null for a root issue", async () => {

--- a/tests/unit/tools/issue/parent_get.test.ts
+++ b/tests/unit/tools/issue/parent_get.test.ts
@@ -1,0 +1,154 @@
+// tests/unit/tools/issue/parent_get.test.ts
+//
+// gh.issue_parent_get: pin both ref-input paths (node_id vs
+// (repo, number)), the null-parent passthrough for root issues,
+// the cross-repo summary shape, and the schema rejection of
+// mixed input.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { registerIssueParentGetTool } from "../../../../src/tools/issue/parent_get.ts";
+import type { ToolEntry } from "../../../../src/registry.ts";
+import { stubGraphqlClient } from "./_fixtures.ts";
+
+function captureRegistration() {
+  let entry: ToolEntry | undefined;
+  const register = (name: string, e: ToolEntry) => {
+    if (name !== "gh.issue_parent_get") throw new Error(`unexpected: ${name}`);
+    entry = e;
+  };
+  return {
+    register,
+    get entry(): ToolEntry {
+      if (!entry) throw new Error("not registered");
+      return entry;
+    },
+  };
+}
+
+const sampleRawParent = {
+  id: "I_parent",
+  number: 1,
+  title: "Parent epic",
+  url: "https://github.com/owner/repo/issues/1",
+  state: "OPEN" as const,
+  repository: {
+    owner: { login: "owner" },
+    name: "repo",
+  },
+};
+
+test("gh.issue_parent_get: (repo, number) → repository.issue.parent path", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "issue/parent_get": (vars: Record<string, unknown>) => {
+      assert.equal(vars.owner, "owner");
+      assert.equal(vars.name, "repo");
+      assert.equal(vars.number, 42);
+      return {
+        repository: { issue: { parent: sampleRawParent } },
+      };
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueParentGetTool(reg.register, graphql);
+  const out = (await reg.entry.handler({
+    repo: "owner/repo",
+    number: 42,
+  })) as { parent: { number: number; repo: string; node_id: string } | null };
+  assert.deepEqual(out.parent, {
+    number: 1,
+    node_id: "I_parent",
+    url: "https://github.com/owner/repo/issues/1",
+    title: "Parent epic",
+    state: "OPEN",
+    repo: "owner/repo",
+  });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]?.queryName, "issue/parent_get");
+});
+
+test("gh.issue_parent_get: node_id → node(id) path (no repo lookup)", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "issue/parent_get_by_id": (vars: Record<string, unknown>) => {
+      assert.equal(vars.issueId, "I_pre");
+      return { node: { parent: sampleRawParent } };
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueParentGetTool(reg.register, graphql);
+  await reg.entry.handler({ node_id: "I_pre" });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]?.queryName, "issue/parent_get_by_id");
+});
+
+test("gh.issue_parent_get: returns parent: null for a root issue", async () => {
+  const { graphql } = stubGraphqlClient({
+    "issue/parent_get": () => ({
+      repository: { issue: { parent: null } },
+    }),
+  });
+  const reg = captureRegistration();
+  registerIssueParentGetTool(reg.register, graphql);
+  const out = (await reg.entry.handler({
+    repo: "owner/repo",
+    number: 1,
+  })) as { parent: unknown };
+  assert.equal(out.parent, null);
+});
+
+test("gh.issue_parent_get: cross-repo parent surfaces with the parent's own repo string", async () => {
+  const { graphql } = stubGraphqlClient({
+    "issue/parent_get": () => ({
+      repository: {
+        issue: {
+          parent: {
+            ...sampleRawParent,
+            repository: { owner: { login: "other-org" }, name: "other-repo" },
+          },
+        },
+      },
+    }),
+  });
+  const reg = captureRegistration();
+  registerIssueParentGetTool(reg.register, graphql);
+  const out = (await reg.entry.handler({
+    repo: "owner/repo",
+    number: 42,
+  })) as { parent: { repo: string } | null };
+  assert.equal(out.parent?.repo, "other-org/other-repo");
+});
+
+test("gh.issue_parent_get: repo missing throws repository-shaped error", async () => {
+  const { graphql } = stubGraphqlClient({
+    "issue/parent_get": () => ({ repository: null }),
+  });
+  const reg = captureRegistration();
+  registerIssueParentGetTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", number: 1 }),
+    /repository 'owner\/repo' not found/,
+  );
+});
+
+test("gh.issue_parent_get: issue missing throws issue-shaped error", async () => {
+  const { graphql } = stubGraphqlClient({
+    "issue/parent_get": () => ({ repository: { issue: null } }),
+  });
+  const reg = captureRegistration();
+  registerIssueParentGetTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", number: 99 }),
+    /issue owner\/repo#99 not found/,
+  );
+});
+
+test("gh.issue_parent_get: rejects mixed (node_id + repo) at the input boundary", async () => {
+  const { graphql } = stubGraphqlClient({});
+  const reg = captureRegistration();
+  registerIssueParentGetTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ node_id: "I_x", repo: "owner/repo", number: 1 }),
+    /gh\.issue_parent_get input/,
+  );
+});

--- a/tests/unit/tools/issue/sub_issues_list.test.ts
+++ b/tests/unit/tools/issue/sub_issues_list.test.ts
@@ -123,6 +123,7 @@ test("gh.issue_sub_issues_list: node_id → node(id).subIssues path", async () =
       assert.equal(vars.issueId, "I_pre");
       return {
         node: {
+          __typename: "Issue",
           subIssues: {
             totalCount: 0,
             pageInfo: { hasNextPage: false, endCursor: null },
@@ -137,6 +138,20 @@ test("gh.issue_sub_issues_list: node_id → node(id).subIssues path", async () =
   await reg.entry.handler({ node_id: "I_pre" });
   assert.equal(calls.length, 1);
   assert.equal(calls[0]?.queryName, "issue/sub_issues_list_by_id");
+});
+
+test("gh.issue_sub_issues_list: node_id pointing at a non-Issue surfaces a typed error", async () => {
+  const { graphql } = stubGraphqlClient({
+    "issue/sub_issues_list_by_id": () => ({
+      node: { __typename: "Repository" },
+    }),
+  });
+  const reg = captureRegistration();
+  registerIssueSubIssuesListTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ node_id: "R_x" }),
+    /is a Repository, not an Issue/,
+  );
 });
 
 test("gh.issue_sub_issues_list: cursor + page_size pass through", async () => {

--- a/tests/unit/tools/issue/sub_issues_list.test.ts
+++ b/tests/unit/tools/issue/sub_issues_list.test.ts
@@ -1,8 +1,9 @@
 // tests/unit/tools/issue/sub_issues_list.test.ts
 //
 // gh.issue_sub_issues_list: pin the two ref-input paths, the
-// include_closed filter, the page_size + cursor pass-through,
-// and the not-found error shapes.
+// include_closed filter, the perPage + after pass-through, the
+// top-level items / total / hasNextPage / endCursor output
+// shape, and the not-found error shapes.
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
@@ -46,7 +47,8 @@ function rawChild(overrides: Record<string, unknown> = {}) {
 test("gh.issue_sub_issues_list: (repo, number) → repository.issue.subIssues path with defaults", async () => {
   const { graphql, calls } = stubGraphqlClient({
     "issue/sub_issues_list": (vars: Record<string, unknown>) => {
-      assert.equal(vars.first, 100);
+      // Default perPage is 30 (matches the other list tools).
+      assert.equal(vars.first, 30);
       assert.equal(vars.after, null);
       assert.equal(vars.number, 1);
       return {
@@ -71,12 +73,12 @@ test("gh.issue_sub_issues_list: (repo, number) → repository.issue.subIssues pa
     repo: "owner/repo",
     number: 1,
   })) as {
-    totalCount: number;
-    children: Array<{ number: number; repo: string }>;
+    total: number;
+    items: Array<{ number: number; repo: string }>;
   };
-  assert.equal(out.totalCount, 2);
-  assert.equal(out.children.length, 2);
-  assert.equal(out.children[0]?.repo, "owner/repo");
+  assert.equal(out.total, 2);
+  assert.equal(out.items.length, 2);
+  assert.equal(out.items[0]?.repo, "owner/repo");
   assert.equal(calls.length, 1);
 });
 
@@ -105,14 +107,14 @@ test("gh.issue_sub_issues_list: include_closed=false filters CLOSED children out
     number: 1,
     include_closed: false,
   })) as {
-    totalCount: number;
-    children: Array<{ number: number; state: string }>;
+    total: number;
+    items: Array<{ number: number; state: string }>;
   };
   // totalCount stays GraphQL-truth even after filtering.
-  assert.equal(out.totalCount, 3);
-  assert.equal(out.children.length, 2);
+  assert.equal(out.total, 3);
+  assert.equal(out.items.length, 2);
   assert.equal(
-    out.children.every((c) => c.state === "OPEN"),
+    out.items.every((c) => c.state === "OPEN"),
     true,
   );
 });
@@ -154,7 +156,7 @@ test("gh.issue_sub_issues_list: node_id pointing at a non-Issue surfaces a typed
   );
 });
 
-test("gh.issue_sub_issues_list: cursor + page_size pass through", async () => {
+test("gh.issue_sub_issues_list: after + perPage pass through", async () => {
   const { graphql } = stubGraphqlClient({
     "issue/sub_issues_list": (vars: Record<string, unknown>) => {
       assert.equal(vars.first, 25);
@@ -177,17 +179,17 @@ test("gh.issue_sub_issues_list: cursor + page_size pass through", async () => {
   await reg.entry.handler({
     repo: "owner/repo",
     number: 1,
-    page_size: 25,
-    cursor: "PAGE2",
+    perPage: 25,
+    after: "PAGE2",
   });
 });
 
-test("gh.issue_sub_issues_list: rejects page_size > 100 at the input boundary", async () => {
+test("gh.issue_sub_issues_list: rejects perPage > 100 at the input boundary", async () => {
   const { graphql } = stubGraphqlClient({});
   const reg = captureRegistration();
   registerIssueSubIssuesListTool(reg.register, graphql);
   await assert.rejects(
-    reg.entry.handler({ repo: "owner/repo", number: 1, page_size: 200 }),
+    reg.entry.handler({ repo: "owner/repo", number: 1, perPage: 200 }),
     /gh\.issue_sub_issues_list input/,
   );
 });

--- a/tests/unit/tools/issue/sub_issues_list.test.ts
+++ b/tests/unit/tools/issue/sub_issues_list.test.ts
@@ -205,3 +205,36 @@ test("gh.issue_sub_issues_list: repo missing throws repository-shaped error", as
     /repository 'owner\/repo' not found/,
   );
 });
+
+test("gh.issue_sub_issues_list: issue missing on existing repo throws issue-shaped error", async () => {
+  // Distinct from repo-missing: the repository resolved, but the
+  // issue number doesn't exist. The handler keys off the two-axis
+  // pattern (repo vs issue) so callers see the right not-found
+  // message instead of a misleading "repository not found".
+  const { graphql } = stubGraphqlClient({
+    "issue/sub_issues_list": () => ({
+      repository: { issue: null },
+    }),
+  });
+  const reg = captureRegistration();
+  registerIssueSubIssuesListTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", number: 999 }),
+    /issue owner\/repo#999 not found/,
+  );
+});
+
+test("gh.issue_sub_issues_list: node_id not found throws not-found", async () => {
+  // `node(id)` returns null when the global ID can't be resolved
+  // at all. Distinct from the wrong-typename case (which is
+  // tested above).
+  const { graphql } = stubGraphqlClient({
+    "issue/sub_issues_list_by_id": () => ({ node: null }),
+  });
+  const reg = captureRegistration();
+  registerIssueSubIssuesListTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ node_id: "I_missing" }),
+    /issue node_id 'I_missing' not found/,
+  );
+});

--- a/tests/unit/tools/issue/sub_issues_list.test.ts
+++ b/tests/unit/tools/issue/sub_issues_list.test.ts
@@ -1,0 +1,190 @@
+// tests/unit/tools/issue/sub_issues_list.test.ts
+//
+// gh.issue_sub_issues_list: pin the two ref-input paths, the
+// include_closed filter, the page_size + cursor pass-through,
+// and the not-found error shapes.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { registerIssueSubIssuesListTool } from "../../../../src/tools/issue/sub_issues_list.ts";
+import type { ToolEntry } from "../../../../src/registry.ts";
+import { stubGraphqlClient } from "./_fixtures.ts";
+
+function captureRegistration() {
+  let entry: ToolEntry | undefined;
+  const register = (name: string, e: ToolEntry) => {
+    if (name !== "gh.issue_sub_issues_list") {
+      throw new Error(`unexpected: ${name}`);
+    }
+    entry = e;
+  };
+  return {
+    register,
+    get entry(): ToolEntry {
+      if (!entry) throw new Error("not registered");
+      return entry;
+    },
+  };
+}
+
+function rawChild(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "I_child",
+    number: 10,
+    title: "Child",
+    url: "https://github.com/owner/repo/issues/10",
+    state: "OPEN" as const,
+    repository: {
+      owner: { login: "owner" },
+      name: "repo",
+    },
+    ...overrides,
+  };
+}
+
+test("gh.issue_sub_issues_list: (repo, number) → repository.issue.subIssues path with defaults", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "issue/sub_issues_list": (vars: Record<string, unknown>) => {
+      assert.equal(vars.first, 100);
+      assert.equal(vars.after, null);
+      assert.equal(vars.number, 1);
+      return {
+        repository: {
+          issue: {
+            subIssues: {
+              totalCount: 2,
+              pageInfo: { hasNextPage: false, endCursor: "abc" },
+              nodes: [
+                rawChild({ id: "I_a", number: 10 }),
+                rawChild({ id: "I_b", number: 11 }),
+              ],
+            },
+          },
+        },
+      };
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueSubIssuesListTool(reg.register, graphql);
+  const out = (await reg.entry.handler({
+    repo: "owner/repo",
+    number: 1,
+  })) as {
+    totalCount: number;
+    children: Array<{ number: number; repo: string }>;
+  };
+  assert.equal(out.totalCount, 2);
+  assert.equal(out.children.length, 2);
+  assert.equal(out.children[0]?.repo, "owner/repo");
+  assert.equal(calls.length, 1);
+});
+
+test("gh.issue_sub_issues_list: include_closed=false filters CLOSED children out", async () => {
+  const { graphql } = stubGraphqlClient({
+    "issue/sub_issues_list": () => ({
+      repository: {
+        issue: {
+          subIssues: {
+            totalCount: 3,
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [
+              rawChild({ id: "I_open_1", number: 10, state: "OPEN" }),
+              rawChild({ id: "I_closed", number: 11, state: "CLOSED" }),
+              rawChild({ id: "I_open_2", number: 12, state: "OPEN" }),
+            ],
+          },
+        },
+      },
+    }),
+  });
+  const reg = captureRegistration();
+  registerIssueSubIssuesListTool(reg.register, graphql);
+  const out = (await reg.entry.handler({
+    repo: "owner/repo",
+    number: 1,
+    include_closed: false,
+  })) as {
+    totalCount: number;
+    children: Array<{ number: number; state: string }>;
+  };
+  // totalCount stays GraphQL-truth even after filtering.
+  assert.equal(out.totalCount, 3);
+  assert.equal(out.children.length, 2);
+  assert.equal(
+    out.children.every((c) => c.state === "OPEN"),
+    true,
+  );
+});
+
+test("gh.issue_sub_issues_list: node_id → node(id).subIssues path", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "issue/sub_issues_list_by_id": (vars: Record<string, unknown>) => {
+      assert.equal(vars.issueId, "I_pre");
+      return {
+        node: {
+          subIssues: {
+            totalCount: 0,
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [],
+          },
+        },
+      };
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueSubIssuesListTool(reg.register, graphql);
+  await reg.entry.handler({ node_id: "I_pre" });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]?.queryName, "issue/sub_issues_list_by_id");
+});
+
+test("gh.issue_sub_issues_list: cursor + page_size pass through", async () => {
+  const { graphql } = stubGraphqlClient({
+    "issue/sub_issues_list": (vars: Record<string, unknown>) => {
+      assert.equal(vars.first, 25);
+      assert.equal(vars.after, "PAGE2");
+      return {
+        repository: {
+          issue: {
+            subIssues: {
+              totalCount: 0,
+              pageInfo: { hasNextPage: false, endCursor: null },
+              nodes: [],
+            },
+          },
+        },
+      };
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueSubIssuesListTool(reg.register, graphql);
+  await reg.entry.handler({
+    repo: "owner/repo",
+    number: 1,
+    page_size: 25,
+    cursor: "PAGE2",
+  });
+});
+
+test("gh.issue_sub_issues_list: rejects page_size > 100 at the input boundary", async () => {
+  const { graphql } = stubGraphqlClient({});
+  const reg = captureRegistration();
+  registerIssueSubIssuesListTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", number: 1, page_size: 200 }),
+    /gh\.issue_sub_issues_list input/,
+  );
+});
+
+test("gh.issue_sub_issues_list: repo missing throws repository-shaped error", async () => {
+  const { graphql } = stubGraphqlClient({
+    "issue/sub_issues_list": () => ({ repository: null }),
+  });
+  const reg = captureRegistration();
+  registerIssueSubIssuesListTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", number: 1 }),
+    /repository 'owner\/repo' not found/,
+  );
+});


### PR DESCRIPTION
## Summary
- Two new tools for sub-issue tree walking, backing `parallel-validation.md`'s dependency-graph audits and unblocking the future validator-script migration to mcp-github.
- `gh.issue_parent_get`: returns `{ parent: { number, node_id, url, title, state, repo } | null }`. Null means the issue is a root in the sub-issue tree.
- `gh.issue_sub_issues_list`: paginated children via `subIssues(first, after)`. Pagination uses `perPage` / `after` on input and the flat `hasNextPage` / `endCursor` shape on output, matching the other list tools; output also surfaces `total` (the GraphQL totalCount, like `gh.issue_search`) so the client-side `include_closed` filter doesn't hide how many children exist. `include_closed` defaults to true; set false to filter CLOSED client-side.
- Both accept either a pre-resolved `node_id` (uses `node(id)` — one query) or `(repo, number)` (uses `repository.issue` — same query). Cross-repo refs surface a `repo: "owner/name"` summary derived from each node's `repository.owner.login`.
- The `node(id)` path also selects `__typename` and guards against non-Issue node IDs (PullRequest / Project / etc.) with a typed error rather than a downstream TypeError.

## Test plan
- [x] `npm run lint`
- [x] `npm test` — 15 unit tests across both tools pin: both ref-input paths; null-parent passthrough for roots; cross-repo summary shape; perPage / after / include_closed behaviour; not-found error shapes on both axes (repo missing, issue missing on existing repo, node_id missing, node_id pointing at non-Issue); schema rejection of mixed and oversized input.