### PR TITLE
feat: wait_for_mergeable polling on gh.pr_view (A9)

### DIFF
--- a/src/tools/pr/view.ts
+++ b/src/tools/pr/view.ts
@@ -92,30 +92,43 @@ interface Response {
   repository: { pullRequest: RawPR | null } | null;
 }
 
-// Sleeper injection-point lets the unit tests advance fake time
-// without an actual setTimeout. Production path uses the default;
-// tests override via the exported `_setSleeper`.
+// Sleeper + clock injection-points let the unit tests advance
+// fake time without real setTimeout / Date.now. Both have a
+// single source-of-truth default (defined once, referenced from
+// both the initial binding and the reset-to-null path of the
+// `_set*` hook) and both `let` bindings start at the default.
+// The `_set*` hooks below are MODULE-INTERNAL TEST HOOKS — the
+// `_` prefix follows the same convention used by other tools
+// (`_readReviewRequestsOff`, `_resetQueryCache`); they are not
+// part of the package's public API and the test file uses them
+// inside `try { ... } finally { _setX(null); }` blocks so each
+// test restores the defaults before the next runs.
+//
+// Concurrency note: Node's `--test` runs files concurrently but
+// tests WITHIN a file serially, which matches the assumption
+// these module-level hooks rely on. If we ever fan tests out
+// to parallel `test.concurrent(...)`, switch to closure-scoped
+// dependency injection via `registerPRViewTool`.
 type Sleeper = (ms: number) => Promise<void>;
-let sleeper: Sleeper = (ms) =>
+type Clock = () => number;
+
+const defaultSleeper: Sleeper = (ms) =>
   new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
+const defaultClock: Clock = () => Date.now();
 
+let sleeper: Sleeper = defaultSleeper;
+let clock: Clock = defaultClock;
+
+/** @internal — test-only hook; do not import from outside tests/. */
 export function _setSleeper(s: Sleeper | null): void {
-  sleeper = s ?? ((ms) =>
-    new Promise((resolve) => {
-      setTimeout(resolve, ms);
-    }));
+  sleeper = s ?? defaultSleeper;
 }
 
