### PR TITLE
fix(registry): drop top-level oneOf/allOf/anyOf from advertised schemas

### DIFF
--- a/src/registry.ts
+++ b/src/registry.ts
@@ -18,6 +18,8 @@
 // Nothing in this file is part of the published API. Names beginning
 // with `_` are test-only hooks and may change without a release note.
 
+import { toPublicInputSchema } from "./validation/advertise.js";
+
 export type ToolHandler = (args: Record<string, unknown>) => Promise<unknown>;
 
 export interface ToolEntry {
@@ -52,7 +54,10 @@ export function listToolDescriptors(): Array<{
   return Array.from(tools.entries()).map(([name, t]) => ({
     name,
     description: t.description,
-    inputSchema: t.inputSchema,
+    // Strip top-level oneOf/allOf/anyOf from the ADVERTISED schema.
+    // ajv still enforces them at call time via each handler's
+    // validate() call. See validation/advertise.ts for why.
+    inputSchema: toPublicInputSchema(t.inputSchema),
   }));
 }
 

--- a/src/validation/advertise.ts
+++ b/src/validation/advertise.ts
@@ -1,0 +1,42 @@
+// src/validation/advertise.ts
+//
+// Make a tool input schema safe to ADVERTISE to an Anthropic-backed
+// MCP client. The Anthropic tool-use API rejects oneOf, allOf, and
+// anyOf at the TOP LEVEL of a tool input_schema:
+//
+//   tools.N.custom.input_schema: input_schema does not support
+//   oneOf, allOf, or anyOf at the top level
+//
+// Several tools here use a top-level oneOf/allOf to pin "exactly one
+// call shape" (for example: pass a content URL, or pass repo plus
+// number, never both). When an agent is handed the full tool surface
+// (Claude Code sub-agents receive every registered tool), advertising
+// those schemas makes the API reject the whole request, which silently
+// disables Explore and Plan sub-agents in any project that registers
+// this server.
+//
+// The constraint is still enforced at call time: every handler runs
+// validate(inputSchema, args, ...) (see validator.ts) with ajv, which
+// honours the full schema including the top-level union. Stripping
+// only touches the ADVERTISED copy, and only the top level: nested
+// unions (such as properties.value.oneOf) are valid and are kept.
+
+const FORBIDDEN_TOP_LEVEL = ["oneOf", "allOf", "anyOf"] as const;
+
+// Return a copy of `schema` with the forbidden top-level keywords
+// removed. Does not recurse, and never mutates the input (handlers
+// reuse the same schema object for ajv validation). When there is
+// nothing to strip, the original object is returned unchanged so the
+// common case stays allocation-free and identity-stable.
+export function toPublicInputSchema(
+  schema: Record<string, unknown>,
+): Record<string, unknown> {
+  let cloned: Record<string, unknown> | undefined;
+  for (const key of FORBIDDEN_TOP_LEVEL) {
+    if (key in schema) {
+      cloned ??= { ...schema };
+      delete cloned[key];
+    }
+  }
+  return cloned ?? schema;
+}

--- a/tests/smoke/server-lists-tools.mjs
+++ b/tests/smoke/server-lists-tools.mjs
@@ -151,6 +151,24 @@ child.stdout.on("data", (chunk) => {
             `expected tools ${JSON.stringify(expected)}, got ${JSON.stringify(names)}`,
           );
         }
+        // The Anthropic tool-use API rejects oneOf/allOf/anyOf at the
+        // top level of a tool input_schema. A server that advertises
+        // one breaks every Anthropic-backed client (and its sub-agents,
+        // which receive the full tool surface), so guard the real wire
+        // output here, not just the in-process helper.
+        const FORBIDDEN_TOP_LEVEL = ["oneOf", "allOf", "anyOf"];
+        const offenders = tools
+          .filter(
+            (t) =>
+              t.inputSchema &&
+              FORBIDDEN_TOP_LEVEL.some((k) => k in t.inputSchema),
+          )
+          .map((t) => t.name);
+        if (offenders.length > 0) {
+          throw new Error(
+            `tools advertise a top-level oneOf/allOf/anyOf, which the Anthropic API rejects: ${offenders.join(", ")}`,
+          );
+        }
         process.stdout.write(
           `smoke: server lists ${names.length} tool(s) as expected: ${names.join(", ")}\n`,
         );

--- a/tests/unit/registry.test.ts
+++ b/tests/unit/registry.test.ts
@@ -69,6 +69,42 @@ test("listToolDescriptors: returns the JSON-Schema-shaped list ListTools hands b
   assert.equal(descriptors[1]?.name, "gh.beta");
 });
 
