### PR TITLE
feat: gh.pr_view exposes review_decision + per-review submitted_at (A7+A8)

### DIFF
--- a/src/graphql/queries/pr/_ready-for-review.graphql
+++ b/src/graphql/queries/pr/_ready-for-review.graphql
@@ -16,6 +16,7 @@ mutation PRReadyForReview($input: MarkPullRequestReadyForReviewInput!) {
       mergeCommit {
         oid
       }
+      reviewDecision
       labels(first: 100) {
         pageInfo {
           hasNextPage
@@ -47,6 +48,7 @@ mutation PRReadyForReview($input: MarkPullRequestReadyForReviewInput!) {
           author {
             login
           }
+          submittedAt
         }
       }
       reviewThreads(first: 100) {

--- a/src/graphql/queries/pr/_to-draft.graphql
+++ b/src/graphql/queries/pr/_to-draft.graphql
@@ -16,6 +16,7 @@ mutation PRToDraft($input: ConvertPullRequestToDraftInput!) {
       mergeCommit {
         oid
       }
+      reviewDecision
       labels(first: 100) {
         pageInfo {
           hasNextPage
@@ -47,6 +48,7 @@ mutation PRToDraft($input: ConvertPullRequestToDraftInput!) {
           author {
             login
           }
+          submittedAt
         }
       }
       reviewThreads(first: 100) {

--- a/src/graphql/queries/pr/create.graphql
+++ b/src/graphql/queries/pr/create.graphql
@@ -16,6 +16,7 @@ mutation PRCreate($input: CreatePullRequestInput!) {
       mergeCommit {
         oid
       }
+      reviewDecision
       labels(first: 100) {
         pageInfo {
           hasNextPage
@@ -47,6 +48,7 @@ mutation PRCreate($input: CreatePullRequestInput!) {
           author {
             login
           }
+          submittedAt
         }
       }
       reviewThreads(first: 100) {

--- a/src/graphql/queries/pr/edit.graphql
+++ b/src/graphql/queries/pr/edit.graphql
@@ -16,6 +16,7 @@ mutation PREdit($input: UpdatePullRequestInput!) {
       mergeCommit {
         oid
       }
+      reviewDecision
       labels(first: 100) {
         pageInfo {
           hasNextPage
@@ -47,6 +48,7 @@ mutation PREdit($input: UpdatePullRequestInput!) {
           author {
             login
           }
+          submittedAt
         }
       }
       reviewThreads(first: 100) {

--- a/src/graphql/queries/pr/list.graphql
+++ b/src/graphql/queries/pr/list.graphql
@@ -36,6 +36,7 @@ query PRList(
         mergeCommit {
           oid
         }
+        reviewDecision
         labels(first: 100) {
           pageInfo {
             hasNextPage
@@ -67,6 +68,7 @@ query PRList(
             author {
               login
             }
+            submittedAt
           }
         }
         reviewThreads(first: 100) {

--- a/src/graphql/queries/pr/view.graphql
+++ b/src/graphql/queries/pr/view.graphql
@@ -16,6 +16,7 @@ query PRView($owner: String!, $name: String!, $number: Int!) {
       mergeCommit {
         oid
       }
+      reviewDecision
       labels(first: 100) {
         pageInfo {
           hasNextPage
@@ -47,6 +48,7 @@ query PRView($owner: String!, $name: String!, $number: Int!) {
           author {
             login
           }
+          submittedAt
         }
       }
       reviewThreads(first: 100) {

--- a/src/tools/pr/_shared.ts
+++ b/src/tools/pr/_shared.ts
@@ -87,6 +87,11 @@ export async function lookupRepoNodeId(
 export interface ReviewSummary {
   author: string | null;
   state: "PENDING" | "COMMENTED" | "APPROVED" | "CHANGES_REQUESTED" | "DISMISSED";
+  // `submitted_at` is null for PENDING reviews (the user has
+  // started a review but not yet hit "Submit"). Every other
+  // state implies a submission, but GitHub still types the
+  // field as nullable so we mirror that.
+  submitted_at: string | null;
 }
 
 export interface StatusCheck {
@@ -108,6 +113,19 @@ export interface PRSummary {
   merged: boolean;
   merged_at: string | null;
   merge_commit_sha: string | null;
+  // GitHub's computed aggregate of `reviews[]`:
+  //   - "APPROVED": every required reviewer's latest non-DISMISSED
+  //     review is APPROVED.
+  //   - "CHANGES_REQUESTED": at least one such review is
+  //     CHANGES_REQUESTED.
+  //   - "REVIEW_REQUIRED": branch protection requires a review and
+  //     the PR doesn't yet satisfy it.
+  //   - null: the PR's base doesn't require code review at all
+  //     (no branch protection rule, or the rule is off for this
+  //     repo).
+  // The methodology consumes this directly; do NOT recompute on
+  // the agent side from `reviews[]`.
+  review_decision: "APPROVED" | "CHANGES_REQUESTED" | "REVIEW_REQUIRED" | null;
   labels: string[];
   assignees: string[];
   author: string | null;
@@ -122,13 +140,14 @@ export interface PRSummary {
 
 export const reviewSummarySchema = {
   type: "object",
-  required: ["author", "state"],
+  required: ["author", "state", "submitted_at"],
   properties: {
     author: { type: ["string", "null"] },
     state: {
       type: "string",
       enum: ["PENDING", "COMMENTED", "APPROVED", "CHANGES_REQUESTED", "DISMISSED"],
     },
+    submitted_at: { type: ["string", "null"] },
   },
   additionalProperties: false,
 } as const;
@@ -162,6 +181,7 @@ export const prSummarySchema = {
     "merged",
     "merged_at",
     "merge_commit_sha",
+    "review_decision",
     "labels",
     "assignees",
     "author",
@@ -187,6 +207,10 @@ export const prSummarySchema = {
     merged: { type: "boolean" },
     merged_at: { type: ["string", "null"] },
     merge_commit_sha: { type: ["string", "null"] },
+    review_decision: {
+      type: ["string", "null"],
+      enum: ["APPROVED", "CHANGES_REQUESTED", "REVIEW_REQUIRED", null],
+    },
     labels: { type: "array", items: { type: "string" } },
     assignees: { type: "array", items: { type: "string" } },
     author: { type: ["string", "null"] },
@@ -228,6 +252,7 @@ export interface RawPR {
   merged: boolean;
   mergedAt: string | null;
   mergeCommit: { oid: string } | null;
+  reviewDecision: "APPROVED" | "CHANGES_REQUESTED" | "REVIEW_REQUIRED" | null;
   labels: PaginatedNodes<{ name: string }>;
   assignees: PaginatedNodes<{ login: string }>;
   author: { login: string } | null;
@@ -237,6 +262,7 @@ export interface RawPR {
   reviews: PaginatedNodes<{
     state: ReviewSummary["state"];
     author: { login: string } | null;
+    submittedAt: string | null;
   }>;
   reviewThreads: PaginatedNodes<{
     comments: { totalCount: number };
@@ -285,6 +311,7 @@ export function summarisePR(
   const reviews: ReviewSummary[] = raw.reviews.nodes.map((r) => ({
     author: r.author?.login ?? null,
     state: r.state,
+    submitted_at: r.submittedAt,
   }));
   const reviewCommentsCount = raw.reviewThreads.nodes.reduce(
     (sum, t) => sum + t.comments.totalCount,
@@ -308,6 +335,7 @@ export function summarisePR(
     merged: raw.merged,
     merged_at: raw.mergedAt,
     merge_commit_sha: raw.mergeCommit?.oid ?? null,
+    review_decision: raw.reviewDecision,
     labels: raw.labels.nodes.map((n) => n.name),
     assignees: raw.assignees.nodes.map((n) => n.login),
     author: raw.author?.login ?? null,

--- a/tests/unit/tools/pr/_fixtures.ts
+++ b/tests/unit/tools/pr/_fixtures.ts
@@ -55,6 +55,7 @@ export const sampleRawPR = {
   merged: false,
   mergedAt: null,
   mergeCommit: null,
+  reviewDecision: "APPROVED" as const,
   labels: {
     pageInfo: { hasNextPage: false },
     nodes: [{ name: "enhancement" }],
@@ -70,7 +71,11 @@ export const sampleRawPR = {
   reviews: {
     pageInfo: { hasNextPage: false },
     nodes: [
-      { state: "APPROVED" as const, author: { login: "carol" } },
+      {
+        state: "APPROVED" as const,
+        author: { login: "carol" },
+        submittedAt: "2026-04-02T01:00:00Z",
+      },
     ],
   },
   reviewThreads: {

--- a/tests/unit/tools/pr/view.test.ts
+++ b/tests/unit/tools/pr/view.test.ts
@@ -36,14 +36,20 @@ test("gh.pr_view: maps a full GraphQL response onto the canonical PRSummary", as
     number: number;
     base: string;
     head: string;
+    review_decision: string | null;
     review_comments_count: number;
     status_checks_state: string | null;
     status_checks: Array<{ context: string; state: string }>;
-    reviews: Array<{ author: string | null; state: string }>;
+    reviews: Array<{
+      author: string | null;
+      state: string;
+      submitted_at: string | null;
+    }>;
   };
   assert.equal(out.number, 7);
   assert.equal(out.base, "main");
   assert.equal(out.head, "feat/x");
+  assert.equal(out.review_decision, "APPROVED");
   // 3 + 0 = 3 review-comments across two threads.
   assert.equal(out.review_comments_count, 3);
   assert.equal(out.status_checks_state, "SUCCESS");
@@ -51,7 +57,13 @@ test("gh.pr_view: maps a full GraphQL response onto the canonical PRSummary", as
     out.status_checks.map((c) => c.context),
     ["ci/build", "ci/legacy"],
   );
-  assert.deepEqual(out.reviews, [{ author: "carol", state: "APPROVED" }]);
+  assert.deepEqual(out.reviews, [
+    {
+      author: "carol",
+      state: "APPROVED",
+      submitted_at: "2026-04-02T01:00:00Z",
+    },
+  ]);
   assert.equal(calls.length, 1);
   assert.deepEqual(calls[0]?.vars, {
     owner: "owner",
@@ -132,6 +144,67 @@ test("gh.pr_view: maps CheckRun + StatusContext onto the unified status_checks s
     { context: "ci/lint", state: "FAILURE" },
     { context: "ci/test", state: "PENDING" },
   ]);
+});
+
+test("gh.pr_view: review_decision: null passes through (no branch-protection review requirement)", async () => {
+  // A PR against a base with no branch-protection rule returns
+  // reviewDecision: null. Methodology must NOT mistake null for
+  // "REVIEW_REQUIRED" — the absence of a requirement is not the
+  // same as a pending one.
+  const customPR = { ...sampleRawPR, reviewDecision: null };
+  const { graphql } = stubGraphqlClient({
+    "pr/view": { repository: { pullRequest: customPR } },
+  });
+  const reg = captureRegistration();
+  registerPRViewTool(reg.register, graphql);
+  const out = (await reg.entry.handler({ repo: "owner/repo", number: 7 })) as {
+    review_decision: string | null;
+  };
+  assert.equal(out.review_decision, null);
+});
+
+test("gh.pr_view: each review_decision enum value passes through unchanged", async () => {
+  for (const decision of ["APPROVED", "CHANGES_REQUESTED", "REVIEW_REQUIRED"] as const) {
+    const customPR = { ...sampleRawPR, reviewDecision: decision };
+    const { graphql } = stubGraphqlClient({
+      "pr/view": { repository: { pullRequest: customPR } },
+    });
+    const reg = captureRegistration();
+    registerPRViewTool(reg.register, graphql);
+    const out = (await reg.entry.handler({ repo: "owner/repo", number: 7 })) as {
+      review_decision: string | null;
+    };
+    assert.equal(out.review_decision, decision);
+  }
+});
+
+test("gh.pr_view: PENDING review with null submittedAt passes through as null", async () => {
+  // A reviewer who started but didn't submit a review surfaces
+  // as { state: "PENDING", submitted_at: null }. The methodology's
+  // "fresh review on new HEAD" check skips PENDING reviews.
+  const customPR = {
+    ...sampleRawPR,
+    reviews: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          state: "PENDING" as const,
+          author: { login: "draft-reviewer" },
+          submittedAt: null,
+        },
+      ],
+    },
+  };
+  const { graphql } = stubGraphqlClient({
+    "pr/view": { repository: { pullRequest: customPR } },
+  });
+  const reg = captureRegistration();
+  registerPRViewTool(reg.register, graphql);
+  const out = (await reg.entry.handler({ repo: "owner/repo", number: 7 })) as {
+    reviews: Array<{ submitted_at: string | null; state: string }>;
+  };
+  assert.equal(out.reviews[0]?.state, "PENDING");
+  assert.equal(out.reviews[0]?.submitted_at, null);
 });
 
 test("gh.pr_view: status_checks_state is null when there's no rollup", async () => {


### PR DESCRIPTION
## Summary
- `PRSummary` gains `review_decision: "APPROVED" | "CHANGES_REQUESTED" | "REVIEW_REQUIRED" | null` — GitHub's computed aggregate. Methodology consumes the field directly; no agent-side derivation from `reviews[]`.
- `ReviewSummary` gains `submitted_at: string | null` (null for PENDING reviews). Unblocks the methodology's "fresh review on new HEAD" predicate (memory `feedback_review_check_cycle`): the agent compares the latest review's `submitted_at` against the PR's `updated_at`.
- Both fields land via the GraphQL `pr/view` query; `summarisePR` propagates them through.

## Test plan
- [x] `npm run lint`
- [x] `npm test` — 3 new unit tests pin: each enum value passes through unchanged (APPROVED / CHANGES_REQUESTED / REVIEW_REQUIRED); null passthrough for PRs against a base with no branch-protection rule (must NOT collapse to REVIEW_REQUIRED); PENDING review surfaces `submitted_at: null`. The existing happy-path test updated to assert both new fields.