-// Clock injection-point for the wall-clock budget. Defaulting to
-// `Date.now` keeps prod fast; tests override to advance time
-// deterministically alongside the sleeper.
-type Clock = () => number;
-let clock: Clock = () => Date.now();
-
+/** @internal — test-only hook; do not import from outside tests/. */
 export function _setClock(c: Clock | null): void {
-  clock = c ?? (() => Date.now());
+  clock = c ?? defaultClock;
 }
 
 export function registerPRViewTool(
@@ -170,13 +183,17 @@ async function fetchWithOptionalWait(
       POLL_INTERVAL_DEFAULT_SECONDS) * 1000;
   const deadline = clock() + timeoutMs;
   let lastRaw = firstRaw;
-  while (clock() < deadline) {
+  // Capture `now` once per iteration so we only call `clock()`
+  // a single time per pass — easier to reason about under
+  // injected clocks, and consistent across the three comparisons
+  // the loop body does.
+  for (let now = clock(); now < deadline; now = clock()) {
     // Sleep BEFORE re-querying so we don't hammer the API on the
     // first iteration — the initial fetch already used the
     // current state. Cap the sleep at the remaining budget so a
     // 30s timeout with a 25s interval doesn't wait the full 25s
     // past the deadline.
-    const remaining = deadline - clock();
+    const remaining = deadline - now;
     if (remaining <= 0) break;
     await sleeper(Math.min(intervalMs, remaining));
     // Re-check the deadline AFTER sleeping. The sleep may have

--- a/src/tools/pr/view.ts
+++ b/src/tools/pr/view.ts
@@ -33,6 +33,12 @@ import {
   summarisePR,
 } from "./_shared.js";
 
+// The polling path holds onto the RawPR and summarises only
+// once at the very end (see fetchWithOptionalWait below), so the
+// truncation-warning side effect fires exactly once per tool
+// call rather than once per retry. Matches the methodology's
+// "agent gets one signal per op" expectation.
+
 const WAIT_TIMEOUT_DEFAULT_SECONDS = 30;
 const WAIT_TIMEOUT_MAX_SECONDS = 120;
 const POLL_INTERVAL_DEFAULT_SECONDS = 5;
@@ -141,12 +147,20 @@ async function fetchWithOptionalWait(
   coords: { owner: string; name: string },
   args: Input,
 ): Promise<PRSummary> {
-  const first = await fetchOnce(graphql, coords, args.number);
-  if (
-    args.wait_for_mergeable === undefined ||
-    first.mergeable !== "UNKNOWN"
-  ) {
-    return first;
+  // Fast path: no polling. Summarise with the default warn so
+  // truncation hints land normally.
+  if (args.wait_for_mergeable === undefined) {
+    const raw = await fetchRawOnce(graphql, coords, args.number);
+    return summarisePR(raw);
+  }
+  // Polling path: every intermediate fetch suppresses warnings
+  // (otherwise the same truncation message would spam stderr
+  // once per retry); the FINAL returned payload re-summarises
+  // with the default warn, so the user sees the truncation hint
+  // exactly once per tool call.
+  const firstRaw = await fetchRawOnce(graphql, coords, args.number);
+  if (firstRaw.mergeable !== "UNKNOWN") {
+    return summarisePR(firstRaw);
   }
   const timeoutMs =
     (args.wait_for_mergeable.timeout_seconds ??
@@ -155,7 +169,7 @@ async function fetchWithOptionalWait(
     (args.wait_for_mergeable.poll_interval_seconds ??
       POLL_INTERVAL_DEFAULT_SECONDS) * 1000;
   const deadline = clock() + timeoutMs;
-  let last = first;
+  let lastRaw = firstRaw;
   while (clock() < deadline) {
     // Sleep BEFORE re-querying so we don't hammer the API on the
     // first iteration — the initial fetch already used the
@@ -171,19 +185,23 @@ async function fetchWithOptionalWait(
     // wall-clock time) after the budget is gone, exceeding the
     // documented `timeout_seconds` ceiling.
     if (clock() >= deadline) break;
-    last = await fetchOnce(graphql, coords, args.number);
-    if (last.mergeable !== "UNKNOWN") return last;
+    lastRaw = await fetchRawOnce(graphql, coords, args.number);
+    if (lastRaw.mergeable !== "UNKNOWN") return summarisePR(lastRaw);
   }
-  // Timeout: return the last payload as-is. mergeable stays
-  // UNKNOWN; caller decides whether to retry the whole tool call.
-  return last;
+  // Timeout: summarise the last payload (mergeable stays
+  // UNKNOWN). Use the default warn so any truncation hint fires
+  // exactly once — the intermediate retries suppressed it.
+  // Reset the per-payload warn by re-summarising via a fresh
+  // call rather than re-using a stale summary; cheaper than
+  // tracking warn state.
+  return summarisePR(lastRaw);
 }
 
-async function fetchOnce(
+async function fetchRawOnce(
   graphql: GraphqlClient,
   coords: { owner: string; name: string },
   number: number,
-): Promise<PRSummary> {
+): Promise<RawPR> {
   const data = await graphql<Response>("pr/view", {
     owner: coords.owner,
     name: coords.name,
@@ -203,5 +221,8 @@ async function fetchOnce(
       `mcp-github: gh.pr_view: PR ${coords.owner}/${coords.name}#${number} not found`,
     );
   }
-  return summarisePR(pr);
+  // Return the raw payload; summarisePR runs once at the end of
+  // fetchWithOptionalWait so the truncation-warning side effect
+  // fires exactly once per tool call (even when polling).
+  return pr;
 }

--- a/src/tools/pr/view.ts
+++ b/src/tools/pr/view.ts
@@ -165,6 +165,12 @@ async function fetchWithOptionalWait(
     const remaining = deadline - clock();
     if (remaining <= 0) break;
     await sleeper(Math.min(intervalMs, remaining));
+    // Re-check the deadline AFTER sleeping. The sleep may have
+    // consumed the entire remaining budget; without this guard
+    // we'd kick off another GraphQL fetch (which itself takes
+    // wall-clock time) after the budget is gone, exceeding the
+    // documented `timeout_seconds` ceiling.
+    if (clock() >= deadline) break;
     last = await fetchOnce(graphql, coords, args.number);
     if (last.mergeable !== "UNKNOWN") return last;
   }

--- a/src/tools/pr/view.ts
+++ b/src/tools/pr/view.ts
@@ -8,6 +8,18 @@
 // `{merged, sha, url, number}` shape because the merge mutation
 // only guarantees those fields and a full re-fetch would be
 // wasted work.
+//
+// Optional `wait_for_mergeable` polling (A9): GitHub returns
+// `mergeable: UNKNOWN` for a short window after a push while it
+// computes the mergeability state in the background. The
+// methodology's PR loop needs the resolved value to decide
+// whether to merge or ask the user to rebase; rather than making
+// the agent poll, this tool owns the cadence — when
+// `wait_for_mergeable` is supplied, it re-runs the query at
+// `poll_interval_seconds` intervals until `mergeable !=
+// "UNKNOWN"` or the timeout fires. On timeout the last payload
+// is returned as-is (still `UNKNOWN`); the caller decides whether
+// to retry the whole tool call or proceed.
 
 import type { GraphqlClient } from "../../graphql/client.js";
 import type { ToolEntry } from "../../registry.js";
@@ -21,12 +33,40 @@ import {
   summarisePR,
 } from "./_shared.js";
 
+const WAIT_TIMEOUT_DEFAULT_SECONDS = 30;
+const WAIT_TIMEOUT_MAX_SECONDS = 120;
+const POLL_INTERVAL_DEFAULT_SECONDS = 5;
+const POLL_INTERVAL_MIN_SECONDS = 1;
+const POLL_INTERVAL_MAX_SECONDS = 30;
+
+const waitForMergeableSchema = {
+  type: "object",
+  properties: {
+    timeout_seconds: {
+      type: "integer",
+      minimum: 1,
+      maximum: WAIT_TIMEOUT_MAX_SECONDS,
+      description:
+        `Max wall-clock seconds to spend polling (default ${WAIT_TIMEOUT_DEFAULT_SECONDS}, max ${WAIT_TIMEOUT_MAX_SECONDS}).`,
+    },
+    poll_interval_seconds: {
+      type: "integer",
+      minimum: POLL_INTERVAL_MIN_SECONDS,
+      maximum: POLL_INTERVAL_MAX_SECONDS,
+      description:
+        `Seconds between retries (default ${POLL_INTERVAL_DEFAULT_SECONDS}, min ${POLL_INTERVAL_MIN_SECONDS}, max ${POLL_INTERVAL_MAX_SECONDS}).`,
+    },
+  },
+  additionalProperties: false,
+} as const;
+
 const inputSchema = {
   type: "object",
   required: ["repo", "number"],
   properties: {
     repo: repoSlugSchema,
     number: { type: "integer", minimum: 1 },
+    wait_for_mergeable: waitForMergeableSchema,
   },
   additionalProperties: false,
 } as const;
@@ -36,10 +76,40 @@ type RegisterToolFn = (name: string, entry: ToolEntry) => void;
 interface Input {
   repo: string;
   number: number;
+  wait_for_mergeable?: {
+    timeout_seconds?: number;
+    poll_interval_seconds?: number;
+  };
 }
 
 interface Response {
   repository: { pullRequest: RawPR | null } | null;
+}
+
+// Sleeper injection-point lets the unit tests advance fake time
+// without an actual setTimeout. Production path uses the default;
+// tests override via the exported `_setSleeper`.
+type Sleeper = (ms: number) => Promise<void>;
+let sleeper: Sleeper = (ms) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+export function _setSleeper(s: Sleeper | null): void {
+  sleeper = s ?? ((ms) =>
+    new Promise((resolve) => {
+      setTimeout(resolve, ms);
+    }));
+}
+
+// Clock injection-point for the wall-clock budget. Defaulting to
+// `Date.now` keeps prod fast; tests override to advance time
+// deterministically alongside the sleeper.
+type Clock = () => number;
+let clock: Clock = () => Date.now();
+
+export function _setClock(c: Clock | null): void {
+  clock = c ?? (() => Date.now());
 }
 
 export function registerPRViewTool(
@@ -50,32 +120,82 @@ export function registerPRViewTool(
     description:
       "Fetch a PR with reviews, review-comment count, and " +
       "status-checks summary. Returns the canonical PRSummary " +
-      "shape used by every PR tool that produces a full payload.",
+      "shape used by every PR tool that produces a full payload. " +
+      "Optional `wait_for_mergeable`: re-runs the query at " +
+      "`poll_interval_seconds` intervals until `mergeable != UNKNOWN` " +
+      "or `timeout_seconds` elapses; on timeout the last payload " +
+      "is returned regardless (mergeable still UNKNOWN), so the " +
+      "caller has a final answer rather than a hang.",
     inputSchema,
     handler: async (raw) => {
       const args = validate<Input>(inputSchema, raw, "gh.pr_view input");
       const coords = parseRepoSlug(args.repo, "gh.pr_view input");
-      const data = await graphql<Response>("pr/view", {
-        owner: coords.owner,
-        name: coords.name,
-        number: args.number,
-      });
-      // Distinguish "repo missing / no access" from "PR missing" so
-      // a typo in the slug doesn't surface as a misleading
-      // "PR not found" message.
-      if (!data.repository) {
-        throw new Error(
-          `mcp-github: gh.pr_view: repository '${coords.owner}/${coords.name}' not found or token lacks read access`,
-        );
-      }
-      const pr = data.repository.pullRequest;
-      if (!pr) {
-        throw new Error(
-          `mcp-github: gh.pr_view: PR ${coords.owner}/${coords.name}#${args.number} not found`,
-        );
-      }
-      const summary = summarisePR(pr);
+      const summary = await fetchWithOptionalWait(graphql, coords, args);
       return validate<PRSummary>(prSummarySchema, summary, "gh.pr_view output");
     },
   });
+}
+
+async function fetchWithOptionalWait(
+  graphql: GraphqlClient,
+  coords: { owner: string; name: string },
+  args: Input,
+): Promise<PRSummary> {
+  const first = await fetchOnce(graphql, coords, args.number);
+  if (
+    args.wait_for_mergeable === undefined ||
+    first.mergeable !== "UNKNOWN"
+  ) {
+    return first;
+  }
+  const timeoutMs =
+    (args.wait_for_mergeable.timeout_seconds ??
+      WAIT_TIMEOUT_DEFAULT_SECONDS) * 1000;
+  const intervalMs =
+    (args.wait_for_mergeable.poll_interval_seconds ??
+      POLL_INTERVAL_DEFAULT_SECONDS) * 1000;
+  const deadline = clock() + timeoutMs;
+  let last = first;
+  while (clock() < deadline) {
+    // Sleep BEFORE re-querying so we don't hammer the API on the
+    // first iteration — the initial fetch already used the
+    // current state. Cap the sleep at the remaining budget so a
+    // 30s timeout with a 25s interval doesn't wait the full 25s
+    // past the deadline.
+    const remaining = deadline - clock();
+    if (remaining <= 0) break;
+    await sleeper(Math.min(intervalMs, remaining));
+    last = await fetchOnce(graphql, coords, args.number);
+    if (last.mergeable !== "UNKNOWN") return last;
+  }
+  // Timeout: return the last payload as-is. mergeable stays
+  // UNKNOWN; caller decides whether to retry the whole tool call.
+  return last;
+}
+
+async function fetchOnce(
+  graphql: GraphqlClient,
+  coords: { owner: string; name: string },
+  number: number,
+): Promise<PRSummary> {
+  const data = await graphql<Response>("pr/view", {
+    owner: coords.owner,
+    name: coords.name,
+    number,
+  });
+  // Distinguish "repo missing / no access" from "PR missing" so
+  // a typo in the slug doesn't surface as a misleading
+  // "PR not found" message.
+  if (!data.repository) {
+    throw new Error(
+      `mcp-github: gh.pr_view: repository '${coords.owner}/${coords.name}' not found or token lacks read access`,
+    );
+  }
+  const pr = data.repository.pullRequest;
+  if (!pr) {
+    throw new Error(
+      `mcp-github: gh.pr_view: PR ${coords.owner}/${coords.name}#${number} not found`,
+    );
+  }
+  return summarisePR(pr);
 }

--- a/tests/smoke/server-lists-tools.mjs
+++ b/tests/smoke/server-lists-tools.mjs
@@ -9,9 +9,10 @@
 // + tool registration chain end-to-end without pulling in the
 // unit-test framework.
 //
-// Current surface: 1 auth probe (`gh.test_connection` from MCP-2)
-// + 7 issue tools (MCP-4) + 4 label tools (MCP-7) + 7 PR tools
-// (MCP-5 + MCP-6, the latter adding `gh.pr_request_reviews`).
+// The EXPECTED_TOOLS array below is the authoritative list of
+// the current tool surface; this header used to also carry a
+// human-readable count, but that drifted on every PR. Read the
+// array if you want the current set.
 //
 // Wire format: the MCP SDK's StdioServerTransport uses newline-
 // delimited JSON-RPC (one JSON message per `\n`-terminated line),

--- a/tests/unit/tools/pr/view.test.ts
+++ b/tests/unit/tools/pr/view.test.ts
@@ -7,7 +7,11 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { registerPRViewTool } from "../../../../src/tools/pr/view.ts";
+import {
+  _setClock,
+  _setSleeper,
+  registerPRViewTool,
+} from "../../../../src/tools/pr/view.ts";
 import type { ToolEntry } from "../../../../src/registry.ts";
 import { sampleRawPR, stubGraphqlClient } from "./_fixtures.ts";
 
@@ -205,6 +209,155 @@ test("gh.pr_view: PENDING review with null submittedAt passes through as null", 
   };
   assert.equal(out.reviews[0]?.state, "PENDING");
   assert.equal(out.reviews[0]?.submitted_at, null);
+});
+
+// Build a deterministic test clock + sleeper that advance virtual
+// time on each sleep. Used by the wait_for_mergeable tests so the
+// suite doesn't actually wait 5+ seconds per case.
+function makeFakeTimeControls(initialMs = 1_000_000) {
+  let now = initialMs;
+  const sleeper = async (ms: number) => {
+    now += ms;
+  };
+  const clock = () => now;
+  return { sleeper, clock };
+}
+
+test("gh.pr_view: wait_for_mergeable polls until mergeable resolves, then returns", async () => {
+  const { sleeper, clock } = makeFakeTimeControls();
+  _setSleeper(sleeper);
+  _setClock(clock);
+  try {
+    let call = 0;
+    const { graphql, calls } = stubGraphqlClient({
+      "pr/view": () => {
+        call += 1;
+        // Calls 1+2 return UNKNOWN; call 3 returns MERGEABLE.
+        const mergeable = call < 3 ? "UNKNOWN" : "MERGEABLE";
+        return {
+          repository: { pullRequest: { ...sampleRawPR, mergeable } },
+        };
+      },
+    });
+    const reg = captureRegistration();
+    registerPRViewTool(reg.register, graphql);
+    const out = (await reg.entry.handler({
+      repo: "owner/repo",
+      number: 7,
+      wait_for_mergeable: { timeout_seconds: 30, poll_interval_seconds: 5 },
+    })) as { mergeable: string };
+    assert.equal(out.mergeable, "MERGEABLE");
+    // 3 GraphQL calls: initial + 2 retries.
+    assert.equal(calls.length, 3);
+  } finally {
+    _setSleeper(null);
+    _setClock(null);
+  }
+});
+
+test("gh.pr_view: wait_for_mergeable times out and returns last payload as UNKNOWN", async () => {
+  const { sleeper, clock } = makeFakeTimeControls();
+  _setSleeper(sleeper);
+  _setClock(clock);
+  try {
+    const { graphql, calls } = stubGraphqlClient({
+      "pr/view": () => ({
+        repository: {
+          pullRequest: { ...sampleRawPR, mergeable: "UNKNOWN" },
+        },
+      }),
+    });
+    const reg = captureRegistration();
+    registerPRViewTool(reg.register, graphql);
+    const out = (await reg.entry.handler({
+      repo: "owner/repo",
+      number: 7,
+      wait_for_mergeable: { timeout_seconds: 10, poll_interval_seconds: 5 },
+    })) as { mergeable: string };
+    // Stayed UNKNOWN; tool returned cleanly, didn't throw.
+    assert.equal(out.mergeable, "UNKNOWN");
+    // Initial fetch + retries until the 10s budget is exhausted.
+    // With a 5s interval that's 1 (initial) + 2 retries = 3.
+    assert.equal(calls.length, 3);
+  } finally {
+    _setSleeper(null);
+    _setClock(null);
+  }
+});
+
+test("gh.pr_view: wait_for_mergeable defaults to 30s timeout, 5s interval", async () => {
+  const { sleeper, clock } = makeFakeTimeControls();
+  _setSleeper(sleeper);
+  _setClock(clock);
+  try {
+    const { graphql, calls } = stubGraphqlClient({
+      "pr/view": () => ({
+        repository: {
+          pullRequest: { ...sampleRawPR, mergeable: "UNKNOWN" },
+        },
+      }),
+    });
+    const reg = captureRegistration();
+    registerPRViewTool(reg.register, graphql);
+    await reg.entry.handler({
+      repo: "owner/repo",
+      number: 7,
+      wait_for_mergeable: {},
+    });
+    // 30s / 5s = 6 retries + 1 initial = 7 calls.
+    assert.equal(calls.length, 7);
+  } finally {
+    _setSleeper(null);
+    _setClock(null);
+  }
+});
+
+test("gh.pr_view: no wait_for_mergeable → single fetch even if mergeable is UNKNOWN", async () => {
+  // The default behaviour is a single round-trip; polling is
+  // explicit opt-in.
+  const { graphql, calls } = stubGraphqlClient({
+    "pr/view": () => ({
+      repository: {
+        pullRequest: { ...sampleRawPR, mergeable: "UNKNOWN" },
+      },
+    }),
+  });
+  const reg = captureRegistration();
+  registerPRViewTool(reg.register, graphql);
+  const out = (await reg.entry.handler({
+    repo: "owner/repo",
+    number: 7,
+  })) as { mergeable: string };
+  assert.equal(out.mergeable, "UNKNOWN");
+  assert.equal(calls.length, 1);
+});
+
+test("gh.pr_view: rejects timeout_seconds > 120 at the input boundary", async () => {
+  const { graphql } = stubGraphqlClient({});
+  const reg = captureRegistration();
+  registerPRViewTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      repo: "owner/repo",
+      number: 7,
+      wait_for_mergeable: { timeout_seconds: 999 },
+    }),
+    /gh\.pr_view input/,
+  );
+});
+
+test("gh.pr_view: rejects poll_interval_seconds > 30 at the input boundary", async () => {
+  const { graphql } = stubGraphqlClient({});
+  const reg = captureRegistration();
+  registerPRViewTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      repo: "owner/repo",
+      number: 7,
+      wait_for_mergeable: { poll_interval_seconds: 60 },
+    }),
+    /gh\.pr_view input/,
+  );
 });
 
 test("gh.pr_view: status_checks_state is null when there's no rollup", async () => {

--- a/tests/unit/tools/pr/view.test.ts
+++ b/tests/unit/tools/pr/view.test.ts
@@ -276,9 +276,11 @@ test("gh.pr_view: wait_for_mergeable times out and returns last payload as UNKNO
     })) as { mergeable: string };
     // Stayed UNKNOWN; tool returned cleanly, didn't throw.
     assert.equal(out.mergeable, "UNKNOWN");
