### PR TITLE
feat: gh.org_issue_type_create + gh.issue_set_issue_type (A5)

### DIFF
--- a/src/graphql/queries/issue/set_issue_type.graphql
+++ b/src/graphql/queries/issue/set_issue_type.graphql
@@ -1,0 +1,34 @@
+mutation IssueSetIssueType($input: UpdateIssueIssueTypeInput!) {
+  updateIssueIssueType(input: $input) {
+    issue {
+      number
+      url
+      id
+      title
+      state
+      body
+      labels(first: 100) {
+        pageInfo {
+          hasNextPage
+        }
+        nodes {
+          name
+        }
+      }
+      assignees(first: 100) {
+        pageInfo {
+          hasNextPage
+        }
+        nodes {
+          login
+        }
+      }
+      author {
+        login
+      }
+      createdAt
+      updatedAt
+      closedAt
+    }
+  }
+}

--- a/src/graphql/queries/org/_org-id.graphql
+++ b/src/graphql/queries/org/_org-id.graphql
@@ -1,0 +1,5 @@
+query OrgId($login: String!) {
+  organization(login: $login) {
+    id
+  }
+}

--- a/src/graphql/queries/org/issue_type_create.graphql
+++ b/src/graphql/queries/org/issue_type_create.graphql
@@ -1,0 +1,13 @@
+mutation OrgIssueTypeCreate($input: CreateIssueTypeInput!) {
+  createIssueType(input: $input) {
+    issueType {
+      id
+      name
+      color
+      description
+      isEnabled
+      createdAt
+      updatedAt
+    }
+  }
+}

--- a/src/graphql/queries/org/issue_type_create.graphql
+++ b/src/graphql/queries/org/issue_type_create.graphql
@@ -6,8 +6,6 @@ mutation OrgIssueTypeCreate($input: CreateIssueTypeInput!) {
       color
       description
       isEnabled
-      createdAt
-      updatedAt
     }
   }
 }

--- a/src/tools/issue/index.ts
+++ b/src/tools/issue/index.ts
@@ -14,6 +14,7 @@ import { registerIssueCreateTool } from "./create.js";
 import { registerIssueEditTool } from "./edit.js";
 import { registerIssueListTool } from "./list.js";
 import { registerIssueSearchTool } from "./search.js";
+import { registerIssueSetIssueTypeTool } from "./set_issue_type.js";
 import { registerIssueViewTool } from "./view.js";
 
 type RegisterToolFn = (name: string, entry: ToolEntry) => void;
@@ -29,4 +30,5 @@ export function registerIssueTools(
   registerIssueCloseTool(register, graphql);
   registerIssueCommentTool(register, graphql);
   registerIssueSearchTool(register, graphql);
+  registerIssueSetIssueTypeTool(register, graphql);
 }

--- a/src/tools/issue/set_issue_type.ts
+++ b/src/tools/issue/set_issue_type.ts
@@ -1,0 +1,139 @@
+// src/tools/issue/set_issue_type.ts
+//
+// `gh.issue_set_issue_type` — apply a native Issue Type to an
+// existing issue via the `updateIssueIssueType` GraphQL mutation.
+// Requires `admin:org` (same scope as creating the type via
+// `gh.org_issue_type_create`). The methodology calls this right
+// after `gh.issue_create` when the optional native Issue Type
+// flow is on.
+//
+// Issue ref accepts the same `(repo, number) | { node_id }` shape
+// as `gh.issue_add_sub_issue` — sourcing the node ID from
+// `gh.issue_create`'s `node_id` output skips one round-trip.
+
+import type { GraphqlClient } from "../../graphql/client.js";
+import type { ToolEntry } from "../../registry.js";
+import { validate } from "../../validation/validator.js";
+import {
+  type IssueSummary,
+  type RawIssue,
+  issueSummarySchema,
+  lookupIssueNodeId,
+  parseRepoSlug,
+  repoSlugSchema,
+  summariseIssue,
+} from "./_shared.js";
+
+// Same `oneOf` issue-ref shape as add_sub_issue: either a
+// pre-resolved node_id or a (repo, number) pair, never both.
+const issueRefSchema = {
+  type: "object",
+  properties: {
+    node_id: { type: "string", minLength: 1 },
+    repo: repoSlugSchema,
+    number: { type: "integer", minimum: 1 },
+  },
+  oneOf: [
+    {
+      required: ["node_id"],
+      not: { anyOf: [{ required: ["repo"] }, { required: ["number"] }] },
+    },
+    {
+      required: ["repo", "number"],
+      not: { required: ["node_id"] },
+    },
+  ],
+  additionalProperties: false,
+} as const;
+
+const inputSchema = {
+  type: "object",
+  required: ["issue", "issue_type_id"],
+  properties: {
+    issue: issueRefSchema,
+    issue_type_id: {
+      type: "string",
+      minLength: 1,
+      description:
+        "Issue type GraphQL node id (looks like `IT_kw...`), as " +
+        "returned by `gh.org_issue_type_create` or by " +
+        "`gh.org_issue_types_list`'s `id` field cast to the GraphQL " +
+        "form.",
+    },
+  },
+  additionalProperties: false,
+} as const;
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+interface IssueRef {
+  node_id?: string;
+  repo?: string;
+  number?: number;
+}
+
+interface Input {
+  issue: IssueRef;
+  issue_type_id: string;
+}
+
+interface SetResponse {
+  updateIssueIssueType: {
+    issue: RawIssue;
+  };
+}
+
+export function registerIssueSetIssueTypeTool(
+  register: RegisterToolFn,
+  graphql: GraphqlClient,
+): void {
+  register("gh.issue_set_issue_type", {
+    description:
+      "Apply a native Issue Type to an existing issue via the " +
+      "`updateIssueIssueType` GraphQL mutation. Requires the same " +
+      "`admin:org` scope as creating the type. Issue ref accepts " +
+      "either a pre-resolved `node_id` (from `gh.issue_create`) or " +
+      "a `(repo, number)` pair (one extra round-trip).",
+    inputSchema,
+    handler: async (raw) => {
+      const args = validate<Input>(
+        inputSchema,
+        raw,
+        "gh.issue_set_issue_type input",
+      );
+      const issueId = await resolveIssueId(graphql, args.issue);
+      const data = await graphql<SetResponse>("issue/set_issue_type", {
+        input: { issueId, issueTypeId: args.issue_type_id },
+      });
+      const summary = summariseIssue(data.updateIssueIssueType.issue);
+      return validate<IssueSummary>(
+        issueSummarySchema,
+        summary,
+        "gh.issue_set_issue_type output",
+      );
+    },
+  });
+}
+
+async function resolveIssueId(
+  graphql: GraphqlClient,
+  ref: IssueRef,
+): Promise<string> {
+  if (typeof ref.node_id === "string") {
+    return ref.node_id;
+  }
+  if (typeof ref.repo === "string" && typeof ref.number === "number") {
+    const coords = parseRepoSlug(ref.repo, "gh.issue_set_issue_type input");
+    return lookupIssueNodeId(
+      graphql,
+      coords,
+      ref.number,
+      "gh.issue_set_issue_type",
+    );
+  }
+  // Schema oneOf guards this; defensive throw mirrors the
+  // sibling pattern in add_sub_issue.
+  throw new Error(
+    `mcp-github: gh.issue_set_issue_type input: must supply either node_id or repo + number`,
+  );
+}

