### PR TITLE
feat: paginate gh.label_sync_from_yaml across all label pages (A11)

### DIFF
--- a/src/tools/label/sync_from_yaml.ts
+++ b/src/tools/label/sync_from_yaml.ts
@@ -34,6 +34,12 @@ import {
 } from "./_shared.js";
 
 const LABELS_PAGE_SIZE = 100;
+// Hard ceiling on the total label set to detect runaway queries
+// (e.g. a misconfigured cursor that fails to advance) without
+// exhausting GitHub's rate-limit budget. Real repos top out
+// well under this; if you hit it, something is wrong upstream
+// rather than a legitimately enormous taxonomy.
+const LABELS_TOTAL_CEILING = 5000;
 
 const inputSchema = {
   type: "object",
@@ -282,34 +288,59 @@ function parseTaxonomy(yamlText: string): TaxonomyEntry[] {
   );
 }
 
-// Walk the repo's full label list. v0.1 caps at 100 labels for
-// the same reason the issue-domain repo-context tool does:
-// pagination would add complexity disproportionate to the
-// vanishingly rare case of a repo with > 100 labels. A truncated
-// fetch surfaces as an actionable error pointing the operator
-// at the v0.1 ceiling.
+// Walk the repo's full label list across every page. Drives a
+// `pageInfo.hasNextPage` loop with `after: endCursor` until the
+// API reports no more results, or until the accumulated set
+// exceeds `LABELS_TOTAL_CEILING` (safety guard for a runaway
+// cursor — a real taxonomy never approaches that count).
 async function loadAllLabels(
   graphql: GraphqlClient,
   coords: { owner: string; name: string },
 ): Promise<RawLabel[]> {
-  const data = await graphql<ListResponse>("label/list", {
-    owner: coords.owner,
-    name: coords.name,
-    first: LABELS_PAGE_SIZE,
-    after: null,
-  });
-  if (!data.repository) {
-    throw new Error(
-      `mcp-github: gh.label_sync_from_yaml: repository '${coords.owner}/${coords.name}' not found or token lacks read access`,
-    );
+  const all: RawLabel[] = [];
+  let cursor: string | null = null;
+  // Safety bound: even at LABELS_PAGE_SIZE per call, this is far
+  // more iterations than any realistic taxonomy needs. The
+  // ceiling-check inside the loop is the primary guard; this
+  // for-loop bound is the secondary backstop in case the API
+  // reports hasNextPage forever with no advancing cursor.
+  const MAX_PAGES = Math.ceil(LABELS_TOTAL_CEILING / LABELS_PAGE_SIZE) + 1;
+  for (let page = 0; page < MAX_PAGES; page += 1) {
+    const data: ListResponse = await graphql<ListResponse>("label/list", {
+      owner: coords.owner,
+      name: coords.name,
+      first: LABELS_PAGE_SIZE,
+      after: cursor,
+    });
+    if (!data.repository) {
+      throw new Error(
+        `mcp-github: gh.label_sync_from_yaml: repository '${coords.owner}/${coords.name}' not found or token lacks read access`,
+      );
+    }
+    all.push(...data.repository.labels.nodes);
+    if (all.length > LABELS_TOTAL_CEILING) {
+      throw new Error(
+        `mcp-github: gh.label_sync_from_yaml: repository '${coords.owner}/${coords.name}' exceeded the ${LABELS_TOTAL_CEILING}-label safety ceiling; ` +
+          `aborting to avoid a runaway pagination loop. Investigate upstream before retrying.`,
+      );
+    }
+    if (!data.repository.labels.pageInfo.hasNextPage) {
+      return all;
+    }
+    const next: string | null = data.repository.labels.pageInfo.endCursor;
+    if (typeof next !== "string" || next === cursor) {
+      // Defensive: an API quirk where hasNextPage is true but
+      // endCursor doesn't advance would otherwise loop until the
+      // backstop. Throw early with a clear signal instead.
+      throw new Error(
+        `mcp-github: gh.label_sync_from_yaml: pagination stalled (hasNextPage: true but endCursor did not advance) on '${coords.owner}/${coords.name}'`,
+      );
+    }
+    cursor = next;
   }
-  if (data.repository.labels.pageInfo.hasNextPage) {
-    throw new Error(
-      `mcp-github: gh.label_sync_from_yaml: repository '${coords.owner}/${coords.name}' has more than ${LABELS_PAGE_SIZE} labels; ` +
-        `sync is not supported on repos that large at v0.1.`,
-    );
-  }
-  return data.repository.labels.nodes;
+  throw new Error(
+    `mcp-github: gh.label_sync_from_yaml: pagination did not terminate within ${MAX_PAGES} pages on '${coords.owner}/${coords.name}'`,
+  );
 }
 
 function diffLabel(

--- a/tests/unit/tools/label/sync_from_yaml.test.ts
+++ b/tests/unit/tools/label/sync_from_yaml.test.ts
@@ -337,28 +337,91 @@ test("gh.label_sync_from_yaml: throws on YAML that's not an array or labels obje
   );
 });
 
