### PR TITLE
chore(package): add prepare so the server builds on git/npx install

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test": "node ./scripts/run-tests.mjs unit",
     "test:integration": "node ./scripts/run-tests.mjs integration",
     "lint": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.tests.json --noEmit",
-    "prepack": "npm run build"
+    "prepare": "npm run build"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",


### PR DESCRIPTION
## Summary

- Adds `"prepare": "npm run build"` to `package.json` so the server builds on install. `dist/` is gitignored and the `bin` is `dist/server.mjs`, so `npm install github:ctxr-dev/mcp-github` and `npx -y github:ctxr-dev/mcp-github` previously left the server unbuilt and unrunnable.
- `prepare` runs on git installs, local installs, and before pack/publish, so it supersedes the now-redundant `prepack` (replaced).
- Unblocks the canonical "install from GitHub" path that `github-dev-methodology`'s install prompt will recommend.

## Test plan

- [x] `npm run lint`
- [x] `npm test` (291 unit tests)
- [x] `npm run build`
- [x] Clean-install proof: `rm -rf dist && npm install` rebuilds `dist/server.mjs`
- [x] Git-install proof: `npm install github:ctxr-dev/mcp-github#chore/issue-41-prepare-build-hook` in a scratch dir built `dist/server.mjs`

Closes: ctxr-dev/mcp-github#41