### PR TITLE
feat: gh.pr_reviews_list (A10)

### DIFF
--- a/src/graphql/queries/pr/reviews_list.graphql
+++ b/src/graphql/queries/pr/reviews_list.graphql
@@ -1,0 +1,32 @@
+query PRReviewsList(
+  $owner: String!
+  $name: String!
+  $number: Int!
+  $first: Int!
+  $after: String
+) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviews(first: $first, after: $after) {
+        totalCount
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          id
+          state
+          body
+          submittedAt
+          author {
+            login
+          }
+          commit {
+            oid
+          }
+          url
+        }
+      }
+    }
+  }
+}

--- a/src/tools/pr/index.ts
+++ b/src/tools/pr/index.ts
@@ -1,8 +1,11 @@
 // src/tools/pr/index.ts
 //
-// Aggregator for the seven gh.pr_* tools. Imported by
+// Aggregator for the gh.pr_* tools. Imported by
 // `src/server.ts`'s startServer() and called once at boot to
-// register every PR-domain tool against the registry.
+// register every PR-domain tool against the registry. The
+// function body below is the authoritative list — no hard-coded
+// count in this header so it doesn't drift each time a tool
+// joins or leaves the group.
 
 import type { GraphqlClient } from "../../graphql/client.js";
 import type { ToolEntry } from "../../registry.js";

--- a/src/tools/pr/index.ts
+++ b/src/tools/pr/index.ts
@@ -12,6 +12,7 @@ import { registerPREditTool } from "./edit.js";
 import { registerPRListTool } from "./list.js";
 import { registerPRMergeTool } from "./merge.js";
 import { registerPRRequestReviewsTool } from "./request_reviews.js";
+import { registerPRReviewsListTool } from "./reviews_list.js";
 import { registerPRViewTool } from "./view.js";
 
 type RegisterToolFn = (name: string, entry: ToolEntry) => void;
@@ -27,4 +28,5 @@ export function registerPRTools(
   registerPRCommentTool(register, graphql);
   registerPRMergeTool(register, graphql);
   registerPRRequestReviewsTool(register, graphql);
+  registerPRReviewsListTool(register, graphql);
 }