+test("listToolDescriptors: strips top-level oneOf/allOf/anyOf but keeps nested unions", () => {
+  // The Anthropic tool-use API rejects a top-level oneOf/allOf/anyOf,
+  // so the ADVERTISED schema must not carry one even though the stored
+  // entry keeps it for ajv validation at call time.
+  const schema = {
+    type: "object",
+    properties: {
+      url: { type: "string" },
+      repo: { type: "string" },
+      value: { type: "object", oneOf: [{ required: ["a"] }] },
+    },
+    oneOf: [{ required: ["url"] }, { required: ["repo"] }],
+    additionalProperties: false,
+  };
+  registerTool("gh.union", {
+    description: "u",
+    inputSchema: schema,
+    handler: async () => ({}),
+  });
+  const advertised = listToolDescriptors()[0]?.inputSchema as Record<
+    string,
+    unknown
+  >;
+  assert.equal("oneOf" in advertised, false);
+  // Nested union under a property is valid and must survive.
+  const props = advertised["properties"] as Record<string, unknown>;
+  const value = props["value"] as Record<string, unknown>;
+  assert.ok(Array.isArray(value["oneOf"]));
+  // The stored entry keeps the full schema so ajv still enforces it.
+  const stored = (getToolEntry("gh.union")?.inputSchema ?? {}) as Record<
+    string,
+    unknown
+  >;
+  assert.ok("oneOf" in stored);
+});
+
 test("getToolEntry: returns the registered entry, or undefined for unknown names", () => {
   registerTool("gh.known", sampleEntry);
   assert.equal(getToolEntry("gh.known"), sampleEntry);

--- a/tests/unit/validation/advertise.test.ts
+++ b/tests/unit/validation/advertise.test.ts
@@ -1,0 +1,71 @@
+// tests/unit/validation/advertise.test.ts
+//
+// Pins toPublicInputSchema: it must remove ONLY the top-level
+// oneOf/allOf/anyOf keywords the Anthropic tool-use API rejects, keep
+// every other key (including nested unions), and never mutate the
+// input the handlers still validate against with ajv.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { toPublicInputSchema } from "../../../src/validation/advertise.ts";
+
+test("toPublicInputSchema: strips a top-level oneOf, keeps the rest", () => {
+  const schema = {
+    type: "object",
+    properties: { a: { type: "string" }, b: { type: "string" } },
+    required: ["a"],
+    oneOf: [{ required: ["a"] }, { required: ["b"] }],
+    additionalProperties: false,
+  };
+  assert.deepEqual(toPublicInputSchema(schema), {
+    type: "object",
+    properties: { a: { type: "string" }, b: { type: "string" } },
+    required: ["a"],
+    additionalProperties: false,
+  });
+});
+
+test("toPublicInputSchema: strips top-level allOf and anyOf", () => {
+  const out = toPublicInputSchema({
+    type: "object",
+    allOf: [{ oneOf: [{ required: ["x"] }] }],
+    anyOf: [{ required: ["y"] }],
+  });
+  assert.equal("allOf" in out, false);
+  assert.equal("anyOf" in out, false);
+  assert.equal(out["type"], "object");
+});
+
+test("toPublicInputSchema: preserves a nested oneOf under a property", () => {
+  const out = toPublicInputSchema({
+    type: "object",
+    properties: {
+      value: {
+        type: "object",
+        oneOf: [{ required: ["text"] }, { required: ["number"] }],
+      },
+    },
+    allOf: [{ oneOf: [{ required: ["a"] }] }],
+  });
+  assert.equal("allOf" in out, false);
+  const props = out["properties"] as Record<string, unknown>;
+  const value = props["value"] as Record<string, unknown>;
+  assert.ok(Array.isArray(value["oneOf"]));
+  assert.equal((value["oneOf"] as unknown[]).length, 2);
+});
+
+test("toPublicInputSchema: does not mutate the input (ajv keeps the union)", () => {
+  const schema = { type: "object", oneOf: [{ required: ["a"] }] };
+  toPublicInputSchema(schema);
+  assert.ok("oneOf" in schema, "input must keep oneOf for runtime validation");
+});
+
+test("toPublicInputSchema: returns the same object when nothing to strip", () => {
+  const schema = {
+    type: "object",
+    properties: {},
+    additionalProperties: false,
+  };
+  assert.equal(toPublicInputSchema(schema), schema);
+});


### PR DESCRIPTION
## Summary

- Strips top-level `oneOf`/`allOf`/`anyOf` from the ADVERTISED tool schema in `listToolDescriptors` via a new `toPublicInputSchema` helper, so Anthropic-backed clients (and Claude Code Explore/Plan sub-agents, which receive the full tool surface) can load the server.
- Runtime enforcement is unchanged: every handler still validates against the full schema with ajv, so the "exactly one call shape" contract still holds. Nested unions (for example `gh.project_item_update_field`'s `value.oneOf`) are preserved.
- Root cause: the Anthropic tool-use API rejects those keywords at the top level of a tool `input_schema`; nine tools advertised a top-level `oneOf`/`allOf`.

## Test plan

- [x] `npm run lint`
- [x] `npm test` (291 unit tests; adds the `toPublicInputSchema` suite and a registry strip case)
- [x] `npm run build && node tests/smoke/server-lists-tools.mjs` (real stdio `tools/list` reports zero top-level unions across all 36 tools)
- [ ] After merge and MCP client restart: an Explore or Plan sub-agent runs without the 400

Closes: ctxr-dev/mcp-github#39