--- a/src/tools/issue/set_issue_type.ts
+++ b/src/tools/issue/set_issue_type.ts
@@ -7,9 +7,11 @@
 // after `gh.issue_create` when the optional native Issue Type
 // flow is on.
 //
-// Issue ref accepts the same `(repo, number) | { node_id }` shape
-// as `gh.issue_add_sub_issue` — sourcing the node ID from
-// `gh.issue_create`'s `node_id` output skips one round-trip.
+// Issue ref accepts either a pre-resolved `node_id` (one query —
+// straight to the mutation) or a `(repo, number)` pair (one
+// extra GraphQL lookup to resolve the issue's node ID). Sourcing
+// the node ID directly from `gh.issue_create`'s `node_id` output
+// skips the lookup.
 
 import type { GraphqlClient } from "../../graphql/client.js";
 import type { ToolEntry } from "../../registry.js";
@@ -24,8 +26,9 @@ import {
   summariseIssue,
 } from "./_shared.js";
 
-// Same `oneOf` issue-ref shape as add_sub_issue: either a
-// pre-resolved node_id or a (repo, number) pair, never both.
+// Issue-ref schema: either pre-resolved `node_id` or
+// `(repo, number)`, never both. `oneOf` enforces the divide so
+// a mis-shaped input fails fast at the schema boundary.
 const issueRefSchema = {
   type: "object",
   properties: {

--- a/src/tools/issue/set_issue_type.ts
+++ b/src/tools/issue/set_issue_type.ts
@@ -55,10 +55,13 @@ const inputSchema = {
       type: "string",
       minLength: 1,
       description:
-        "Issue type GraphQL node id (looks like `IT_kw...`), as " +
-        "returned by `gh.org_issue_type_create` or by " +
-        "`gh.org_issue_types_list`'s `id` field cast to the GraphQL " +
-        "form.",
+        "Issue type GraphQL node id (looks like `IT_kw...`). The " +
+        "canonical source is `gh.org_issue_type_create`'s `node_id` " +
+        "output. Note that `gh.org_issue_types_list` returns the " +
+        "REST numeric id, NOT a GraphQL node id — those are not " +
+        "interchangeable. Until a dedicated list-by-node-id helper " +
+        "lands, capture the node id at create time and cache it " +
+        "in your config.",
     },
   },
   additionalProperties: false,

--- a/src/tools/org/_shared.ts
+++ b/src/tools/org/_shared.ts
@@ -7,12 +7,16 @@
 // `label-taxonomy` flow to set canonical issue categories without
 // piggybacking on labels.
 
+import type { GraphqlClient } from "../../graphql/client.js";
+
 // JSON-Schema-shaped summary of one Issue Type as returned by the
 // REST endpoint `GET /orgs/{org}/issue-types`. The endpoint is
 // not in `@octokit/openapi-types` yet, so we describe the wire
-// format here and pin it via output validation. Fields match
-// GitHub's response 1:1 with snake_case → camelCase for the
-// nullable `is_enabled` (other names are already snake_case).
+// format here and pin it via output validation. Fields pass
+// through 1:1 from GitHub's response: `id` is numeric, `name`/
+// `description`/`color` are strings (the latter two nullable),
+// `is_enabled` is a non-nullable boolean, and the timestamps
+// are ISO-8601 strings.
 export interface IssueTypeSummary {
   id: number;
   name: string;
@@ -120,11 +124,12 @@ export function fromGraphqlColor(color: string | null): string | null {
 }
 
 // Lookup helper used by org mutations that need the
-// organisation's GraphQL node ID. The shared GraphQL client
-// handles request-level concerns; this just wraps the query in
-// a typed not-found error.
-import type { GraphqlClient } from "../../graphql/client.js";
-
+// organisation's GraphQL node ID. Resolving the org costs only
+// `read:org`; whether the *containing* tool can then mutate
+// depends on the caller's actual scope (`admin:org` for the
+// Issue Type mutations). The not-found error mentions both
+// scopes so a permissions-failure on the read or the write
+// step both surface a useful hint.
 interface OrgIdResponse {
   organization: { id: string } | null;
 }
@@ -137,7 +142,7 @@ export async function lookupOrgNodeId(
   const data = await graphql<OrgIdResponse>("org/_org-id", { login: org });
   if (!data.organization) {
     throw new Error(
-      `mcp-github: ${where}: organisation '${org}' not found or token lacks read:org access`,
+      `mcp-github: ${where}: organisation '${org}' not found, or the token lacks the required scopes (read:org to look the org up, plus admin:org for the Issue Type mutations)`,
     );
   }
   return data.organization.id;

--- a/src/tools/org/_shared.ts
+++ b/src/tools/org/_shared.ts
@@ -83,3 +83,62 @@ export const orgLoginSchema = {
   pattern: "^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$",
   description: "Organisation login (e.g. `my-org`).",
 } as const;
+
+// User-facing color values, lowercase to match the REST shape
+// returned by `gh.org_issue_types_list`. GraphQL's
+// `IssueTypeColor` enum uses the uppercase form; `toGraphqlColor`
+// converts at the boundary so the tool's user-facing API stays
+// consistent across REST + GraphQL paths.
+export const ISSUE_TYPE_COLORS = [
+  "gray",
+  "blue",
+  "green",
+  "yellow",
+  "orange",
+  "red",
+  "pink",
+  "purple",
+] as const;
+
+export type IssueTypeColor = (typeof ISSUE_TYPE_COLORS)[number];
+
+export const issueTypeColorSchema = {
+  type: "string",
+  enum: ISSUE_TYPE_COLORS,
+} as const;
+
+export function toGraphqlColor(color: IssueTypeColor): string {
+  return color.toUpperCase();
+}
+
+export function fromGraphqlColor(color: string | null): string | null {
+  // GraphQL returns uppercase enum values (`PURPLE`); normalise
+  // to the lowercase REST form so callers see a single shape
+  // regardless of which path the data came from.
+  if (color === null) return null;
+  return color.toLowerCase();
+}
+
+// Lookup helper used by org mutations that need the
+// organisation's GraphQL node ID. The shared GraphQL client
+// handles request-level concerns; this just wraps the query in
+// a typed not-found error.
+import type { GraphqlClient } from "../../graphql/client.js";
+
+interface OrgIdResponse {
+  organization: { id: string } | null;
+}
+
+export async function lookupOrgNodeId(
+  graphql: GraphqlClient,
+  org: string,
+  where: string,
+): Promise<string> {
+  const data = await graphql<OrgIdResponse>("org/_org-id", { login: org });
+  if (!data.organization) {
+    throw new Error(
+      `mcp-github: ${where}: organisation '${org}' not found or token lacks read:org access`,
+    );
+  }
+  return data.organization.id;
+}

--- a/src/tools/org/_shared.ts
+++ b/src/tools/org/_shared.ts
@@ -1,7 +1,7 @@
 // src/tools/org/_shared.ts
 //
 // Helpers shared across the gh.org_* tools. The org domain covers
-// organisation-scoped operations that don't fit under issue / pr
+// organization-scoped operations that don't fit under issue / pr
 // / label / project — at v0.1 that's just GitHub's native "Issue
 // Types" (REST + GraphQL) used by the methodology's optional
 // `label-taxonomy` flow to set canonical issue categories without
@@ -85,7 +85,7 @@ export const orgLoginSchema = {
   // leading/trailing/double hyphens. Conservative pattern
   // matches the same form the API accepts.
   pattern: "^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$",
-  description: "Organisation login (e.g. `my-org`).",
+  description: "Organization login (e.g. `my-org`).",
 } as const;
 
 // User-facing color values, lowercase to match the REST shape
@@ -124,7 +124,7 @@ export function fromGraphqlColor(color: string | null): string | null {
 }
 
 // Lookup helper used by org mutations that need the
-// organisation's GraphQL node ID. Resolving the org costs only
+// organization's GraphQL node ID. Resolving the org costs only
 // `read:org`; whether the *containing* tool can then mutate
 // depends on the caller's actual scope (`admin:org` for the
 // Issue Type mutations). The not-found error mentions both
@@ -142,7 +142,7 @@ export async function lookupOrgNodeId(
   const data = await graphql<OrgIdResponse>("org/_org-id", { login: org });
   if (!data.organization) {
     throw new Error(
-      `mcp-github: ${where}: organisation '${org}' not found, or the token lacks the required scopes (read:org to look the org up, plus admin:org for the Issue Type mutations)`,
+      `mcp-github: ${where}: organization '${org}' not found, or the token lacks the required scopes (read:org to look the org up, plus admin:org for the Issue Type mutations)`,
     );
   }
   return data.organization.id;

--- a/src/tools/org/index.ts
+++ b/src/tools/org/index.ts
@@ -3,13 +3,12 @@
 // Aggregator for the gh.org_* tools. Like the workflow group, the
 // registrar takes `authedRequest` (REST) plus `graphql` because
 // native Issue Type mutations live on GraphQL while the listing
-// endpoint is REST-only. v0.1 of this group exposes a single
-// REST list tool; the create + assign mutations (A5) layer on
-// top.
+// endpoint is REST-only.
 
 import type { AuthedRequest } from "../../auth/octokit.js";
 import type { GraphqlClient } from "../../graphql/client.js";
 import type { ToolEntry } from "../../registry.js";
+import { registerOrgIssueTypeCreateTool } from "./issue_type_create.js";
 import { registerOrgIssueTypesListTool } from "./issue_types_list.js";
 
 type RegisterToolFn = (name: string, entry: ToolEntry) => void;
@@ -17,10 +16,8 @@ type RegisterToolFn = (name: string, entry: ToolEntry) => void;
 export function registerOrgTools(
   register: RegisterToolFn,
   authedRequest: AuthedRequest,
-  // graphql is unused at the moment but the signature anticipates
-  // A5's `org_issue_type_create` GraphQL mutation. Keeping the
-  // parameter here avoids a churn-y signature change one PR later.
-  _graphql: GraphqlClient,
+  graphql: GraphqlClient,
 ): void {
   registerOrgIssueTypesListTool(register, authedRequest);
+  registerOrgIssueTypeCreateTool(register, graphql);
 }

--- a/src/tools/org/issue_type_create.ts
+++ b/src/tools/org/issue_type_create.ts
@@ -39,15 +39,19 @@ const inputSchema = {
   additionalProperties: false,
 } as const;
 
-// Output shape mirrors the GraphQL `IssueType` fields available
-// off the createIssueType mutation. Note this differs from the
-// REST `IssueTypeSummary` shape (no created_at/updated_at from
-// the mutation), so we expose a slimmer summary here.
+// Output shape mirrors the GraphQL `IssueType` fields needed by
+// callers (the node id, name, color, description, enabled flag).
+// `node_id` rather than `id` to match the naming convention used
+// by every other summary (IssueSummary.node_id, PRSummary.node_id,
+// project tools' item_id). createdAt/updatedAt are NOT exposed
+// or queried here — callers that need the timestamps should hit
+// `gh.org_issue_types_list` after creating, which is the REST
+// path that carries them.
 const outputSchema = {
   type: "object",
-  required: ["id", "name", "color", "description", "is_enabled"],
+  required: ["node_id", "name", "color", "description", "is_enabled"],
   properties: {
-    id: { type: "string" },
+    node_id: { type: "string" },
     name: { type: "string" },
     color: { type: ["string", "null"] },
     description: { type: ["string", "null"] },
@@ -67,7 +71,7 @@ interface Input {
 }
 
 interface Output {
-  id: string;
+  node_id: string;
   name: string;
   color: string | null;
   description: string | null;
@@ -96,11 +100,12 @@ export function registerOrgIssueTypeCreateTool(
     description:
       "Create a native Issue Type on an organisation via the " +
       "`createIssueType` GraphQL mutation. Requires `admin:org` " +
-      "scope. Returns the new type's GraphQL node id — capture it " +
-      "and pass to `gh.issue_set_issue_type` to apply on issues. " +
-      "Color accepts the lowercase form returned by " +
-      "`gh.org_issue_types_list` (gray, blue, green, yellow, " +
-      "orange, red, pink, purple).",
+      "scope. Returns the new type's `node_id` (GraphQL node id) — " +
+      "capture it and pass straight to the setter tool's " +
+      "`issue_type_id` input. Color accepts the lowercase form " +
+      "(gray, blue, green, yellow, orange, red, pink, purple); " +
+      "GraphQL takes the uppercase enum, which we translate at " +
+      "the boundary.",
     inputSchema,
     handler: async (raw) => {
       const args = validate<Input>(
@@ -129,7 +134,7 @@ export function registerOrgIssueTypeCreateTool(
       });
       const raw_type = data.createIssueType.issueType;
       const out: Output = {
-        id: raw_type.id,
+        node_id: raw_type.id,
         name: raw_type.name,
         color: fromGraphqlColor(raw_type.color),
         description: raw_type.description,

--- a/src/tools/org/issue_type_create.ts
+++ b/src/tools/org/issue_type_create.ts
@@ -132,13 +132,13 @@ export function registerOrgIssueTypeCreateTool(
       const data = await graphql<CreateResponse>("org/issue_type_create", {
         input,
       });
-      const raw_type = data.createIssueType.issueType;
+      const rawType = data.createIssueType.issueType;
       const out: Output = {
-        node_id: raw_type.id,
-        name: raw_type.name,
-        color: fromGraphqlColor(raw_type.color),
-        description: raw_type.description,
-        is_enabled: raw_type.isEnabled,
+        node_id: rawType.id,
+        name: rawType.name,
+        color: fromGraphqlColor(rawType.color),
+        description: rawType.description,
+        is_enabled: rawType.isEnabled,
       };
       return validate<Output>(
         outputSchema,

--- a/src/tools/org/issue_type_create.ts
+++ b/src/tools/org/issue_type_create.ts
@@ -98,7 +98,7 @@ export function registerOrgIssueTypeCreateTool(
 ): void {
   register("gh.org_issue_type_create", {
     description:
-      "Create a native Issue Type on an organisation via the " +
+      "Create a native Issue Type on an organization via the " +
       "`createIssueType` GraphQL mutation. Requires `admin:org` " +
       "scope. Returns the new type's `node_id` (GraphQL node id) — " +
       "capture it and pass straight to the setter tool's " +

--- a/src/tools/org/issue_type_create.ts
+++ b/src/tools/org/issue_type_create.ts
@@ -1,0 +1,145 @@
+// src/tools/org/issue_type_create.ts
+//
+// `gh.org_issue_type_create` — create a new native Issue Type on
+// an org via the `createIssueType` GraphQL mutation. Requires
+// `admin:org` scope. Used by the methodology's optional
+// auto-create flow (`label-taxonomy.md`) when the user wants
+// org-wide native types rather than label-based proxies.
+//
+// The user-facing color is the lowercase form (gray, blue, ...)
+// so the input shape matches what `gh.org_issue_types_list`
+// returns; the mutation requires the uppercase GraphQL enum, so
+// we translate at the boundary via `toGraphqlColor`.
+
+import type { GraphqlClient } from "../../graphql/client.js";
+import type { ToolEntry } from "../../registry.js";
+import { validate } from "../../validation/validator.js";
+import {
+  type IssueTypeColor,
+  fromGraphqlColor,
+  issueTypeColorSchema,
+  lookupOrgNodeId,
+  orgLoginSchema,
+  toGraphqlColor,
+} from "./_shared.js";
+
+const inputSchema = {
+  type: "object",
+  required: ["org", "name"],
+  properties: {
+    org: orgLoginSchema,
+    name: { type: "string", minLength: 1 },
+    color: issueTypeColorSchema,
+    description: { type: "string" },
+    is_enabled: {
+      type: "boolean",
+      description: "Default true; pass false to create a disabled type.",
+    },
+  },
+  additionalProperties: false,
+} as const;
+
+// Output shape mirrors the GraphQL `IssueType` fields available
+// off the createIssueType mutation. Note this differs from the
+// REST `IssueTypeSummary` shape (no created_at/updated_at from
+// the mutation), so we expose a slimmer summary here.
+const outputSchema = {
+  type: "object",
+  required: ["id", "name", "color", "description", "is_enabled"],
+  properties: {
+    id: { type: "string" },
+    name: { type: "string" },
+    color: { type: ["string", "null"] },
+    description: { type: ["string", "null"] },
+    is_enabled: { type: "boolean" },
+  },
+  additionalProperties: false,
+} as const;
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+interface Input {
+  org: string;
+  name: string;
+  color?: IssueTypeColor;
+  description?: string;
+  is_enabled?: boolean;
+}
+
+interface Output {
+  id: string;
+  name: string;
+  color: string | null;
+  description: string | null;
+  is_enabled: boolean;
+}
+
+interface RawIssueTypeNode {
+  id: string;
+  name: string;
+  color: string | null;
+  description: string | null;
+  isEnabled: boolean;
+}
+
+interface CreateResponse {
+  createIssueType: {
+    issueType: RawIssueTypeNode;
+  };
+}
+
+export function registerOrgIssueTypeCreateTool(
+  register: RegisterToolFn,
+  graphql: GraphqlClient,
+): void {
+  register("gh.org_issue_type_create", {
+    description:
+      "Create a native Issue Type on an organisation via the " +
+      "`createIssueType` GraphQL mutation. Requires `admin:org` " +
+      "scope. Returns the new type's GraphQL node id — capture it " +
+      "and pass to `gh.issue_set_issue_type` to apply on issues. " +
+      "Color accepts the lowercase form returned by " +
+      "`gh.org_issue_types_list` (gray, blue, green, yellow, " +
+      "orange, red, pink, purple).",
+    inputSchema,
+    handler: async (raw) => {
+      const args = validate<Input>(
+        inputSchema,
+        raw,
+        "gh.org_issue_type_create input",
+      );
+      const ownerId = await lookupOrgNodeId(
+        graphql,
+        args.org,
+        "gh.org_issue_type_create",
+      );
+      // Build the mutation input incrementally so unset fields
+      // stay absent rather than serialised as explicit null,
+      // which GraphQL rejects on optional-of-strict-string
+      // fields.
+      const input: Record<string, unknown> = {
+        ownerId,
+        name: args.name,
+      };
+      if (args.color !== undefined) input.color = toGraphqlColor(args.color);
+      if (args.description !== undefined) input.description = args.description;
+      if (args.is_enabled !== undefined) input.isEnabled = args.is_enabled;
+      const data = await graphql<CreateResponse>("org/issue_type_create", {
+        input,
+      });
+      const raw_type = data.createIssueType.issueType;
+      const out: Output = {
+        id: raw_type.id,
+        name: raw_type.name,
+        color: fromGraphqlColor(raw_type.color),
+        description: raw_type.description,
+        is_enabled: raw_type.isEnabled,
+      };
+      return validate<Output>(
+        outputSchema,
+        out,
+        "gh.org_issue_type_create output",
+      );
+    },
+  });
+}

--- a/src/tools/org/issue_types_list.ts
+++ b/src/tools/org/issue_types_list.ts
@@ -60,8 +60,15 @@ export function registerOrgIssueTypesListTool(
     description:
       "List native Issue Types configured on an organization. " +
       "Requires `read:org` (and the org must have native Issue " +
-      "Types enabled). Returns the type's numeric id used by " +
-      "`gh.issue_set_issue_type` to apply it to an issue.",
+      "Types enabled). Returns each type's REST numeric `id`, " +
+      "name, description, color, enabled flag, and ISO-8601 " +
+      "timestamps. Note: this REST `id` is NOT a GraphQL node " +
+      "id and is NOT what `gh.issue_set_issue_type` consumes — " +
+      "the setter takes a GraphQL node id (looks like `IT_kw…`) " +
+      "which is only returned by `gh.org_issue_type_create.node_id`. " +
+      "Capture and cache the node id at create time; the REST " +
+      "id surfaced here is for human / catalog use, not for " +
+      "assignment.",
     inputSchema,
     handler: async (raw) => {
       const args = validate<Input>(

--- a/src/tools/org/issue_types_list.ts
+++ b/src/tools/org/issue_types_list.ts
@@ -58,7 +58,7 @@ export function registerOrgIssueTypesListTool(
 ): void {
   register("gh.org_issue_types_list", {
     description:
-      "List native Issue Types configured on an organisation. " +
+      "List native Issue Types configured on an organization. " +
       "Requires `read:org` (and the org must have native Issue " +
       "Types enabled). Returns the type's numeric id used by " +
       "`gh.issue_set_issue_type` to apply it to an issue.",

--- a/tests/smoke/server-lists-tools.mjs
+++ b/tests/smoke/server-lists-tools.mjs
@@ -9,9 +9,10 @@
 // + tool registration chain end-to-end without pulling in the
 // unit-test framework.
 //
-// Current surface: 1 auth probe (`gh.test_connection` from MCP-2)
-// + 7 issue tools (MCP-4) + 4 label tools (MCP-7) + 7 PR tools
-// (MCP-5 + MCP-6, the latter adding `gh.pr_request_reviews`).
+// The EXPECTED_TOOLS array below is the authoritative list of
+// the current tool surface; this header used to also carry a
+// human-readable count, but that drifted on every PR. Read the
+// array if you want the current set.
 //
 // Wire format: the MCP SDK's StdioServerTransport uses newline-
 // delimited JSON-RPC (one JSON message per `\n`-terminated line),

--- a/tests/smoke/server-lists-tools.mjs
+++ b/tests/smoke/server-lists-tools.mjs
@@ -58,6 +58,9 @@ const EXPECTED_TOOLS = [
   "gh.workflow_run_view",
   "gh.workflow_run_cancel",
   "gh.workflow_run_jobs",
+  "gh.org_issue_types_list",
+  "gh.org_issue_type_create",
+  "gh.issue_set_issue_type",
 ];
 
 function frame(payload) {

--- a/tests/unit/tools/issue/set_issue_type.test.ts
+++ b/tests/unit/tools/issue/set_issue_type.test.ts
@@ -1,0 +1,95 @@
+// tests/unit/tools/issue/set_issue_type.test.ts
+//
+// gh.issue_set_issue_type: pin the (repo, number) vs node_id
+// resolution paths, the updateIssueIssueType mutation input
+// shape, and the schema's rejection of mixed input shapes.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { registerIssueSetIssueTypeTool } from "../../../../src/tools/issue/set_issue_type.ts";
+import type { ToolEntry } from "../../../../src/registry.ts";
+import { sampleRawIssue, stubGraphqlClient } from "./_fixtures.ts";
+
+function captureRegistration() {
+  let entry: ToolEntry | undefined;
+  const register = (name: string, e: ToolEntry) => {
+    if (name !== "gh.issue_set_issue_type") {
+      throw new Error(`unexpected: ${name}`);
+    }
+    entry = e;
+  };
+  return {
+    register,
+    get entry(): ToolEntry {
+      if (!entry) throw new Error("not registered");
+      return entry;
+    },
+  };
+}
+
+test("gh.issue_set_issue_type: node_id passes through → one mutation call", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "issue/set_issue_type": (vars: Record<string, unknown>) => {
+      const input = vars.input as Record<string, unknown>;
+      assert.equal(input.issueId, "I_pre");
+      assert.equal(input.issueTypeId, "IT_kw_1");
+      return { updateIssueIssueType: { issue: sampleRawIssue } };
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueSetIssueTypeTool(reg.register, graphql);
+  const out = (await reg.entry.handler({
+    issue: { node_id: "I_pre" },
+    issue_type_id: "IT_kw_1",
+  })) as { number: number };
+  assert.equal(out.number, 42);
+  assert.equal(calls.length, 1);
+});
+
+test("gh.issue_set_issue_type: (repo, number) triggers a node-id lookup first", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "issue/_issue-lookup": () => ({
+      repository: { issue: { id: "I_resolved" } },
+    }),
+    "issue/set_issue_type": (vars: Record<string, unknown>) => {
+      const input = vars.input as Record<string, unknown>;
+      assert.equal(input.issueId, "I_resolved");
+      assert.equal(input.issueTypeId, "IT_kw_1");
+      return { updateIssueIssueType: { issue: sampleRawIssue } };
+    },
+  });
+  const reg = captureRegistration();
+  registerIssueSetIssueTypeTool(reg.register, graphql);
+  await reg.entry.handler({
+    issue: { repo: "owner/repo", number: 42 },
+    issue_type_id: "IT_kw_1",
+  });
+  assert.deepEqual(
+    calls.map((c) => c.queryName),
+    ["issue/_issue-lookup", "issue/set_issue_type"],
+  );
+});
+
+test("gh.issue_set_issue_type: rejects mixing node_id with (repo, number) at the input boundary", async () => {
+  const { graphql } = stubGraphqlClient({});
+  const reg = captureRegistration();
+  registerIssueSetIssueTypeTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      issue: { node_id: "I_x", repo: "owner/repo", number: 42 },
+      issue_type_id: "IT_kw_1",
+    }),
+    /gh\.issue_set_issue_type input/,
+  );
+});
+
+test("gh.issue_set_issue_type: rejects missing issue_type_id at the input boundary", async () => {
+  const { graphql } = stubGraphqlClient({});
+  const reg = captureRegistration();
+  registerIssueSetIssueTypeTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ issue: { node_id: "I_x" } }),
+    /gh\.issue_set_issue_type input/,
+  );
+});

--- a/tests/unit/tools/org/issue_type_create.test.ts
+++ b/tests/unit/tools/org/issue_type_create.test.ts
@@ -1,0 +1,142 @@
+// tests/unit/tools/org/issue_type_create.test.ts
+//
+// gh.org_issue_type_create: pin the org-id lookup → createIssueType
+// flow, the lowercase ↔ uppercase color translation at the
+// boundary, the optional-field passthrough behaviour, and the
+// schema's rejection of unknown colors.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { registerOrgIssueTypeCreateTool } from "../../../../src/tools/org/issue_type_create.ts";
+import type { ToolEntry } from "../../../../src/registry.ts";
+import { stubGraphqlClient } from "./_fixtures.ts";
+
+function captureRegistration() {
+  let entry: ToolEntry | undefined;
+  const register = (name: string, e: ToolEntry) => {
+    if (name !== "gh.org_issue_type_create") {
+      throw new Error(`unexpected: ${name}`);
+    }
+    entry = e;
+  };
+  return {
+    register,
+    get entry(): ToolEntry {
+      if (!entry) throw new Error("not registered");
+      return entry;
+    },
+  };
+}
+
+test("gh.org_issue_type_create: org-id lookup → createIssueType with mapped color", async () => {
+  const { graphql, calls } = stubGraphqlClient({
+    "org/_org-id": (vars: Record<string, unknown>) => {
+      assert.equal(vars.login, "my-org");
+      return { organization: { id: "O_org" } };
+    },
+    "org/issue_type_create": (vars: Record<string, unknown>) => {
+      const input = vars.input as Record<string, unknown>;
+      assert.equal(input.ownerId, "O_org");
+      assert.equal(input.name, "Epic");
+      // Lowercase user input → uppercase GraphQL enum.
+      assert.equal(input.color, "PURPLE");
+      assert.equal(input.description, "Top-level mission");
+      assert.equal(input.isEnabled, true);
+      return {
+        createIssueType: {
+          issueType: {
+            id: "IT_kw_1",
+            name: "Epic",
+            color: "PURPLE",
+            description: "Top-level mission",
+            isEnabled: true,
+          },
+        },
+      };
+    },
+  });
+  const reg = captureRegistration();
+  registerOrgIssueTypeCreateTool(reg.register, graphql);
+  const out = (await reg.entry.handler({
+    org: "my-org",
+    name: "Epic",
+    color: "purple",
+    description: "Top-level mission",
+    is_enabled: true,
+  })) as { id: string; color: string | null; name: string; is_enabled: boolean };
+  // Output color normalised back to lowercase.
+  assert.deepEqual(out, {
+    id: "IT_kw_1",
+    name: "Epic",
+    color: "purple",
+    description: "Top-level mission",
+    is_enabled: true,
+  });
+  assert.equal(calls.length, 2);
+});
+
+test("gh.org_issue_type_create: omits color / description / is_enabled when not supplied", async () => {
+  const { graphql } = stubGraphqlClient({
+    "org/_org-id": () => ({ organization: { id: "O_org" } }),
+    "org/issue_type_create": (vars: Record<string, unknown>) => {
+      const input = vars.input as Record<string, unknown>;
+      // Optional fields STAY absent rather than serialised as
+      // explicit undefined / null (GraphQL would reject).
+      assert.equal("color" in input, false);
+      assert.equal("description" in input, false);
+      assert.equal("isEnabled" in input, false);
+      return {
+        createIssueType: {
+          issueType: {
+            id: "IT_kw_2",
+            name: "Bare",
+            color: null,
+            description: null,
+            isEnabled: true,
+          },
+        },
+      };
+    },
+  });
+  const reg = captureRegistration();
+  registerOrgIssueTypeCreateTool(reg.register, graphql);
+  const out = (await reg.entry.handler({ org: "my-org", name: "Bare" })) as {
+    color: string | null;
+    description: string | null;
+  };
+  assert.equal(out.color, null);
+  assert.equal(out.description, null);
+});
+
+test("gh.org_issue_type_create: org-not-found surfaces a structured error", async () => {
+  const { graphql } = stubGraphqlClient({
+    "org/_org-id": () => ({ organization: null }),
+  });
+  const reg = captureRegistration();
+  registerOrgIssueTypeCreateTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ org: "my-org", name: "Epic" }),
+    /organisation 'my-org' not found/,
+  );
+});
+
+test("gh.org_issue_type_create: rejects an unknown color enum at the input boundary", async () => {
+  const { graphql } = stubGraphqlClient({});
+  const reg = captureRegistration();
+  registerOrgIssueTypeCreateTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ org: "my-org", name: "Epic", color: "magenta" }),
+    /gh\.org_issue_type_create input/,
+  );
+});
+
+test("gh.org_issue_type_create: rejects empty name at the input boundary", async () => {
+  const { graphql } = stubGraphqlClient({});
+  const reg = captureRegistration();
+  registerOrgIssueTypeCreateTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ org: "my-org", name: "" }),
+    /gh\.org_issue_type_create input/,
+  );
+});

--- a/tests/unit/tools/org/issue_type_create.test.ts
+++ b/tests/unit/tools/org/issue_type_create.test.ts
@@ -123,7 +123,7 @@ test("gh.org_issue_type_create: org-not-found surfaces a structured error", asyn
   registerOrgIssueTypeCreateTool(reg.register, graphql);
   await assert.rejects(
     reg.entry.handler({ org: "my-org", name: "Epic" }),
-    /organisation 'my-org' not found/,
+    /organization 'my-org' not found/,
   );
 });
 

--- a/tests/unit/tools/org/issue_type_create.test.ts
+++ b/tests/unit/tools/org/issue_type_create.test.ts
@@ -64,10 +64,16 @@ test("gh.org_issue_type_create: org-id lookup → createIssueType with mapped co
     color: "purple",
     description: "Top-level mission",
     is_enabled: true,
-  })) as { id: string; color: string | null; name: string; is_enabled: boolean };
-  // Output color normalised back to lowercase.
+  })) as {
+    node_id: string;
+    color: string | null;
+    name: string;
+    is_enabled: boolean;
+  };
+  // Output color normalised back to lowercase; id key is
+  // `node_id` to match the convention on other summaries.
   assert.deepEqual(out, {
-    id: "IT_kw_1",
+    node_id: "IT_kw_1",
     name: "Epic",
     color: "purple",
     description: "Top-level mission",


### PR DESCRIPTION
## Summary
- Stacked on top of #30 (A4). Two GraphQL mutations for native Issue Types (`admin:org` scope).
- `gh.org_issue_type_create`: `createIssueType` mutation — resolves the org's GraphQL node id internally via `org/_org-id`. Color stays lowercase on the user-facing API; `toGraphqlColor`/`fromGraphqlColor` translate at the boundary because the GraphQL `IssueTypeColor` enum uses uppercase (GRAY / BLUE / GREEN / YELLOW / ORANGE / RED / PINK / PURPLE).
- `gh.issue_set_issue_type`: `updateIssueIssueType` mutation. Issue ref accepts either a pre-resolved `node_id` (from `gh.issue_create.node_id`) or a `(repo, number)` pair (one extra round-trip), mirroring `gh.issue_add_sub_issue`.
- Closes the methodology's `label-taxonomy.md` GraphQL escape-hatch usage.

## Test plan
- [x] `npm run lint`
- [x] `npm test` — 9 new unit tests pin: org-id lookup + color enum translation; optional-field omission (color/description/isEnabled stay absent rather than serialised as null); org-not-found error; unknown color enum + empty name rejection; both ref-input paths on `set_issue_type`; mutation input shape; mixed-shape and missing-field schema rejection.

## Merge order
This stacks on #30 (A4). Merge #30 first, then this rebases onto main and merges.