-test("gh.label_sync_from_yaml: throws on truncated label list (>100 labels)", async () => {
-  // Mirrors the issue domain's truncation contract: v0.1 caps at
-  // 100 labels because pagination would add complexity
-  // disproportionate to the rare case.
+test("gh.label_sync_from_yaml: paginates across multiple label pages (A11)", async () => {
+  // Repo has 3 labels split across two pages of 2 + 1. The
+  // installer should follow `endCursor` to the second page and
+  // see the full set; YAML wants only "bug" which is already on
+  // the repo, so report should be all-unchanged with no
+  // mutations.
+  const pages = [
+    {
+      pageInfo: { hasNextPage: true, endCursor: "C1" },
+      nodes: [
+        rawLabel({ id: "LA_a", name: "alpha", color: "111111" }),
+        rawLabel({
+          id: "LA_bug",
+          name: "bug",
+          color: "d73a4a",
+          description: "Something is broken",
+        }),
+      ],
+    },
+    {
+      pageInfo: { hasNextPage: false, endCursor: null },
+      nodes: [rawLabel({ id: "LA_z", name: "zeta", color: "222222" })],
+    },
+  ];
+  let call = 0;
+  const { graphql, calls } = stubGraphqlClient({
+    "label/list": (vars: Record<string, unknown>) => {
+      // First call has after: null; second call uses the prior
+      // endCursor.
+      if (call === 0) assert.equal(vars.after, null);
+      if (call === 1) assert.equal(vars.after, "C1");
+      const page = pages[call];
+      call += 1;
+      return { repository: { labels: page } };
+    },
+    "label/_repo-id": { repository: { id: "R_repo" } },
+  });
+  const reg = captureRegistration();
+  registerLabelSyncFromYamlTool(reg.register, graphql);
+  const out = (await reg.entry.handler({
+    repo: "owner/repo",
+    yaml_text: `- name: bug
+  color: d73a4a
+  description: Something is broken
+`,
+    mode: "install",
+  })) as { unchanged: Array<{ name: string }>; created: unknown[] };
+  // Two list pages walked.
+  assert.equal(
+    calls.filter((c) => c.queryName === "label/list").length,
+    2,
+  );
+  // Bug exists on page 1 — no create needed.
+  assert.deepEqual(out.created, []);
+  assert.deepEqual(
+    out.unchanged.map((u) => u.name),
+    ["bug"],
+  );
+});
+
+test("gh.label_sync_from_yaml: throws on a stalled cursor (hasNextPage true but endCursor doesn't advance)", async () => {
+  // Defensive guard against an API quirk: hasNextPage stays true
+  // but endCursor returns the same value, which would otherwise
+  // loop until the safety ceiling.
   const { graphql } = stubGraphqlClient({
     "label/list": {
       repository: {
         labels: {
-          pageInfo: { hasNextPage: true, endCursor: "C" },
-          nodes: [],
+          pageInfo: { hasNextPage: true, endCursor: "STUCK" },
+          nodes: [rawLabel({ id: "LA_a", name: "alpha" })],
         },
       },
     },
   });
   const reg = captureRegistration();
   registerLabelSyncFromYamlTool(reg.register, graphql);
+  // The same fixture echoes "STUCK" on every page; the first call
+  // sets cursor = STUCK, the second call returns endCursor = STUCK
+  // again → stall detected, throw.
   await assert.rejects(
     reg.entry.handler({
       repo: "owner/repo",
       yaml_text: TAXONOMY_YAML,
       mode: "install",
     }),
-    /more than 100 labels/,
+    /pagination stalled/,
   );
 });


### PR DESCRIPTION
## Summary
- Replaces the v0.1 100-label single-page cap with a real `hasNextPage` / `endCursor` loop in `loadAllLabels()`.
- Safety bounds: a 5000-label ceiling (no real taxonomy approaches that) plus an early throw when `hasNextPage: true` but `endCursor` doesn't advance (stalled cursor), so an API quirk can't spin forever.
- Closes the v0.1 ceiling the methodology's `label-taxonomy` flow could otherwise hit on repos with >100 labels.

## Test plan
- [x] `npm run lint`
- [x] `npm test` — old "throws on truncated label list" test replaced by:
  - paginates across two pages and assembles the full set (also asserts `after: null` on call 1, `after: "C1"` on call 2);
  - stalled-cursor early throw (`hasNextPage: true` with the same `endCursor` echoed back).