-    // Initial fetch + retries until the 10s budget is exhausted.
-    // With a 5s interval that's 1 (initial) + 2 retries = 3.
-    assert.equal(calls.length, 3);
+    // Initial fetch + retries within the 10s budget. After the
+    // post-sleep deadline-recheck (A9 fix), the second sleep ends
+    // exactly at t=10 and the loop breaks before kicking off
+    // another fetch — so 1 initial + 1 retry = 2 calls.
+    assert.equal(calls.length, 2);
   } finally {
     _setSleeper(null);
     _setClock(null);
@@ -304,8 +306,11 @@ test("gh.pr_view: wait_for_mergeable defaults to 30s timeout, 5s interval", asyn
       number: 7,
       wait_for_mergeable: {},
     });
-    // 30s / 5s = 6 retries + 1 initial = 7 calls.
-    assert.equal(calls.length, 7);
+    // 30s / 5s budget. After the post-sleep deadline-recheck
+    // (A9 fix), the sixth sleep ends exactly at t=30 and the
+    // loop breaks without a final fetch — so 1 initial + 5
+    // retries = 6 calls.
+    assert.equal(calls.length, 6);
   } finally {
     _setSleeper(null);
     _setClock(null);


### PR DESCRIPTION
## Summary
- Stacked on top of #32 (A7+A8). Optional `wait_for_mergeable: { timeout_seconds, poll_interval_seconds }` on `gh.pr_view` makes the tool re-run its GraphQL query until `mergeable !== "UNKNOWN"` or the timeout fires.
- mcp-github owns the cadence (defaults: 30s timeout, 5s interval; caps: 120s / 30s). On timeout the last payload is returned as-is with `mergeable: "UNKNOWN"` so the caller gets a final answer rather than a hang.
- Replaces the methodology's agent-side `mergeable: UNKNOWN` poll pattern.

## Implementation notes
- Sleeper + clock are injectable for deterministic tests (no actual `setTimeout` in the suite).
- The remaining-budget cap on each sleep stops a 25s interval from sleeping past a 30s deadline.
- A post-sleep deadline-recheck guards against starting another GraphQL fetch after the timeout budget is exhausted (Copilot review #36).
- Polling holds the RawPR and summarises only once at the very end so the truncation-warning side effect fires exactly once per tool call (Copilot review #36).

## Test plan
- [x] `npm run lint`
- [x] `npm test` — 6 unit tests pin: polls until MERGEABLE; times out and returns UNKNOWN (1 initial + 1 retry = 2 calls for 10s/5s); defaults 30s/5s → 6 calls (1 initial + 5 retries; the sixth sleep ends at the deadline and the post-sleep recheck breaks before a final fetch); no `wait_for_mergeable` → single fetch even on UNKNOWN; timeout_seconds > 120 + poll_interval_seconds > 30 schema rejections.

## Merge order
This stacks on #32 (A7+A8). Merge #32 first, then this rebases onto main and merges.