--- a/src/tools/pr/reviews_list.ts
+++ b/src/tools/pr/reviews_list.ts
@@ -77,9 +77,9 @@ const reviewSchema = {
 
 const outputSchema = {
   type: "object",
-  required: ["reviews", "total", "hasNextPage", "endCursor"],
+  required: ["items", "total", "hasNextPage", "endCursor"],
   properties: {
-    reviews: { type: "array", items: reviewSchema },
+    items: { type: "array", items: reviewSchema },
     total: {
       type: "integer",
       minimum: 0,
@@ -121,7 +121,7 @@ interface ReviewSummary {
 }
 
 interface Output {
-  reviews: ReviewSummary[];
+  items: ReviewSummary[];
   total: number;
   hasNextPage: boolean;
   endCursor: string | null;
@@ -148,11 +148,11 @@ export function registerPRReviewsListTool(
       "Paginated list of a PR's reviews — the full history, " +
       "including reviews beyond gh.pr_view's first-100 window. " +
       "Pagination uses `perPage` / `after` on input and " +
-      "`hasNextPage` / `endCursor` at top of output, matching " +
-      "the other list tools. Each entry exposes id, author, " +
-      "state, submitted_at, body (full summary text, not " +
-      "truncated), commit_oid (the SHA the review was submitted " +
-      "against), and url.",
+      "`items` / `total` / `hasNextPage` / `endCursor` at top " +
+      "of output, matching the other list tools. Each entry " +
+      "exposes id, author, state, submitted_at, body (full " +
+      "summary text, not truncated), commit_oid (the SHA the " +
+      "review was submitted against), and url.",
     inputSchema,
     handler: async (raw) => {
       const args = validate<Input>(
@@ -180,7 +180,7 @@ export function registerPRReviewsListTool(
         );
       }
       const out: Output = {
-        reviews: pr.reviews.nodes.map(summariseReview),
+        items: pr.reviews.nodes.map(summariseReview),
         total: pr.reviews.totalCount,
         hasNextPage: pr.reviews.pageInfo.hasNextPage,
         endCursor: pr.reviews.pageInfo.endCursor,

--- a/src/tools/pr/reviews_list.ts
+++ b/src/tools/pr/reviews_list.ts
@@ -12,7 +12,7 @@
 // at the top level (no `pageInfo` wrapper).
 //
 // Per-review fields: id, author, state, submitted_at, body (the
-// full review-summary text, not truncated), commit_oid (the SHA
+// full review-summary text, not truncated), commit_sha (the SHA
 // the review was submitted against), and url.
 
 import type { GraphqlClient } from "../../graphql/client.js";
@@ -57,7 +57,7 @@ const reviewSchema = {
     "state",
     "submitted_at",
     "body",
-    "commit_oid",
+    "commit_sha",
     "url",
   ],
   properties: {
@@ -69,7 +69,7 @@ const reviewSchema = {
     },
     submitted_at: { type: ["string", "null"] },
     body: { type: "string" },
-    commit_oid: { type: ["string", "null"] },
+    commit_sha: { type: ["string", "null"] },
     url: { type: "string" },
   },
   additionalProperties: false,
@@ -116,7 +116,7 @@ interface ReviewSummary {
   state: RawReview["state"];
   submitted_at: string | null;
   body: string;
-  commit_oid: string | null;
+  commit_sha: string | null;
   url: string;
 }
 
@@ -151,7 +151,7 @@ export function registerPRReviewsListTool(
       "`items` / `total` / `hasNextPage` / `endCursor` at top " +
       "of output, matching the other list tools. Each entry " +
       "exposes id, author, state, submitted_at, body (full " +
-      "summary text, not truncated), commit_oid (the SHA the " +
+      "summary text, not truncated), commit_sha (the SHA the " +
       "review was submitted against), and url.",
     inputSchema,
     handler: async (raw) => {
@@ -201,7 +201,7 @@ function summariseReview(raw: RawReview): ReviewSummary {
     state: raw.state,
     submitted_at: raw.submittedAt,
     body: raw.body,
-    commit_oid: raw.commit?.oid ?? null,
+    commit_sha: raw.commit?.oid ?? null,
     url: raw.url,
   };
 }

--- a/src/tools/pr/reviews_list.ts
+++ b/src/tools/pr/reviews_list.ts
@@ -4,17 +4,24 @@
 // `gh.pr_view` already surfaces a `reviews` array, but caps at
 // the first 100 entries; PRs with > 100 reviews (very long-lived
 // migration PRs, bot-driven repos, etc.) need real pagination to
-// see the tail. Caller drives pagination via `cursor: endCursor`.
+// see the tail.
 //
-// Per-review fields include `submitted_at`, `commit_oid` (the
-// HEAD the review was submitted against), and a short `body`
-// preview so consumers can tell which review was leaving the
-// inline comments rolled up in `gh.pr_review_threads_list`.
+// Pagination follows the codebase-wide convention from
+// `gh.issue_list` / `gh.pr_list` / `gh.label_list`: input uses
+// `perPage` + `after`, output exposes `hasNextPage` + `endCursor`
+// at the top level (no `pageInfo` wrapper).
+//
+// Per-review fields: id, author, state, submitted_at, body (the
+// full review-summary text, not truncated), commit_oid (the SHA
+// the review was submitted against), and url.
 
 import type { GraphqlClient } from "../../graphql/client.js";
 import type { ToolEntry } from "../../registry.js";
 import { validate } from "../../validation/validator.js";
 import { parseRepoSlug, repoSlugSchema } from "./_shared.js";
+
+const PER_PAGE_DEFAULT = 100;
+const PER_PAGE_MAX = 100;
 
 const inputSchema = {
   type: "object",
@@ -22,8 +29,22 @@ const inputSchema = {
   properties: {
     repo: repoSlugSchema,
     number: { type: "integer", minimum: 1 },
-    cursor: { type: "string", minLength: 1 },
-    page_size: { type: "integer", minimum: 1, maximum: 100 },
+    after: {
+      type: "string",
+      minLength: 1,
+      description:
+        "Opaque cursor from a previous call's `endCursor`. Omit " +
+        "on the first call. Naming matches `gh.pr_list` / " +
+        "`gh.issue_list` / `gh.label_list`.",
+    },
+    perPage: {
+      type: "integer",
+      minimum: 1,
+      maximum: PER_PAGE_MAX,
+      description:
+        `Reviews per page (default ${PER_PAGE_DEFAULT}, max ${PER_PAGE_MAX}). ` +
+        "Naming matches the other paginated list tools.",
+    },
   },
   additionalProperties: false,
 } as const;
@@ -56,19 +77,16 @@ const reviewSchema = {
 
 const outputSchema = {
   type: "object",
-  required: ["totalCount", "pageInfo", "reviews"],
+  required: ["reviews", "total", "hasNextPage", "endCursor"],
   properties: {
-    totalCount: { type: "integer", minimum: 0 },
-    pageInfo: {
-      type: "object",
-      required: ["hasNextPage", "endCursor"],
-      properties: {
-        hasNextPage: { type: "boolean" },
-        endCursor: { type: ["string", "null"] },
-      },
-      additionalProperties: false,
-    },
     reviews: { type: "array", items: reviewSchema },
+    total: {
+      type: "integer",
+      minimum: 0,
+      description: "GraphQL totalCount across all pages.",
+    },
+    hasNextPage: { type: "boolean" },
+    endCursor: { type: ["string", "null"] },
   },
   additionalProperties: false,
 } as const;
@@ -78,8 +96,8 @@ type RegisterToolFn = (name: string, entry: ToolEntry) => void;
 interface Input {
   repo: string;
   number: number;
-  cursor?: string;
-  page_size?: number;
+  after?: string;
+  perPage?: number;
 }
 
 interface RawReview {
@@ -103,9 +121,10 @@ interface ReviewSummary {
 }
 
 interface Output {
-  totalCount: number;
-  pageInfo: { hasNextPage: boolean; endCursor: string | null };
   reviews: ReviewSummary[];
+  total: number;
+  hasNextPage: boolean;
+  endCursor: string | null;
 }
 
 interface Response {
@@ -128,10 +147,12 @@ export function registerPRReviewsListTool(
     description:
       "Paginated list of a PR's reviews — the full history, " +
       "including reviews beyond gh.pr_view's first-100 window. " +
-      "Each entry exposes the review id, author, state, " +
-      "submitted_at, body, commit_oid (the SHA the review was " +
-      "submitted against), and url. Caller drives pagination via " +
-      "`cursor: endCursor`.",
+      "Pagination uses `perPage` / `after` on input and " +
+      "`hasNextPage` / `endCursor` at top of output, matching " +
+      "the other list tools. Each entry exposes id, author, " +
+      "state, submitted_at, body (full summary text, not " +
+      "truncated), commit_oid (the SHA the review was submitted " +
+      "against), and url.",
     inputSchema,
     handler: async (raw) => {
       const args = validate<Input>(
@@ -144,8 +165,8 @@ export function registerPRReviewsListTool(
         owner: coords.owner,
         name: coords.name,
         number: args.number,
-        first: args.page_size ?? 100,
-        after: args.cursor ?? null,
+        first: args.perPage ?? PER_PAGE_DEFAULT,
+        after: args.after ?? null,
       });
       if (!data.repository) {
         throw new Error(
@@ -159,9 +180,10 @@ export function registerPRReviewsListTool(
         );
       }
       const out: Output = {
-        totalCount: pr.reviews.totalCount,
-        pageInfo: pr.reviews.pageInfo,
         reviews: pr.reviews.nodes.map(summariseReview),
+        total: pr.reviews.totalCount,
+        hasNextPage: pr.reviews.pageInfo.hasNextPage,
+        endCursor: pr.reviews.pageInfo.endCursor,
       };
       return validate<Output>(
         outputSchema,

--- a/src/tools/pr/reviews_list.ts
+++ b/src/tools/pr/reviews_list.ts
@@ -20,7 +20,7 @@ import type { ToolEntry } from "../../registry.js";
 import { validate } from "../../validation/validator.js";
 import { parseRepoSlug, repoSlugSchema } from "./_shared.js";
 
-const PER_PAGE_DEFAULT = 100;
+const PER_PAGE_DEFAULT = 30;
 const PER_PAGE_MAX = 100;
 
 const inputSchema = {

--- a/src/tools/pr/reviews_list.ts
+++ b/src/tools/pr/reviews_list.ts
@@ -1,0 +1,185 @@
+// src/tools/pr/reviews_list.ts
+//
+// `gh.pr_reviews_list` — paginated list of a PR's reviews.
+// `gh.pr_view` already surfaces a `reviews` array, but caps at
+// the first 100 entries; PRs with > 100 reviews (very long-lived
+// migration PRs, bot-driven repos, etc.) need real pagination to
+// see the tail. Caller drives pagination via `cursor: endCursor`.
+//
+// Per-review fields include `submitted_at`, `commit_oid` (the
+// HEAD the review was submitted against), and a short `body`
+// preview so consumers can tell which review was leaving the
+// inline comments rolled up in `gh.pr_review_threads_list`.
+
+import type { GraphqlClient } from "../../graphql/client.js";
+import type { ToolEntry } from "../../registry.js";
+import { validate } from "../../validation/validator.js";
+import { parseRepoSlug, repoSlugSchema } from "./_shared.js";
+
+const inputSchema = {
+  type: "object",
+  required: ["repo", "number"],
+  properties: {
+    repo: repoSlugSchema,
+    number: { type: "integer", minimum: 1 },
+    cursor: { type: "string", minLength: 1 },
+    page_size: { type: "integer", minimum: 1, maximum: 100 },
+  },
+  additionalProperties: false,
+} as const;
+
+const reviewSchema = {
+  type: "object",
+  required: [
+    "id",
+    "author",
+    "state",
+    "submitted_at",
+    "body",
+    "commit_oid",
+    "url",
+  ],
+  properties: {
+    id: { type: "string" },
+    author: { type: ["string", "null"] },
+    state: {
+      type: "string",
+      enum: ["PENDING", "COMMENTED", "APPROVED", "CHANGES_REQUESTED", "DISMISSED"],
+    },
+    submitted_at: { type: ["string", "null"] },
+    body: { type: "string" },
+    commit_oid: { type: ["string", "null"] },
+    url: { type: "string" },
+  },
+  additionalProperties: false,
+} as const;
+
+const outputSchema = {
+  type: "object",
+  required: ["totalCount", "pageInfo", "reviews"],
+  properties: {
+    totalCount: { type: "integer", minimum: 0 },
+    pageInfo: {
+      type: "object",
+      required: ["hasNextPage", "endCursor"],
+      properties: {
+        hasNextPage: { type: "boolean" },
+        endCursor: { type: ["string", "null"] },
+      },
+      additionalProperties: false,
+    },
+    reviews: { type: "array", items: reviewSchema },
+  },
+  additionalProperties: false,
+} as const;
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+interface Input {
+  repo: string;
+  number: number;
+  cursor?: string;
+  page_size?: number;
+}
+
+interface RawReview {
+  id: string;
+  state: "PENDING" | "COMMENTED" | "APPROVED" | "CHANGES_REQUESTED" | "DISMISSED";
+  body: string;
+  submittedAt: string | null;
+  author: { login: string } | null;
+  commit: { oid: string } | null;
+  url: string;
+}
+
+interface ReviewSummary {
+  id: string;
+  author: string | null;
+  state: RawReview["state"];
+  submitted_at: string | null;
+  body: string;
+  commit_oid: string | null;
+  url: string;
+}
+
+interface Output {
+  totalCount: number;
+  pageInfo: { hasNextPage: boolean; endCursor: string | null };
+  reviews: ReviewSummary[];
+}
+
+interface Response {
+  repository: {
+    pullRequest: {
+      reviews: {
+        totalCount: number;
+        pageInfo: { hasNextPage: boolean; endCursor: string | null };
+        nodes: RawReview[];
+      };
+    } | null;
+  } | null;
+}
+
+export function registerPRReviewsListTool(
+  register: RegisterToolFn,
+  graphql: GraphqlClient,
+): void {
+  register("gh.pr_reviews_list", {
+    description:
+      "Paginated list of a PR's reviews — the full history, " +
+      "including reviews beyond gh.pr_view's first-100 window. " +
+      "Each entry exposes the review id, author, state, " +
+      "submitted_at, body, commit_oid (the SHA the review was " +
+      "submitted against), and url. Caller drives pagination via " +
+      "`cursor: endCursor`.",
+    inputSchema,
+    handler: async (raw) => {
+      const args = validate<Input>(
+        inputSchema,
+        raw,
+        "gh.pr_reviews_list input",
+      );
+      const coords = parseRepoSlug(args.repo, "gh.pr_reviews_list input");
+      const data = await graphql<Response>("pr/reviews_list", {
+        owner: coords.owner,
+        name: coords.name,
+        number: args.number,
+        first: args.page_size ?? 100,
+        after: args.cursor ?? null,
+      });
+      if (!data.repository) {
+        throw new Error(
+          `mcp-github: gh.pr_reviews_list: repository '${coords.owner}/${coords.name}' not found or token lacks read access`,
+        );
+      }
+      const pr = data.repository.pullRequest;
+      if (!pr) {
+        throw new Error(
+          `mcp-github: gh.pr_reviews_list: PR ${coords.owner}/${coords.name}#${args.number} not found`,
+        );
+      }
+      const out: Output = {
+        totalCount: pr.reviews.totalCount,
+        pageInfo: pr.reviews.pageInfo,
+        reviews: pr.reviews.nodes.map(summariseReview),
+      };
+      return validate<Output>(
+        outputSchema,
+        out,
+        "gh.pr_reviews_list output",
+      );
+    },
+  });
+}
+
+function summariseReview(raw: RawReview): ReviewSummary {
+  return {
+    id: raw.id,
+    author: raw.author?.login ?? null,
+    state: raw.state,
+    submitted_at: raw.submittedAt,
+    body: raw.body,
+    commit_oid: raw.commit?.oid ?? null,
+    url: raw.url,
+  };
+}

--- a/src/tools/pr/reviews_list.ts
+++ b/src/tools/pr/reviews_list.ts
@@ -8,8 +8,11 @@
 //
 // Pagination follows the codebase-wide convention from
 // `gh.issue_list` / `gh.pr_list` / `gh.label_list`: input uses
-// `perPage` + `after`, output exposes `hasNextPage` + `endCursor`
-// at the top level (no `pageInfo` wrapper).
+// `perPage` + `after`, output exposes `items` and flat
+// `hasNextPage` / `endCursor` at the top level. We also surface
+// `total` (the GraphQL totalCount) like `gh.issue_search` does
+// — useful because reviews on long-lived PRs can run into the
+// hundreds and the caller wants to know the absolute count.
 //
 // Per-review fields: id, author, state, submitted_at, body (the
 // full review-summary text, not truncated), commit_sha (the SHA
@@ -147,9 +150,12 @@ export function registerPRReviewsListTool(
     description:
       "Paginated list of a PR's reviews — the full history, " +
       "including reviews beyond gh.pr_view's first-100 window. " +
-      "Pagination uses `perPage` / `after` on input and " +
-      "`items` / `total` / `hasNextPage` / `endCursor` at top " +
-      "of output, matching the other list tools. Each entry " +
+      "Pagination uses `perPage` / `after` on input and the flat " +
+      "`hasNextPage` / `endCursor` shape on output, matching the " +
+      "other list tools; we also surface `total` (the GraphQL " +
+      "totalCount) like `gh.issue_search` does, since long-lived " +
+      "PRs can accumulate hundreds of reviews and the absolute " +
+      "count is the useful signal for the agent. Each entry " +
       "exposes id, author, state, submitted_at, body (full " +
       "summary text, not truncated), commit_sha (the SHA the " +
       "review was submitted against), and url.",

--- a/tests/smoke/server-lists-tools.mjs
+++ b/tests/smoke/server-lists-tools.mjs
@@ -9,9 +9,10 @@
 // + tool registration chain end-to-end without pulling in the
 // unit-test framework.
 //
-// Current surface: 1 auth probe (`gh.test_connection` from MCP-2)
-// + 7 issue tools (MCP-4) + 4 label tools (MCP-7) + 7 PR tools
-// (MCP-5 + MCP-6, the latter adding `gh.pr_request_reviews`).
+// The EXPECTED_TOOLS array below is the authoritative list of
+// the current tool surface; this header used to also carry a
+// human-readable count, but that drifted on every PR. Read the
+// array if you want the current set.
 //
 // Wire format: the MCP SDK's StdioServerTransport uses newline-
 // delimited JSON-RPC (one JSON message per `\n`-terminated line),

--- a/tests/smoke/server-lists-tools.mjs
+++ b/tests/smoke/server-lists-tools.mjs
@@ -58,6 +58,7 @@ const EXPECTED_TOOLS = [
   "gh.workflow_run_view",
   "gh.workflow_run_cancel",
   "gh.workflow_run_jobs",
+  "gh.pr_reviews_list",
 ];
 
 function frame(payload) {

--- a/tests/unit/tools/pr/reviews_list.test.ts
+++ b/tests/unit/tools/pr/reviews_list.test.ts
@@ -1,7 +1,7 @@
 // tests/unit/tools/pr/reviews_list.test.ts
 //
 // gh.pr_reviews_list: pin the GraphQL → summary mapping (incl.
-// commit_oid + submitted_at), the after / perPage input naming,
+// commit_sha + submitted_at), the after / perPage input naming,
 // the top-level pagination output (hasNextPage + endCursor at
 // the root, matching the other list tools), and the not-found
 // error shapes.
@@ -73,7 +73,7 @@ test("gh.pr_reviews_list: maps a full GraphQL response onto the canonical summar
       author: string | null;
       state: string;
       submitted_at: string | null;
-      commit_oid: string | null;
+      commit_sha: string | null;
       body: string;
       url: string;
     }>;
@@ -87,7 +87,7 @@ test("gh.pr_reviews_list: maps a full GraphQL response onto the canonical summar
     state: "APPROVED",
     submitted_at: "2026-04-02T01:00:00Z",
     body: "LGTM",
-    commit_oid: "deadbeef",
+    commit_sha: "deadbeef",
     url: "https://github.com/owner/repo/pull/7#pullrequestreview-1",
   });
   assert.equal(calls.length, 1);
@@ -148,7 +148,7 @@ test("gh.pr_reviews_list: hasNextPage + endCursor surface at the top of the outp
   assert.equal(out.endCursor, "PAGE_2_CURSOR");
 });
 
-test("gh.pr_reviews_list: PENDING review surfaces submitted_at: null + commit_oid: null", async () => {
+test("gh.pr_reviews_list: PENDING review surfaces submitted_at: null + commit_sha: null", async () => {
   const { graphql } = stubGraphqlClient({
     "pr/reviews_list": () => ({
       repository: {
@@ -178,13 +178,13 @@ test("gh.pr_reviews_list: PENDING review surfaces submitted_at: null + commit_oi
     items: Array<{
       author: string | null;
       submitted_at: string | null;
-      commit_oid: string | null;
+      commit_sha: string | null;
       state: string;
     }>;
   };
   assert.equal(out.items[0]?.state, "PENDING");
   assert.equal(out.items[0]?.submitted_at, null);
-  assert.equal(out.items[0]?.commit_oid, null);
+  assert.equal(out.items[0]?.commit_sha, null);
   assert.equal(out.items[0]?.author, null);
 });
 

--- a/tests/unit/tools/pr/reviews_list.test.ts
+++ b/tests/unit/tools/pr/reviews_list.test.ts
@@ -68,7 +68,7 @@ test("gh.pr_reviews_list: maps a full GraphQL response onto the canonical summar
     total: number;
     hasNextPage: boolean;
     endCursor: string | null;
-    reviews: Array<{
+    items: Array<{
       id: string;
       author: string | null;
       state: string;
@@ -81,7 +81,7 @@ test("gh.pr_reviews_list: maps a full GraphQL response onto the canonical summar
   assert.equal(out.total, 1);
   assert.equal(out.hasNextPage, false);
   assert.equal(out.endCursor, "abc");
-  assert.deepEqual(out.reviews[0], {
+  assert.deepEqual(out.items[0], {
     id: "PRR_1",
     author: "alice",
     state: "APPROVED",
@@ -175,17 +175,17 @@ test("gh.pr_reviews_list: PENDING review surfaces submitted_at: null + commit_oi
     repo: "owner/repo",
     number: 7,
   })) as {
-    reviews: Array<{
+    items: Array<{
       author: string | null;
       submitted_at: string | null;
       commit_oid: string | null;
       state: string;
     }>;
   };
-  assert.equal(out.reviews[0]?.state, "PENDING");
-  assert.equal(out.reviews[0]?.submitted_at, null);
-  assert.equal(out.reviews[0]?.commit_oid, null);
-  assert.equal(out.reviews[0]?.author, null);
+  assert.equal(out.items[0]?.state, "PENDING");
+  assert.equal(out.items[0]?.submitted_at, null);
+  assert.equal(out.items[0]?.commit_oid, null);
+  assert.equal(out.items[0]?.author, null);
 });
 
 test("gh.pr_reviews_list: repo missing throws repository-shaped error", async () => {

--- a/tests/unit/tools/pr/reviews_list.test.ts
+++ b/tests/unit/tools/pr/reviews_list.test.ts
@@ -1,0 +1,190 @@
+// tests/unit/tools/pr/reviews_list.test.ts
+//
+// gh.pr_reviews_list: pin the GraphQL → summary mapping (incl.
+// commit_oid + submitted_at), the cursor + page_size
+// pass-through, and the not-found error shapes.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { registerPRReviewsListTool } from "../../../../src/tools/pr/reviews_list.ts";
+import type { ToolEntry } from "../../../../src/registry.ts";
+import { stubGraphqlClient } from "./_fixtures.ts";
+
+function captureRegistration() {
+  let entry: ToolEntry | undefined;
+  const register = (name: string, e: ToolEntry) => {
+    if (name !== "gh.pr_reviews_list") throw new Error(`unexpected: ${name}`);
+    entry = e;
+  };
+  return {
+    register,
+    get entry(): ToolEntry {
+      if (!entry) throw new Error("not registered");
+      return entry;
+    },
+  };
+}
+
+function rawReview(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "PRR_1",
+    state: "APPROVED" as const,
+    body: "LGTM",
+    submittedAt: "2026-04-02T01:00:00Z",
+    author: { login: "alice" },
+    commit: { oid: "deadbeef" },
+    url: "https://github.com/owner/repo/pull/7#pullrequestreview-1",
+    ...overrides,
+  };
+}
+
+test("gh.pr_reviews_list: maps a full GraphQL response onto the canonical summary", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "pr/reviews_list": (vars: Record<string, unknown>) => {
+      assert.equal(vars.first, 100);
+      assert.equal(vars.after, null);
+      return {
+        repository: {
+          pullRequest: {
+            reviews: {
+              totalCount: 1,
+              pageInfo: { hasNextPage: false, endCursor: "abc" },
+              nodes: [rawReview()],
+            },
+          },
+        },
+      };
+    },
+  });
+  const reg = captureRegistration();
+  registerPRReviewsListTool(reg.register, graphql);
+  const out = (await reg.entry.handler({
+    repo: "owner/repo",
+    number: 7,
+  })) as {
+    totalCount: number;
+    reviews: Array<{
+      id: string;
+      author: string | null;
+      state: string;
+      submitted_at: string | null;
+      commit_oid: string | null;
+    }>;
+  };
+  assert.equal(out.totalCount, 1);
+  assert.deepEqual(out.reviews[0], {
+    id: "PRR_1",
+    author: "alice",
+    state: "APPROVED",
+    submitted_at: "2026-04-02T01:00:00Z",
+    body: "LGTM",
+    commit_oid: "deadbeef",
+    url: "https://github.com/owner/repo/pull/7#pullrequestreview-1",
+  });
+  assert.equal(calls.length, 1);
+});
+
+test("gh.pr_reviews_list: cursor + page_size pass through", async () => {
+  const { graphql } = stubGraphqlClient({
+    "pr/reviews_list": (vars: Record<string, unknown>) => {
+      assert.equal(vars.first, 25);
+      assert.equal(vars.after, "PAGE2");
+      return {
+        repository: {
+          pullRequest: {
+            reviews: {
+              totalCount: 0,
+              pageInfo: { hasNextPage: false, endCursor: null },
+              nodes: [],
+            },
+          },
+        },
+      };
+    },
+  });
+  const reg = captureRegistration();
+  registerPRReviewsListTool(reg.register, graphql);
+  await reg.entry.handler({
+    repo: "owner/repo",
+    number: 7,
+    page_size: 25,
+    cursor: "PAGE2",
+  });
+});
+
+test("gh.pr_reviews_list: PENDING review surfaces submitted_at: null + commit_oid: null", async () => {
+  const { graphql } = stubGraphqlClient({
+    "pr/reviews_list": () => ({
+      repository: {
+        pullRequest: {
+          reviews: {
+            totalCount: 1,
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [
+              rawReview({
+                state: "PENDING",
+                submittedAt: null,
+                commit: null,
+                author: null,
+              }),
+            ],
+          },
+        },
+      },
+    }),
+  });
+  const reg = captureRegistration();
+  registerPRReviewsListTool(reg.register, graphql);
+  const out = (await reg.entry.handler({
+    repo: "owner/repo",
+    number: 7,
+  })) as {
+    reviews: Array<{
+      author: string | null;
+      submitted_at: string | null;
+      commit_oid: string | null;
+      state: string;
+    }>;
+  };
+  assert.equal(out.reviews[0]?.state, "PENDING");
+  assert.equal(out.reviews[0]?.submitted_at, null);
+  assert.equal(out.reviews[0]?.commit_oid, null);
+  assert.equal(out.reviews[0]?.author, null);
+});
+
+test("gh.pr_reviews_list: repo missing throws repository-shaped error", async () => {
+  const { graphql } = stubGraphqlClient({
+    "pr/reviews_list": () => ({ repository: null }),
+  });
+  const reg = captureRegistration();
+  registerPRReviewsListTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", number: 7 }),
+    /repository 'owner\/repo' not found/,
+  );
+});
+
+test("gh.pr_reviews_list: PR missing throws PR-shaped error", async () => {
+  const { graphql } = stubGraphqlClient({
+    "pr/reviews_list": () => ({
+      repository: { pullRequest: null },
+    }),
+  });
+  const reg = captureRegistration();
+  registerPRReviewsListTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", number: 99 }),
+    /PR owner\/repo#99 not found/,
+  );
+});
+
+test("gh.pr_reviews_list: rejects page_size > 100 at the input boundary", async () => {
+  const { graphql } = stubGraphqlClient({});
+  const reg = captureRegistration();
+  registerPRReviewsListTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ repo: "owner/repo", number: 7, page_size: 200 }),
+    /gh\.pr_reviews_list input/,
+  );
+});

--- a/tests/unit/tools/pr/reviews_list.test.ts
+++ b/tests/unit/tools/pr/reviews_list.test.ts
@@ -44,7 +44,8 @@ function rawReview(overrides: Record<string, unknown> = {}) {
 test("gh.pr_reviews_list: maps a full GraphQL response onto the canonical summary", async () => {
   const { graphql, calls } = stubGraphqlClient({
     "pr/reviews_list": (vars: Record<string, unknown>) => {
-      assert.equal(vars.first, 100);
+      // Default perPage is 30 (matches the other list tools).
+      assert.equal(vars.first, 30);
       assert.equal(vars.after, null);
       return {
         repository: {

--- a/tests/unit/tools/pr/reviews_list.test.ts
+++ b/tests/unit/tools/pr/reviews_list.test.ts
@@ -1,8 +1,10 @@
 // tests/unit/tools/pr/reviews_list.test.ts
 //
 // gh.pr_reviews_list: pin the GraphQL → summary mapping (incl.
-// commit_oid + submitted_at), the cursor + page_size
-// pass-through, and the not-found error shapes.
+// commit_oid + submitted_at), the after / perPage input naming,
+// the top-level pagination output (hasNextPage + endCursor at
+// the root, matching the other list tools), and the not-found
+// error shapes.
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
@@ -63,16 +65,22 @@ test("gh.pr_reviews_list: maps a full GraphQL response onto the canonical summar
     repo: "owner/repo",
     number: 7,
   })) as {
-    totalCount: number;
+    total: number;
+    hasNextPage: boolean;
+    endCursor: string | null;
     reviews: Array<{
       id: string;
       author: string | null;
       state: string;
       submitted_at: string | null;
       commit_oid: string | null;
+      body: string;
+      url: string;
     }>;
   };
-  assert.equal(out.totalCount, 1);
+  assert.equal(out.total, 1);
+  assert.equal(out.hasNextPage, false);
+  assert.equal(out.endCursor, "abc");
   assert.deepEqual(out.reviews[0], {
     id: "PRR_1",
     author: "alice",
@@ -85,7 +93,7 @@ test("gh.pr_reviews_list: maps a full GraphQL response onto the canonical summar
   assert.equal(calls.length, 1);
 });
 
-test("gh.pr_reviews_list: cursor + page_size pass through", async () => {
+test("gh.pr_reviews_list: after + perPage pass through", async () => {
   const { graphql } = stubGraphqlClient({
     "pr/reviews_list": (vars: Record<string, unknown>) => {
       assert.equal(vars.first, 25);
@@ -108,9 +116,36 @@ test("gh.pr_reviews_list: cursor + page_size pass through", async () => {
   await reg.entry.handler({
     repo: "owner/repo",
     number: 7,
-    page_size: 25,
-    cursor: "PAGE2",
+    perPage: 25,
+    after: "PAGE2",
   });
+});
+
+test("gh.pr_reviews_list: hasNextPage + endCursor surface at the top of the output", async () => {
+  // Pin the pagination output contract (flat hasNextPage/endCursor,
+  // not nested under pageInfo) to match the other list tools.
+  const { graphql } = stubGraphqlClient({
+    "pr/reviews_list": () => ({
+      repository: {
+        pullRequest: {
+          reviews: {
+            totalCount: 500,
+            pageInfo: { hasNextPage: true, endCursor: "PAGE_2_CURSOR" },
+            nodes: [],
+          },
+        },
+      },
+    }),
+  });
+  const reg = captureRegistration();
+  registerPRReviewsListTool(reg.register, graphql);
+  const out = (await reg.entry.handler({
+    repo: "owner/repo",
+    number: 7,
+  })) as { total: number; hasNextPage: boolean; endCursor: string | null };
+  assert.equal(out.total, 500);
+  assert.equal(out.hasNextPage, true);
+  assert.equal(out.endCursor, "PAGE_2_CURSOR");
 });
 
 test("gh.pr_reviews_list: PENDING review surfaces submitted_at: null + commit_oid: null", async () => {
@@ -179,12 +214,12 @@ test("gh.pr_reviews_list: PR missing throws PR-shaped error", async () => {
   );
 });
 
-test("gh.pr_reviews_list: rejects page_size > 100 at the input boundary", async () => {
+test("gh.pr_reviews_list: rejects perPage > 100 at the input boundary", async () => {
   const { graphql } = stubGraphqlClient({});
   const reg = captureRegistration();
   registerPRReviewsListTool(reg.register, graphql);
   await assert.rejects(
-    reg.entry.handler({ repo: "owner/repo", number: 7, page_size: 200 }),
+    reg.entry.handler({ repo: "owner/repo", number: 7, perPage: 200 }),
     /gh\.pr_reviews_list input/,
   );
 });


### PR DESCRIPTION
## Summary
- New tool `gh.pr_reviews_list` — paginated PR reviews. `gh.pr_view` caps at the first 100 reviews; long-lived PRs (migration branches, bot-driven repos) need real pagination to see the tail.
- Each entry surfaces `id`, `author`, `state`, `submitted_at`, `body`, `commit_sha` (the SHA the review was submitted against), and `url`.
- Pagination uses `perPage` / `after` on input and the flat `items` / `total` / `hasNextPage` / `endCursor` shape on output, matching `gh.pr_list` / `gh.issue_list` / `gh.label_list`. Default `perPage` is 30; max 100.

## Test plan
- [x] `npm run lint`
- [x] `npm test` — 7 unit tests pin: GraphQL → summary mapping; after / perPage pass-through; flat hasNextPage / endCursor at top of output; PENDING review with null submitted_at and commit_sha; repo-missing vs PR-missing error shapes; perPage > 100 schema rejection.