### PR TITLE
feat(pr): add gh.pr_review_watch multiplexed multi-reviewer watch tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ live at `docs/tool-reference.md` once MCP-13 lands. At v0.1 the file is
 not yet present: tools land PR by PR, and the reference is generated
 once the surface stabilises.
 
+| Tool | Surfaced as | What it does |
+| --- | --- | --- |
+| `gh.pr_review_watch` | `gh_pr_review_watch` | Blocking, multiplexed long-poll over 1..N PRs for 1..N reviewers. Computes a per-reviewer verdict on HEAD (pending / needs-work / green) from `latestReviews` plus unresolved, non-outdated review threads authored by that reviewer, returns when any PR has a wake-worthy transition (filtered by `waitFor`), becomes `ready` (all reviewers green on HEAD, required approvals present, CI when `requireCi`), or `maxWaitSeconds` elapses. Defaults `maxWaitSeconds` to 25 to stay under the common ~60s client tool-call timeout; the agent re-invokes passing the returned `fingerprint` back as `sinceFingerprint`. |
+
 ## Develop
 
 ```sh

--- a/src/graphql/queries/pr/review_watch.graphql
+++ b/src/graphql/queries/pr/review_watch.graphql
@@ -3,7 +3,7 @@ query PRReviewWatch($owner: String!, $name: String!, $number: Int!) {
     pullRequest(number: $number) {
       headRefOid
       reviewDecision
-      latestReviews(first: 30) {
+      latestReviews(first: 100) {
         nodes {
           id
           author {

--- a/src/graphql/queries/pr/review_watch.graphql
+++ b/src/graphql/queries/pr/review_watch.graphql
@@ -13,7 +13,6 @@ query PRReviewWatch($owner: String!, $name: String!, $number: Int!) {
           commit {
             oid
           }
-          submittedAt
         }
       }
       reviewThreads(first: 100) {
@@ -22,17 +21,13 @@ query PRReviewWatch($owner: String!, $name: String!, $number: Int!) {
           endCursor
         }
         nodes {
-          id
           isResolved
           isOutdated
-          path
-          line
           comments(first: 1) {
             nodes {
               author {
                 login
               }
-              body
             }
           }
         }

--- a/src/graphql/queries/pr/review_watch.graphql
+++ b/src/graphql/queries/pr/review_watch.graphql
@@ -1,0 +1,51 @@
+query PRReviewWatch($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      headRefOid
+      reviewDecision
+      latestReviews(first: 30) {
+        nodes {
+          id
+          author {
+            login
+          }
+          state
+          commit {
+            oid
+          }
+          submittedAt
+        }
+      }
+      reviewThreads(first: 100) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          id
+          isResolved
+          isOutdated
+          path
+          line
+          comments(first: 1) {
+            nodes {
+              author {
+                login
+              }
+              body
+            }
+          }
+        }
+      }
+      commits(last: 1) {
+        nodes {
+          commit {
+            statusCheckRollup {
+              state
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/tools/pr/index.ts
+++ b/src/tools/pr/index.ts
@@ -17,6 +17,7 @@ import { registerPRMergeTool } from "./merge.js";
 import { registerPRRequestReviewsTool } from "./request_reviews.js";
 import { registerPRReviewThreadResolveTool } from "./review_thread_resolve.js";
 import { registerPRReviewThreadsListTool } from "./review_threads_list.js";
+import { registerPRReviewWatchTool } from "./review_watch.js";
 import { registerPRReviewsListTool } from "./reviews_list.js";
 import { registerPRViewTool } from "./view.js";
 
@@ -36,4 +37,5 @@ export function registerPRTools(
   registerPRReviewThreadResolveTool(register, graphql);
   registerPRReviewThreadsListTool(register, graphql);
   registerPRReviewsListTool(register, graphql);
+  registerPRReviewWatchTool(register, graphql);
 }

--- a/src/tools/pr/review_watch.ts
+++ b/src/tools/pr/review_watch.ts
@@ -1,0 +1,859 @@
+// src/tools/pr/review_watch.ts
+//
+// `gh.pr_review_watch`: a blocking, stateless, multiplexed
+// long-poll that watches 1..N PRs for 1..N reviewers and returns
+// when a wake condition fires for ANY watched PR. The agent
+// re-invokes it in a foreground loop, passing the previous
+// `fingerprint` back as `sinceFingerprint`, so each call wakes on a
+// real transition (or on `ready` / timeout) rather than hot-looping.
+//
+// A blocking handler is safe here: the MCP SDK dispatches handlers
+// via `Promise.resolve().then(...)`, so awaiting inside the handler
+// does not stall the stdio read loop or other concurrent tool
+// calls.
+//
+// The per-reviewer verdict is computed off `latestReviews` (latest
+// review per author) plus unresolved, non-outdated review threads
+// authored by the reviewer. We deliberately do NOT use any
+// `review.comments.totalCount` field: it undercounts (it omits
+// replies) and misses Copilot's thread-based findings (Copilot
+// reviews are `COMMENTED` and can carry a non-empty summary with
+// zero inline comments). The actionable signal is the unresolved
+// non-outdated thread set, which also lines up with the
+// methodology's "resolve the threads you fixed in the same push"
+// invariant.
+//
+// `maxWaitSeconds` defaults to 25 deliberately: it stays under the
+// ~60s MCP tool-call timeout common to clients (Cursor wobbles
+// >30s). On timeout the tool returns a snapshot with `timedOut:
+// true` and the agent re-invokes, passing the returned
+// `fingerprint` back as `sinceFingerprint`. Power users can raise
+// the client tool-timeout to lengthen each block.
+
+import { createHash } from "node:crypto";
+
+import type { GraphqlClient } from "../../graphql/client.js";
+import { AbuseDetectionError, RateLimitExhaustedError } from "../../graphql/errors.js";
+import type { ToolEntry } from "../../registry.js";
+import { validate } from "../../validation/validator.js";
+import { parseRepoSlug, repoSlugSchema } from "./_shared.js";
+
+const POLL_SECONDS_DEFAULT = 15;
+const POLL_SECONDS_MIN = 5;
+const POLL_SECONDS_MAX = 120;
+const MAX_WAIT_SECONDS_DEFAULT = 25;
+const MAX_WAIT_SECONDS_MAX = 120;
+
+// `copilot` is the alias the methodology uses everywhere; the real
+// login GitHub resolves it to is `copilot-pull-request-reviewer`.
+// We map it in the handler so the predicate (which matches against
+// thread/review author logins) compares against the real login.
+const COPILOT_ALIAS = "copilot";
+const COPILOT_LOGIN = "copilot-pull-request-reviewer";
+
+// Reviewer logins we treat as bots when defaulting `requiredApprovals`
+// to "the human reviewers". Bots have no APPROVED state, so requiring
+// one would make `ready` unreachable. The Copilot login is the only
+// well-known bot reviewer in the methodology's set; the alias is also
+// covered defensively in case the caller passes it unmapped.
+const BOT_LOGINS = new Set<string>([COPILOT_LOGIN, COPILOT_ALIAS]);
+
+const prItemSchema = {
+  type: "object",
+  required: ["repo", "number"],
+  properties: {
+    repo: repoSlugSchema,
+    number: { type: "integer", minimum: 1 },
+  },
+  additionalProperties: false,
+} as const;
+
+const inputSchema = {
+  type: "object",
+  required: ["prs", "reviewers"],
+  properties: {
+    prs: {
+      type: "array",
+      minItems: 1,
+      items: prItemSchema,
+      description:
+        "PRs to watch. The tool queries each one per poll cycle and " +
+        "wakes when ANY of them satisfies the wake condition.",
+    },
+    reviewers: {
+      type: "array",
+      minItems: 1,
+      items: { type: "string", minLength: 1 },
+      description:
+        "Reviewer logins to watch. The alias `copilot` is mapped to " +
+        "`copilot-pull-request-reviewer`. A PR is `ready` only when " +
+        "every reviewer in this set is green on HEAD.",
+    },
+    requiredApprovals: {
+      type: "array",
+      items: { type: "string", minLength: 1 },
+      description:
+        "Reviewers who must additionally be APPROVED (not merely " +
+        "green) for `ready`. When omitted this defaults to the human " +
+        "reviewers in `reviewers` (every reviewer except `copilot` / " +
+        "bot logins), which avoids an all-green / zero-approvals state " +
+        "that branch protection would still reject. Bots have no " +
+        "APPROVED state, so listing one here would make `ready` " +
+        "unreachable.",
+    },
+    waitFor: {
+      type: "string",
+      enum: ["any", "smart", "all", "quorum"],
+      description:
+        "Which transitions are wake-worthy (vs `sinceFingerprint`): " +
+        "`any` (default) wakes on any change; `smart` only when the " +
+        "PR is actionable or ready; `all` only when every reviewer is " +
+        "on HEAD; `quorum` only when the count of non-pending " +
+        "reviewers reaches `quorum`. `ready` and timeout always wake " +
+        "regardless of this filter.",
+    },
+    quorum: {
+      type: "integer",
+      minimum: 1,
+      description:
+        "Only meaningful with `waitFor: quorum`: the number of " +
+        "non-pending reviewers that wakes the watch.",
+    },
+    sinceFingerprint: {
+      type: "string",
+      description:
+        "The `fingerprint` from the previous call. The tool wakes on a " +
+        "`waitFor`-filtered transition away from this value. Omit on " +
+        "the first call.",
+    },
+    pollSeconds: {
+      type: "integer",
+      minimum: POLL_SECONDS_MIN,
+      maximum: POLL_SECONDS_MAX,
+      description:
+        `Seconds between poll cycles (default ${POLL_SECONDS_DEFAULT}, ` +
+        `min ${POLL_SECONDS_MIN}, max ${POLL_SECONDS_MAX}).`,
+    },
+    maxWaitSeconds: {
+      type: "integer",
+      minimum: 0,
+      maximum: MAX_WAIT_SECONDS_MAX,
+      description:
+        `Max wall-clock seconds to block before returning with ` +
+        `timedOut: true (default ${MAX_WAIT_SECONDS_DEFAULT}, max ` +
+        `${MAX_WAIT_SECONDS_MAX}). 0 = take a single snapshot and ` +
+        `return immediately. The default stays under the ~60s MCP ` +
+        `tool-call timeout common to clients; re-invoke passing the ` +
+        `returned fingerprint back as sinceFingerprint.`,
+    },
+    requireCi: {
+      type: "boolean",
+      description:
+        "Default false. When true, `ready` additionally requires the " +
+        "latest commit's status-check rollup state to be SUCCESS; a " +
+        "null rollup (no checks configured) then fails `ready` with a " +
+        "clear reason rather than passing.",
+    },
+  },
+  additionalProperties: false,
+} as const;
+
+const reviewerVerdictSchema = {
+  type: "object",
+  required: ["login", "onHead", "verdict", "state", "latestReviewId"],
+  properties: {
+    login: { type: "string" },
+    onHead: { type: "boolean" },
+    verdict: { type: "string", enum: ["pending", "needs-work", "green"] },
+    state: {
+      type: ["string", "null"],
+      enum: [
+        "PENDING",
+        "COMMENTED",
+        "APPROVED",
+        "CHANGES_REQUESTED",
+        "DISMISSED",
+        null,
+      ],
+    },
+    latestReviewId: { type: ["string", "null"] },
+  },
+  additionalProperties: false,
+} as const;
+
+const itemSchema = {
+  type: "object",
+  required: [
+    "repo",
+    "number",
+    "head",
+    "reviewers",
+    "actionable",
+    "allOnHead",
+    "ready",
+    "ci",
+    "reviewDecision",
+    "unresolvedByReviewer",
+    "threadsTruncated",
+  ],
+  properties: {
+    repo: { type: "string" },
+    number: { type: "integer" },
+    head: { type: ["string", "null"] },
+    reviewers: { type: "array", items: reviewerVerdictSchema },
+    actionable: { type: "boolean" },
+    allOnHead: { type: "boolean" },
+    ready: { type: "boolean" },
+    ci: { type: ["string", "null"] },
+    reviewDecision: {
+      type: ["string", "null"],
+      enum: ["APPROVED", "CHANGES_REQUESTED", "REVIEW_REQUIRED", null],
+    },
+    unresolvedByReviewer: {
+      type: "object",
+      additionalProperties: { type: "integer", minimum: 0 },
+    },
+    threadsTruncated: { type: "boolean" },
+    error: { type: "string" },
+  },
+  additionalProperties: false,
+} as const;
+
+const changedSchema = {
+  type: "object",
+  required: ["repo", "number", "reason"],
+  properties: {
+    repo: { type: "string" },
+    number: { type: "integer" },
+    reason: { type: "string" },
+  },
+  additionalProperties: false,
+} as const;
+
+const outputSchema = {
+  type: "object",
+  required: ["items", "changed", "fingerprint", "timedOut"],
+  properties: {
+    items: { type: "array", items: itemSchema },
+    changed: { type: "array", items: changedSchema },
+    fingerprint: { type: "string" },
+    timedOut: { type: "boolean" },
+    rateLimited: { type: "boolean" },
+    retryAfter: { type: "integer", minimum: 0 },
+  },
+  additionalProperties: false,
+} as const;
+
+type RegisterToolFn = (name: string, entry: ToolEntry) => void;
+
+type ReviewState =
+  | "PENDING"
+  | "COMMENTED"
+  | "APPROVED"
+  | "CHANGES_REQUESTED"
+  | "DISMISSED";
+
+type RollupState =
+  | "EXPECTED"
+  | "ERROR"
+  | "FAILURE"
+  | "PENDING"
+  | "SUCCESS";
+
+interface PrInput {
+  repo: string;
+  number: number;
+}
+
+interface Input {
+  prs: PrInput[];
+  reviewers: string[];
+  requiredApprovals?: string[];
+  waitFor?: "any" | "smart" | "all" | "quorum";
+  quorum?: number;
+  sinceFingerprint?: string;
+  pollSeconds?: number;
+  maxWaitSeconds?: number;
+  requireCi?: boolean;
+}
+
+// Normalised options the engine + evaluator actually consume.
+interface WatchOptions {
+  prs: PrInput[];
+  reviewers: string[];
+  requiredApprovals: string[];
+  waitFor: "any" | "smart" | "all" | "quorum";
+  quorum: number;
+  sinceFingerprint: string | null;
+  pollSeconds: number;
+  maxWaitSeconds: number;
+  requireCi: boolean;
+}
+
+interface EvalOptions {
+  reviewers: string[];
+  requiredApprovals: string[];
+  requireCi: boolean;
+}
+
+interface RawReview {
+  id: string;
+  author: { login: string } | null;
+  state: ReviewState;
+  commit: { oid: string } | null;
+  submittedAt: string | null;
+}
+
+interface RawThread {
+  id: string;
+  isResolved: boolean;
+  isOutdated: boolean;
+  path: string | null;
+  line: number | null;
+  comments: {
+    nodes: Array<{ author: { login: string } | null; body: string }>;
+  };
+}
+
+interface RawPR {
+  headRefOid: string;
+  reviewDecision: "APPROVED" | "CHANGES_REQUESTED" | "REVIEW_REQUIRED" | null;
+  latestReviews: { nodes: RawReview[] } | null;
+  reviewThreads: {
+    pageInfo: { hasNextPage: boolean; endCursor: string | null };
+    nodes: RawThread[];
+  };
+  commits: {
+    nodes: Array<{
+      commit: { statusCheckRollup: { state: RollupState } | null };
+    }>;
+  };
+}
+
+interface Response {
+  repository: { pullRequest: RawPR | null } | null;
+}
+
+interface ReviewerVerdict {
+  login: string;
+  onHead: boolean;
+  verdict: "pending" | "needs-work" | "green";
+  state: ReviewState | null;
+  latestReviewId: string | null;
+}
+
+interface PrEvaluation {
+  head: string | null;
+  reviewers: ReviewerVerdict[];
+  actionable: boolean;
+  allOnHead: boolean;
+  ready: boolean;
+  ci: RollupState | null;
+  reviewDecision: RawPR["reviewDecision"];
+  unresolvedByReviewer: Record<string, number>;
+  threadsTruncated: boolean;
+  fingerprint: string;
+}
+
+interface OutputItem extends Omit<PrEvaluation, "fingerprint"> {
+  repo: string;
+  number: number;
+  error?: string;
+}
+
+interface Output {
+  items: OutputItem[];
+  changed: Array<{ repo: string; number: number; reason: string }>;
+  fingerprint: string;
+  timedOut: boolean;
+  rateLimited?: boolean;
+  retryAfter?: number;
+}
+
+interface WatchDeps {
+  graphql: GraphqlClient;
+  sleep: (ms: number) => Promise<void>;
+  now: () => number;
+  signal?: { aborted: boolean } | undefined;
+}
+
+// PURE. Given one PR's raw GraphQL payload and the configured
+// reviewer set, compute the per-reviewer verdict, the per-PR
+// aggregates, and a stable fingerprint. No I/O, no clock; the
+// engine and the unit suite both drive this directly.
+export function evaluatePr(rawPr: RawPR, opts: EvalOptions): PrEvaluation {
+  const head = rawPr.headRefOid;
+  const latest = rawPr.latestReviews?.nodes ?? [];
+  // latestReviews is one-per-author already, but index by login so
+  // the per-reviewer lookup is O(1) and resilient to the connection
+  // ever returning more than one node per author.
+  const latestByLogin = new Map<string, RawReview>();
+  for (const review of latest) {
+    const login = review.author?.login;
+    if (login) latestByLogin.set(login, review);
+  }
+
+  // Count unresolved, non-outdated threads per authoring reviewer.
+  // The author is the first comment's author (threads(first:1)).
+  // This is the actionable-work signal: it equals the outstanding
+  // asks the agent still owes the reviewer.
+  const unresolvedByReviewer: Record<string, number> = {};
+  for (const thread of rawPr.reviewThreads.nodes) {
+    if (thread.isResolved || thread.isOutdated) continue;
+    const author = thread.comments.nodes[0]?.author?.login;
+    if (!author) continue;
+    unresolvedByReviewer[author] = (unresolvedByReviewer[author] ?? 0) + 1;
+  }
+
+  const required = new Set(opts.requiredApprovals);
+  const reviewers: ReviewerVerdict[] = opts.reviewers.map((login) => {
+    const review = latestByLogin.get(login);
+    const state = review?.state ?? null;
+    const latestReviewId = review?.id ?? null;
+    // On head only when this reviewer has a non-DISMISSED/PENDING
+    // review whose commit is the current head. DISMISSED reviews
+    // report commit==head with zero findings (would read falsely
+    // green); PENDING reviews carry a null commit/submittedAt.
+    const onHead =
+      review !== undefined &&
+      state !== "DISMISSED" &&
+      state !== "PENDING" &&
+      review.commit?.oid === head;
+
+    let verdict: ReviewerVerdict["verdict"];
+    if (!onHead) {
+      verdict = "pending";
+    } else {
+      const hasOpenThread = (unresolvedByReviewer[login] ?? 0) > 0;
+      if (state === "CHANGES_REQUESTED" || hasOpenThread) {
+        verdict = "needs-work";
+      } else if (required.has(login) && state !== "APPROVED") {
+        // Required approver who is otherwise clean but has not
+        // formally APPROVED stays pending (a CHANGES_REQUESTED is
+        // already needs-work above, so this is the COMMENTED case).
+        verdict = "pending";
+      } else {
+        verdict = "green";
+      }
+    }
+    return { login, onHead, verdict, state, latestReviewId };
+  });
+
+  const actionable = reviewers.some((r) => r.verdict === "needs-work");
+  const allOnHead = reviewers.every((r) => r.verdict !== "pending");
+  const ci = rawPr.commits.nodes[0]?.commit.statusCheckRollup?.state ?? null;
+
+  const allGreen = reviewers.every((r) => r.verdict === "green");
+  const requiredApproved = reviewers
+    .filter((r) => required.has(r.login))
+    .every((r) => r.state === "APPROVED");
+  // A null rollup means "no checks configured": pass unless
+  // requireCi forces a gate, in which case null fails.
+  const ciReady = opts.requireCi ? ci === "SUCCESS" : true;
+  const ready = allGreen && requiredApproved && ciReady;
+
+  const fingerprint = computeFingerprint(reviewers, head, ci);
+
+  return {
+    head,
+    reviewers,
+    actionable,
+    allOnHead,
+    ready,
+    ci,
+    reviewDecision: rawPr.reviewDecision,
+    unresolvedByReviewer,
+    threadsTruncated: rawPr.reviewThreads.pageInfo.hasNextPage,
+    fingerprint,
+  };
+}
+
+// Stable short hash over the sorted-by-login reviewer tuples plus
+// the CI state, so an unchanged review landscape produces an
+// unchanged fingerprint and the transition wake does not re-fire.
+// The tuple shape is fixed (login, latestReviewId, onHeadOid,
+// verdict) so the sibling methodology gh-CLI script can mirror it
+// and produce identical fingerprints for parity.
+function computeFingerprint(
+  reviewers: ReviewerVerdict[],
+  head: string | null,
+  ci: RollupState | null,
+): string {
+  const sorted = [...reviewers].sort((a, b) => a.login.localeCompare(b.login));
+  const tuples = sorted.map((r) => ({
+    login: r.login,
+    latestReviewId: r.latestReviewId,
+    onHeadOid: r.onHead ? head : null,
+    verdict: r.verdict,
+  }));
+  const payload = JSON.stringify({ reviewers: tuples, ci });
+  return createHash("sha1").update(payload).digest("hex").slice(0, 16);
+}
+
+// Whether the (combined) fingerprint moved away from the caller's
+// `sinceFingerprint` baseline. A missing baseline (first call) is
+// NOT a transition: the blocking long-poll waits for a real change
+// (or `ready` / timeout) rather than returning on the first
+// snapshot. Callers wanting an immediate snapshot pass
+// maxWaitSeconds: 0.
+function changedVsSince(combined: string, opts: WatchOptions): boolean {
+  return opts.sinceFingerprint !== null && combined !== opts.sinceFingerprint;
+}
+
+// Whether this PR satisfies the `waitFor` filter THIS cycle (an
+// absolute per-PR predicate; the fingerprint delta is checked
+// separately by changedVsSince). `any` always satisfies, so any
+// combined change wakes; the others gate on a per-PR state.
+function waitForHolds(evaluation: PrEvaluation, opts: WatchOptions): boolean {
+  switch (opts.waitFor) {
+    case "any":
+      return true;
+    case "smart":
+      return evaluation.actionable || evaluation.ready;
+    case "all":
+      return evaluation.allOnHead;
+    case "quorum": {
+      const nonPending = evaluation.reviewers.filter(
+        (r) => r.verdict !== "pending",
+      ).length;
+      return nonPending >= opts.quorum;
+    }
+  }
+}
+
+// A PR is a wake source when it is `ready`, or when the combined
+// fingerprint changed AND its `waitFor` filter holds.
+function prWakes(
+  evaluation: PrEvaluation,
+  combined: string,
+  opts: WatchOptions,
+): boolean {
+  if (evaluation.ready) return true;
+  return changedVsSince(combined, opts) && waitForHolds(evaluation, opts);
+}
+
+// Human-readable reason a PR woke the multiplex, for the `changed`
+// array. Keeps the caller from re-deriving why each PR is listed.
+function wakeReason(
+  evaluation: PrEvaluation,
+  combined: string,
+  opts: WatchOptions,
+): string | null {
+  if (evaluation.ready) return "ready";
+  if (changedVsSince(combined, opts) && waitForHolds(evaluation, opts)) {
+    switch (opts.waitFor) {
+      case "any":
+        return "transition";
+      case "smart":
+        return evaluation.actionable ? "actionable" : "ready-transition";
+      case "all":
+        return "all-on-head";
+      case "quorum":
+        return "quorum-reached";
+    }
+  }
+  return null;
+}
+
+// The watch engine. Loops: query every PR, evaluate, and return as
+// soon as ANY PR is `ready` or has a wake-worthy transition. Bails
+// on abort between awaits, and stops at `maxWaitSeconds` with
+// `timedOut: true`. A per-PR fetch error is captured on that item so
+// one bad PR never kills the batch. Rate-limit / abuse-detection
+// errors return a `rateLimited` snapshot rather than throwing out of
+// the whole call.
+export async function watchPrs(
+  opts: WatchOptions,
+  deps: WatchDeps,
+): Promise<Output> {
+  const { graphql, sleep, now, signal } = deps;
+  const deadline = now() + opts.maxWaitSeconds * 1000;
+
+  // Last good snapshot, so the abort / rate-limit paths can report
+  // what we last saw rather than an empty payload. Empty before the
+  // first cycle completes.
+  let lastItems: OutputItem[] = opts.prs.map((pr) => emptyItem(pr, "not yet polled"));
+  let lastEvaluations: Array<PrEvaluation | null> = opts.prs.map(() => null);
+
+  while (true) {
+    if (signal?.aborted) {
+      return buildOutput(lastItems, lastEvaluations, opts, true);
+    }
+
+    try {
+      const cycle = await runCycle(graphql, opts);
+      lastItems = cycle.items;
+      lastEvaluations = cycle.evaluations;
+    } catch (err) {
+      if (
+        err instanceof RateLimitExhaustedError ||
+        err instanceof AbuseDetectionError
+      ) {
+        return buildRateLimited(lastItems, lastEvaluations, opts, err);
+      }
+      throw err;
+    }
+
+    // Wake if any PR is ready, or the combined fingerprint changed
+    // away from the caller's baseline and some PR satisfies the
+    // waitFor filter.
+    const combined = combinedFingerprint(lastItems, lastEvaluations);
+    const woke = lastEvaluations.some(
+      (ev) => ev !== null && prWakes(ev, combined, opts),
+    );
+    if (woke) return buildOutput(lastItems, lastEvaluations, opts, false);
+
+    // Out of budget: a single snapshot (maxWaitSeconds:0) lands here
+    // immediately, and a longer block lands here once the deadline
+    // passes. Both return timedOut so the caller re-invokes.
+    if (now() >= deadline) {
+      return buildOutput(lastItems, lastEvaluations, opts, true);
+    }
+
+    if (signal?.aborted) {
+      return buildOutput(lastItems, lastEvaluations, opts, true);
+    }
+    await sleep(opts.pollSeconds * 1000);
+    // Re-check the deadline after sleeping so a sleep that consumed
+    // the remaining budget doesn't kick off another full cycle past
+    // the documented ceiling.
+    if (now() >= deadline) {
+      return buildOutput(lastItems, lastEvaluations, opts, true);
+    }
+  }
+}
+
+// Run one poll cycle: query + evaluate every PR. A per-PR fetch
+// error is captured on that item (with a null evaluation) so the
+// batch survives one bad PR.
+async function runCycle(
+  graphql: GraphqlClient,
+  opts: WatchOptions,
+): Promise<{ items: OutputItem[]; evaluations: Array<PrEvaluation | null> }> {
+  const results = await Promise.all(
+    opts.prs.map((pr) => fetchAndEvaluate(graphql, pr, opts)),
+  );
+  return {
+    items: results.map((r) => r.item),
+    evaluations: results.map((r) => r.evaluation),
+  };
+}
+
+async function fetchAndEvaluate(
+  graphql: GraphqlClient,
+  pr: PrInput,
+  opts: WatchOptions,
+): Promise<{ item: OutputItem; evaluation: PrEvaluation | null }> {
+  // Rate-limit / abuse errors must propagate so the engine can return
+  // the dedicated rateLimited snapshot; every other fetch failure is
+  // captured per-PR so one bad PR never kills the batch.
+  let raw: RawPR;
+  try {
+    raw = await fetchRawPr(graphql, pr);
+  } catch (err) {
+    if (
+      err instanceof RateLimitExhaustedError ||
+      err instanceof AbuseDetectionError
+    ) {
+      throw err;
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    return { item: emptyItem(pr, message), evaluation: null };
+  }
+  const evaluation = evaluatePr(raw, opts);
+  return { item: toItem(pr, evaluation), evaluation };
+}
+
+async function fetchRawPr(graphql: GraphqlClient, pr: PrInput): Promise<RawPR> {
+  const coords = parseRepoSlug(pr.repo, "gh.pr_review_watch input");
+  const data = await graphql<Response>("pr/review_watch", {
+    owner: coords.owner,
+    name: coords.name,
+    number: pr.number,
+  });
+  if (!data.repository) {
+    throw new Error(
+      `mcp-github: gh.pr_review_watch: repository '${coords.owner}/${coords.name}' not found or token lacks read access`,
+    );
+  }
+  const raw = data.repository.pullRequest;
+  if (!raw) {
+    throw new Error(
+      `mcp-github: gh.pr_review_watch: PR ${coords.owner}/${coords.name}#${pr.number} not found`,
+    );
+  }
+  return raw;
+}
+
+function toItem(pr: PrInput, evaluation: PrEvaluation): OutputItem {
+  return {
+    repo: pr.repo,
+    number: pr.number,
+    head: evaluation.head,
+    reviewers: evaluation.reviewers,
+    actionable: evaluation.actionable,
+    allOnHead: evaluation.allOnHead,
+    ready: evaluation.ready,
+    ci: evaluation.ci,
+    reviewDecision: evaluation.reviewDecision,
+    unresolvedByReviewer: evaluation.unresolvedByReviewer,
+    threadsTruncated: evaluation.threadsTruncated,
+  };
+}
+
+// Placeholder item for a PR whose fetch failed this cycle. The
+// aggregates are reported as their inert values so the output stays
+// schema-valid; the `error` field carries the failure reason.
+function emptyItem(pr: PrInput, error: string): OutputItem {
+  return {
+    repo: pr.repo,
+    number: pr.number,
+    head: null,
+    reviewers: [],
+    actionable: false,
+    allOnHead: false,
+    ready: false,
+    ci: null,
+    reviewDecision: null,
+    unresolvedByReviewer: {},
+    threadsTruncated: false,
+    error,
+  };
+}
+
+// Combine each PR's per-PR fingerprint into one stable digest for
+// the whole watch set. Failed PRs (null evaluation) contribute their
+// repo#number so the multiplex fingerprint still changes if a
+// previously-failing PR starts resolving (or vice versa).
+function combinedFingerprint(
+  items: OutputItem[],
+  evaluations: Array<PrEvaluation | null>,
+): string {
+  const parts = items.map((item, i) => {
+    const ev = evaluations[i];
+    const fp = ev ? ev.fingerprint : `error:${item.error ?? "unknown"}`;
+    return `${item.repo}#${item.number}:${fp}`;
+  });
+  return createHash("sha1").update(parts.join("|")).digest("hex").slice(0, 16);
+}
+
+function buildOutput(
+  items: OutputItem[],
+  evaluations: Array<PrEvaluation | null>,
+  opts: WatchOptions,
+  timedOut: boolean,
+): Output {
+  const fingerprint = combinedFingerprint(items, evaluations);
+  const changed: Output["changed"] = [];
+  for (let i = 0; i < items.length; i += 1) {
+    const ev = evaluations[i];
+    if (!ev) continue;
+    const reason = wakeReason(ev, fingerprint, opts);
+    if (reason !== null) {
+      const item = items[i];
+      if (item) changed.push({ repo: item.repo, number: item.number, reason });
+    }
+  }
+  return {
+    items,
+    changed,
+    fingerprint,
+    timedOut,
+  };
+}
+
+function buildRateLimited(
+  items: OutputItem[],
+  evaluations: Array<PrEvaluation | null>,
+  opts: WatchOptions,
+  err: RateLimitExhaustedError | AbuseDetectionError,
+): Output {
+  const base = buildOutput(items, evaluations, opts, true);
+  // RateLimitExhaustedError carries `resetAt` (epoch seconds);
+  // AbuseDetectionError carries `retryAfterSeconds`. Surface a
+  // forward-looking "seconds from now" figure for both so the caller
+  // can back off uniformly.
+  const retryAfter =
+    err instanceof AbuseDetectionError
+      ? err.retryAfterSeconds
+      : Math.max(0, Math.round(err.resetAt - Date.now() / 1000));
+  return { ...base, rateLimited: true, retryAfter };
+}
+
+export function registerPRReviewWatchTool(
+  register: RegisterToolFn,
+  graphql: GraphqlClient,
+): void {
+  register("gh.pr_review_watch", {
+    description:
+      "Blocking, multiplexed long-poll that watches 1..N PRs for " +
+      "1..N reviewers and returns when ANY watched PR has a " +
+      "wake-worthy transition, becomes `ready`, or the wait times " +
+      "out. Per reviewer it computes a verdict on HEAD (pending / " +
+      "needs-work / green) from `latestReviews` plus unresolved, " +
+      "non-outdated review threads authored by that reviewer (NOT a " +
+      "comment count, which misses Copilot's thread-based " +
+      "findings). `ready` (strict done) means every reviewer is " +
+      "green on HEAD, every requiredApprovals reviewer is APPROVED, " +
+      "and (when requireCi) CI is SUCCESS. Wake is a TRANSITION away " +
+      "from the prior `fingerprint`, filtered by `waitFor` " +
+      "(any/smart/all/quorum), so it does not hot-loop. " +
+      "`maxWaitSeconds` defaults to 25 to stay under the ~60s MCP " +
+      "tool-call timeout common to clients; the agent re-invokes " +
+      "passing the returned `fingerprint` back as `sinceFingerprint`. " +
+      "Set `maxWaitSeconds: 0` for a single snapshot.",
+    inputSchema,
+    handler: async (raw) => {
+      const args = validate<Input>(inputSchema, raw, "gh.pr_review_watch input");
+      // Parse every repo slug up front so a malformed slug fails the
+      // whole call at the boundary rather than per-cycle.
+      for (const pr of args.prs) {
+        parseRepoSlug(pr.repo, "gh.pr_review_watch input");
+      }
+      const opts = normaliseOptions(args);
+      const deps: WatchDeps = {
+        graphql,
+        sleep: (ms) =>
+          new Promise<void>((resolveSleep) => {
+            setTimeout(resolveSleep, ms);
+          }),
+        now: () => Date.now(),
+        // The MCP CallTool handler signature does not currently
+        // expose an abort signal, so we omit it; watchPrs keeps
+        // `signal` optional and simply never observes an abort here.
+      };
+      const out = await watchPrs(opts, deps);
+      return validate<Output>(outputSchema, out, "gh.pr_review_watch output");
+    },
+  });
+}
+
+// Map the validated input onto the engine's normalised options:
+// apply the copilot alias, default requiredApprovals to the human
+// reviewers, and fill the numeric/enum defaults.
+function normaliseOptions(args: Input): WatchOptions {
+  const reviewers = dedupe(args.reviewers.map(mapReviewerAlias));
+  const requiredApprovals =
+    args.requiredApprovals !== undefined
+      ? dedupe(args.requiredApprovals.map(mapReviewerAlias))
+      : reviewers.filter((login) => !BOT_LOGINS.has(login));
+  return {
+    prs: args.prs,
+    reviewers,
+    requiredApprovals,
+    waitFor: args.waitFor ?? "any",
+    quorum: args.quorum ?? 1,
+    sinceFingerprint: args.sinceFingerprint ?? null,
+    pollSeconds: args.pollSeconds ?? POLL_SECONDS_DEFAULT,
+    maxWaitSeconds: args.maxWaitSeconds ?? MAX_WAIT_SECONDS_DEFAULT,
+    requireCi: args.requireCi ?? false,
+  };
+}
+
+function mapReviewerAlias(login: string): string {
+  return login === COPILOT_ALIAS ? COPILOT_LOGIN : login;
+}
+
+function dedupe(values: string[]): string[] {
+  return [...new Set(values)];
+}

--- a/src/tools/pr/review_watch.ts
+++ b/src/tools/pr/review_watch.ts
@@ -129,10 +129,12 @@ const inputSchema = {
     },
     sinceFingerprint: {
       type: "string",
+      minLength: 1,
       description:
         "The `fingerprint` from the previous call. The tool wakes on a " +
         "`waitFor`-filtered transition away from this value. Omit on " +
-        "the first call.",
+        "the first call (an empty string is rejected so a caller cannot " +
+        "accidentally disable transition wakes).",
     },
     pollSeconds: {
       type: "integer",
@@ -890,7 +892,7 @@ function buildRateLimited(
   // engine stays deterministic under test.
   const retryAfter =
     err instanceof AbuseDetectionError
-      ? err.retryAfterSeconds
+      ? Math.max(0, Math.round(err.retryAfterSeconds))
       : Math.max(0, Math.round(err.resetAt - nowMs / 1000));
   return { ...base, rateLimited: true, retryAfter };
 }
@@ -979,7 +981,7 @@ function normaliseOptions(args: Input): WatchOptions {
       ? dedupe(args.requiredApprovals.map(mapReviewerAlias))
       : reviewers.filter((login) => !BOT_LOGINS.has(login));
   return {
-    prs: args.prs,
+    prs: dedupePrs(args.prs),
     reviewers,
     requiredApprovals,
     waitFor: args.waitFor ?? "any",
@@ -1001,4 +1003,19 @@ function mapReviewerAlias(login: string): string {
 
 function dedupe(values: string[]): string[] {
   return [...new Set(values)];
+}
+
+// Drop duplicate PRs (same repo + number). Duplicates would collide on the
+// `repo#number` key in the fingerprint map (later overwriting earlier), so the
+// returned token could not round-trip a per-PR baseline.
+function dedupePrs(prs: PrInput[]): PrInput[] {
+  const seen = new Set<string>();
+  const out: PrInput[] = [];
+  for (const pr of prs) {
+    const key = `${pr.repo}#${pr.number}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(pr);
+  }
+  return out;
 }

--- a/src/tools/pr/review_watch.ts
+++ b/src/tools/pr/review_watch.ts
@@ -613,10 +613,13 @@ export async function watchPrs(
     // Wake if any PR is ready, or THIS PR's own fingerprint changed away
     // from the caller's baseline and it satisfies the waitFor filter.
     const woke = lastEvaluations.some((ev, i) => {
-      if (ev === null) return false;
       const item = lastItems[i];
       if (item === undefined) return false;
       const changed = prChanged(prKey(item), prComponent(item, ev), priorMap);
+      // An error item has no evaluation, but an OK<->error transition (its
+      // component changed) is still wake-worthy, so the agent learns a
+      // watched PR started or stopped failing instead of waiting for timeout.
+      if (ev === null) return changed;
       return prWakes(ev, changed, opts);
     });
     if (woke) return buildOutput(lastItems, lastEvaluations, opts, priorMap, false);
@@ -813,11 +816,18 @@ function buildOutput(
   const fingerprint = encodeFingerprint(items, evaluations);
   const changed: Output["changed"] = [];
   for (let i = 0; i < items.length; i += 1) {
-    const ev = evaluations[i];
+    const ev = evaluations[i] ?? null;
     const item = items[i];
-    if (!ev || !item) continue;
+    if (!item) continue;
     const changedSince = prChanged(prKey(item), prComponent(item, ev), priorMap);
-    const reason = wakeReason(ev, changedSince, opts);
+    // Error items (null evaluation) surface with reason "error" when their
+    // component changed; otherwise use the normal per-PR wake reason.
+    const reason =
+      ev === null
+        ? changedSince
+          ? "error"
+          : null
+        : wakeReason(ev, changedSince, opts);
     if (reason !== null) {
       changed.push({ repo: item.repo, number: item.number, reason });
     }

--- a/src/tools/pr/review_watch.ts
+++ b/src/tools/pr/review_watch.ts
@@ -403,13 +403,24 @@ export function evaluatePr(rawPr: RawPR, opts: EvalOptions): PrEvaluation {
   // The author is the first comment's author (threads(first:1)).
   // This is the actionable-work signal: it equals the outstanding
   // asks the agent still owes the reviewer.
-  const unresolvedByReviewer: Record<string, number> = {};
+  // One pass: lowercased author login -> unresolved, non-outdated thread count.
+  const allUnresolved: Record<string, number> = {};
   for (const thread of rawPr.reviewThreads.nodes) {
     if (thread.isResolved || thread.isOutdated) continue;
     const author = thread.comments.nodes[0]?.author?.login;
     if (!author) continue;
     const key = author.toLowerCase();
-    unresolvedByReviewer[key] = (unresolvedByReviewer[key] ?? 0) + 1;
+    allUnresolved[key] = (allUnresolved[key] ?? 0) + 1;
+  }
+  // The output map (and the fingerprint, which is built from it) cover only
+  // CONFIGURED reviewers: a thread by a non-watched author is not actionable
+  // for this watch, and restricting it keeps the returned output and the
+  // fingerprint consistent (so a non-watched author's thread cannot change the
+  // output without changing the fingerprint).
+  const unresolvedByReviewer: Record<string, number> = {};
+  for (const login of opts.reviewers) {
+    const count = allUnresolved[login.toLowerCase()] ?? 0;
+    if (count > 0) unresolvedByReviewer[login.toLowerCase()] = count;
   }
 
   const required = new Set(opts.requiredApprovals.map((l) => l.toLowerCase()));
@@ -431,7 +442,7 @@ export function evaluatePr(rawPr: RawPR, opts: EvalOptions): PrEvaluation {
     if (!onHead) {
       verdict = "pending";
     } else {
-      const hasOpenThread = (unresolvedByReviewer[login.toLowerCase()] ?? 0) > 0;
+      const hasOpenThread = (allUnresolved[login.toLowerCase()] ?? 0) > 0;
       if (state === "CHANGES_REQUESTED" || hasOpenThread) {
         verdict = "needs-work";
       } else {

--- a/src/tools/pr/review_watch.ts
+++ b/src/tools/pr/review_watch.ts
@@ -657,7 +657,11 @@ export async function watchPrs(
     if (signal?.aborted) {
       return buildOutput(lastItems, lastEvaluations, opts, priorMap, true);
     }
-    await sleep(opts.pollSeconds * 1000);
+    // Sleep only as long as the remaining budget allows, so a pollSeconds
+    // larger than the remaining maxWaitSeconds never blocks past the ceiling
+    // (or the common MCP client tool-call timeout).
+    const remainingMs = deadline - now();
+    await sleep(Math.min(opts.pollSeconds * 1000, Math.max(0, remainingMs)));
     // Re-check the deadline after sleeping so a sleep that consumed
     // the remaining budget doesn't kick off another full cycle past
     // the documented ceiling.
@@ -810,9 +814,16 @@ function decodeFingerprint(
     const parsed: unknown = JSON.parse(
       Buffer.from(token, "base64").toString("utf8"),
     );
-    return parsed !== null && typeof parsed === "object"
-      ? (parsed as Record<string, string>)
-      : null;
+    // Must be a plain object whose values are ALL strings. A malformed but
+    // JSON-parseable token (an array, or values that are not strings) is
+    // treated as no baseline, so a corrupt token never produces a spurious
+    // transition wake.
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+    const entries = Object.entries(parsed as Record<string, unknown>);
+    if (!entries.every(([, value]) => typeof value === "string")) return null;
+    return Object.fromEntries(entries) as Record<string, string>;
   } catch {
     return null;
   }

--- a/src/tools/pr/review_watch.ts
+++ b/src/tools/pr/review_watch.ts
@@ -309,17 +309,13 @@ interface RawReview {
   author: { login: string } | null;
   state: ReviewState;
   commit: { oid: string } | null;
-  submittedAt: string | null;
 }
 
 interface RawThread {
-  id: string;
   isResolved: boolean;
   isOutdated: boolean;
-  path: string | null;
-  line: number | null;
   comments: {
-    nodes: Array<{ author: { login: string } | null; body: string }>;
+    nodes: Array<{ author: { login: string } | null }>;
   };
 }
 
@@ -468,7 +464,14 @@ export function evaluatePr(rawPr: RawPR, opts: EvalOptions): PrEvaluation {
   const threadsTruncated = rawPr.reviewThreads.pageInfo.hasNextPage;
   const ready = allGreen && requiredApproved && ciReady && !threadsTruncated;
 
-  const fingerprint = computeFingerprint(reviewers, head, ci);
+  const fingerprint = computeFingerprint(
+    reviewers,
+    head,
+    ci,
+    unresolvedByReviewer,
+    threadsTruncated,
+    rawPr.reviewDecision,
+  );
 
   return {
     head,
@@ -484,16 +487,18 @@ export function evaluatePr(rawPr: RawPR, opts: EvalOptions): PrEvaluation {
   };
 }
 
-// Stable short hash over the sorted-by-login reviewer tuples plus
-// the CI state, so an unchanged review landscape produces an
-// unchanged fingerprint and the transition wake does not re-fire.
-// The tuple shape is fixed (login, latestReviewId, onHeadOid,
-// verdict) so the sibling methodology gh-CLI script can mirror it
-// and produce identical fingerprints for parity.
+// Stable short hash over every field that drives the per-PR OUTPUT, so any
+// observable change (verdict, latest-review id, head, ci, per-reviewer
+// unresolved count, threadsTruncated, reviewDecision) moves the fingerprint
+// and a waitFor:any transition wakes. The shape is fixed so the sibling
+// methodology gh-CLI script can mirror it.
 function computeFingerprint(
   reviewers: ReviewerVerdict[],
   head: string | null,
   ci: RollupState | null,
+  unresolvedByReviewer: Record<string, number>,
+  threadsTruncated: boolean,
+  reviewDecision: RawPR["reviewDecision"],
 ): string {
   const sorted = [...reviewers].sort((a, b) => a.login.localeCompare(b.login));
   const tuples = sorted.map((r) => ({
@@ -501,11 +506,18 @@ function computeFingerprint(
     latestReviewId: r.latestReviewId,
     onHeadOid: r.onHead ? head : null,
     verdict: r.verdict,
+    unresolved: unresolvedByReviewer[r.login.toLowerCase()] ?? 0,
   }));
   // `head` is included unconditionally (not only via on-head reviewers'
   // onHeadOid) so a push that moves HEAD always changes the fingerprint,
   // even when every reviewer is still pending.
-  const payload = JSON.stringify({ reviewers: tuples, head, ci });
+  const payload = JSON.stringify({
+    reviewers: tuples,
+    head,
+    ci,
+    threadsTruncated,
+    reviewDecision,
+  });
   return createHash("sha1").update(payload).digest("hex").slice(0, 16);
 }
 

--- a/src/tools/pr/review_watch.ts
+++ b/src/tools/pr/review_watch.ts
@@ -427,12 +427,13 @@ export function evaluatePr(rawPr: RawPR, opts: EvalOptions): PrEvaluation {
       const hasOpenThread = (unresolvedByReviewer[login] ?? 0) > 0;
       if (state === "CHANGES_REQUESTED" || hasOpenThread) {
         verdict = "needs-work";
-      } else if (required.has(login) && state !== "APPROVED") {
-        // Required approver who is otherwise clean but has not
-        // formally APPROVED stays pending (a CHANGES_REQUESTED is
-        // already needs-work above, so this is the COMMENTED case).
-        verdict = "pending";
       } else {
+        // On HEAD, no open thread, no requested changes: green. The
+        // verdict reflects review FEEDBACK only. A required approver
+        // who has not yet formally APPROVED is still green here (they
+        // have no outstanding asks); the orthogonal requiredApproved
+        // gate in `ready` holds the PR until they approve, so `green`
+        // does not on its own imply `ready`.
         verdict = "green";
       }
     }

--- a/src/tools/pr/review_watch.ts
+++ b/src/tools/pr/review_watch.ts
@@ -75,10 +75,13 @@ const inputSchema = {
     prs: {
       type: "array",
       minItems: 1,
+      maxItems: 20,
       items: prItemSchema,
       description:
-        "PRs to watch. The tool queries each one per poll cycle and " +
-        "wakes when ANY of them satisfies the wake condition.",
+        "PRs to watch (max 20). Each poll cycle issues one GraphQL " +
+        "request per PR in parallel, so the cap keeps a cycle's burst " +
+        "well within GitHub's rate limits. The tool wakes when ANY of " +
+        "them satisfies the wake condition.",
     },
     reviewers: {
       type: "array",
@@ -95,6 +98,7 @@ const inputSchema = {
     },
     requiredApprovals: {
       type: "array",
+      maxItems: 50,
       items: { type: "string", minLength: 1 },
       description:
         "Reviewers who must additionally be APPROVED (not merely " +
@@ -458,7 +462,11 @@ export function evaluatePr(rawPr: RawPR, opts: EvalOptions): PrEvaluation {
   // A null rollup means "no checks configured": pass unless
   // requireCi forces a gate, in which case null fails.
   const ciReady = opts.requireCi ? ci === "SUCCESS" : true;
-  const ready = allGreen && requiredApproved && ciReady;
+  // Truncated threads mean only the first page was evaluated; a reviewer's
+  // unresolved thread could be unseen, so never declare ready on partial
+  // data (pessimistic: keep the caller looping rather than false-exiting).
+  const threadsTruncated = rawPr.reviewThreads.pageInfo.hasNextPage;
+  const ready = allGreen && requiredApproved && ciReady && !threadsTruncated;
 
   const fingerprint = computeFingerprint(reviewers, head, ci);
 
@@ -471,7 +479,7 @@ export function evaluatePr(rawPr: RawPR, opts: EvalOptions): PrEvaluation {
     ci,
     reviewDecision: rawPr.reviewDecision,
     unresolvedByReviewer,
-    threadsTruncated: rawPr.reviewThreads.pageInfo.hasNextPage,
+    threadsTruncated,
     fingerprint,
   };
 }
@@ -597,7 +605,7 @@ export async function watchPrs(
         err instanceof RateLimitExhaustedError ||
         err instanceof AbuseDetectionError
       ) {
-        return buildRateLimited(lastItems, lastEvaluations, opts, priorMap, err);
+        return buildRateLimited(lastItems, lastEvaluations, opts, priorMap, err, now());
       }
       throw err;
     }
@@ -735,7 +743,14 @@ function emptyItem(pr: PrInput, error: string): OutputItem {
 // fingerprint, or an error marker so a PR flipping between error and ok
 // still registers as a change.
 function prComponent(item: OutputItem, ev: PrEvaluation | null): string {
-  return ev ? ev.fingerprint : `error:${item.error ?? "unknown"}`;
+  if (ev) return ev.fingerprint;
+  // Hash the error so the opaque token stays compact and never carries a
+  // verbose upstream error string; the full message lives in items[*].error.
+  const digest = createHash("sha1")
+    .update(item.error ?? "unknown")
+    .digest("hex")
+    .slice(0, 8);
+  return `error:${digest}`;
 }
 
 function prKey(item: { repo: string; number: number }): string {
@@ -821,16 +836,18 @@ function buildRateLimited(
   opts: WatchOptions,
   priorMap: Record<string, string> | null,
   err: RateLimitExhaustedError | AbuseDetectionError,
+  nowMs: number,
 ): Output {
   const base = buildOutput(items, evaluations, opts, priorMap, true);
   // RateLimitExhaustedError carries `resetAt` (epoch seconds);
   // AbuseDetectionError carries `retryAfterSeconds`. Surface a
   // forward-looking "seconds from now" figure for both so the caller
-  // can back off uniformly.
+  // can back off uniformly. Use the injected clock (not Date.now) so the
+  // engine stays deterministic under test.
   const retryAfter =
     err instanceof AbuseDetectionError
       ? err.retryAfterSeconds
-      : Math.max(0, Math.round(err.resetAt - Date.now() / 1000));
+      : Math.max(0, Math.round(err.resetAt - nowMs / 1000));
   return { ...base, rateLimited: true, retryAfter };
 }
 
@@ -876,6 +893,20 @@ export function registerPRReviewWatchTool(
             `mcp-github: gh.pr_review_watch input: requiredApprovals must be a subset of reviewers ('${login}' is not in reviewers)`,
           );
         }
+      }
+      // A bot can never reach APPROVED, so requiring its approval would make
+      // `ready` unreachable. Reject the known Copilot bot explicitly.
+      if (opts.requiredApprovals.includes(COPILOT_LOGIN)) {
+        throw new Error(
+          `mcp-github: gh.pr_review_watch input: requiredApprovals cannot include '${COPILOT_LOGIN}' (a bot has no APPROVED state, so ready would be unreachable)`,
+        );
+      }
+      // A quorum larger than the reviewer set can never be met (only `ready`
+      // would ever wake), which is surprising. Fail fast.
+      if (opts.waitFor === "quorum" && opts.quorum > opts.reviewers.length) {
+        throw new Error(
+          `mcp-github: gh.pr_review_watch input: quorum (${opts.quorum}) cannot exceed the reviewer count (${opts.reviewers.length})`,
+        );
       }
       const deps: WatchDeps = {
         graphql,

--- a/src/tools/pr/review_watch.ts
+++ b/src/tools/pr/review_watch.ts
@@ -83,11 +83,15 @@ const inputSchema = {
     reviewers: {
       type: "array",
       minItems: 1,
+      maxItems: 50,
       items: { type: "string", minLength: 1 },
       description:
-        "Reviewer logins to watch. The alias `copilot` is mapped to " +
-        "`copilot-pull-request-reviewer`. A PR is `ready` only when " +
-        "every reviewer in this set is green on HEAD.",
+        "Individual reviewer logins to watch (users and bots; the alias " +
+        "`copilot` maps to `copilot-pull-request-reviewer`). NOT team " +
+        "slugs: the verdict matches a review/thread author login, so a " +
+        "team slug never matches and would stay pending forever. Watch a " +
+        "team via its member logins. A PR is `ready` only when every " +
+        "reviewer here is green on HEAD.",
     },
     requiredApprovals: {
       type: "array",
@@ -390,7 +394,9 @@ export function evaluatePr(rawPr: RawPR, opts: EvalOptions): PrEvaluation {
   const latestByLogin = new Map<string, RawReview>();
   for (const review of latest) {
     const login = review.author?.login;
-    if (login) latestByLogin.set(login, review);
+    // Index by lowercased login: GitHub logins are case-insensitive and
+    // the configured reviewer set is canonicalised the same way.
+    if (login) latestByLogin.set(login.toLowerCase(), review);
   }
 
   // Count unresolved, non-outdated threads per authoring reviewer.
@@ -402,12 +408,13 @@ export function evaluatePr(rawPr: RawPR, opts: EvalOptions): PrEvaluation {
     if (thread.isResolved || thread.isOutdated) continue;
     const author = thread.comments.nodes[0]?.author?.login;
     if (!author) continue;
-    unresolvedByReviewer[author] = (unresolvedByReviewer[author] ?? 0) + 1;
+    const key = author.toLowerCase();
+    unresolvedByReviewer[key] = (unresolvedByReviewer[key] ?? 0) + 1;
   }
 
-  const required = new Set(opts.requiredApprovals);
+  const required = new Set(opts.requiredApprovals.map((l) => l.toLowerCase()));
   const reviewers: ReviewerVerdict[] = opts.reviewers.map((login) => {
-    const review = latestByLogin.get(login);
+    const review = latestByLogin.get(login.toLowerCase());
     const state = review?.state ?? null;
     const latestReviewId = review?.id ?? null;
     // On head only when this reviewer has a non-DISMISSED/PENDING
@@ -424,7 +431,7 @@ export function evaluatePr(rawPr: RawPR, opts: EvalOptions): PrEvaluation {
     if (!onHead) {
       verdict = "pending";
     } else {
-      const hasOpenThread = (unresolvedByReviewer[login] ?? 0) > 0;
+      const hasOpenThread = (unresolvedByReviewer[login.toLowerCase()] ?? 0) > 0;
       if (state === "CHANGES_REQUESTED" || hasOpenThread) {
         verdict = "needs-work";
       } else {
@@ -446,7 +453,7 @@ export function evaluatePr(rawPr: RawPR, opts: EvalOptions): PrEvaluation {
 
   const allGreen = reviewers.every((r) => r.verdict === "green");
   const requiredApproved = reviewers
-    .filter((r) => required.has(r.login))
+    .filter((r) => required.has(r.login.toLowerCase()))
     .every((r) => r.state === "APPROVED");
   // A null rollup means "no checks configured": pass unless
   // requireCi forces a gate, in which case null fails.
@@ -487,24 +494,17 @@ function computeFingerprint(
     onHeadOid: r.onHead ? head : null,
     verdict: r.verdict,
   }));
-  const payload = JSON.stringify({ reviewers: tuples, ci });
+  // `head` is included unconditionally (not only via on-head reviewers'
+  // onHeadOid) so a push that moves HEAD always changes the fingerprint,
+  // even when every reviewer is still pending.
+  const payload = JSON.stringify({ reviewers: tuples, head, ci });
   return createHash("sha1").update(payload).digest("hex").slice(0, 16);
 }
 
-// Whether the (combined) fingerprint moved away from the caller's
-// `sinceFingerprint` baseline. A missing baseline (first call) is
-// NOT a transition: the blocking long-poll waits for a real change
-// (or `ready` / timeout) rather than returning on the first
-// snapshot. Callers wanting an immediate snapshot pass
-// maxWaitSeconds: 0.
-function changedVsSince(combined: string, opts: WatchOptions): boolean {
-  return opts.sinceFingerprint !== null && combined !== opts.sinceFingerprint;
-}
-
 // Whether this PR satisfies the `waitFor` filter THIS cycle (an
-// absolute per-PR predicate; the fingerprint delta is checked
-// separately by changedVsSince). `any` always satisfies, so any
-// combined change wakes; the others gate on a per-PR state.
+// absolute per-PR predicate; the per-PR fingerprint delta is checked
+// separately by prChanged). `any` always satisfies, so any per-PR
+// change wakes; the others gate on a per-PR state.
 function waitForHolds(evaluation: PrEvaluation, opts: WatchOptions): boolean {
   switch (opts.waitFor) {
     case "any":
@@ -522,31 +522,35 @@ function waitForHolds(evaluation: PrEvaluation, opts: WatchOptions): boolean {
   }
 }
 
-// A PR is a wake source when it is `ready`, or when the combined
-// fingerprint changed AND its `waitFor` filter holds.
+// A PR is a wake source when it is `ready`, or when THIS PR's own
+// fingerprint changed away from the caller's baseline AND its `waitFor`
+// filter holds. Using the per-PR delta (not the batch delta) means a
+// benign change to a sibling PR no longer spuriously wakes this one.
 function prWakes(
   evaluation: PrEvaluation,
-  combined: string,
+  changed: boolean,
   opts: WatchOptions,
 ): boolean {
   if (evaluation.ready) return true;
-  return changedVsSince(combined, opts) && waitForHolds(evaluation, opts);
+  return changed && waitForHolds(evaluation, opts);
 }
 
 // Human-readable reason a PR woke the multiplex, for the `changed`
 // array. Keeps the caller from re-deriving why each PR is listed.
 function wakeReason(
   evaluation: PrEvaluation,
-  combined: string,
+  changed: boolean,
   opts: WatchOptions,
 ): string | null {
   if (evaluation.ready) return "ready";
-  if (changedVsSince(combined, opts) && waitForHolds(evaluation, opts)) {
+  if (changed && waitForHolds(evaluation, opts)) {
     switch (opts.waitFor) {
       case "any":
         return "transition";
       case "smart":
-        return evaluation.actionable ? "actionable" : "ready-transition";
+        // Reachable only when not ready (ready returned above), so the
+        // waitFor:smart filter held via `actionable`.
+        return "actionable";
       case "all":
         return "all-on-head";
       case "quorum":
@@ -569,6 +573,9 @@ export async function watchPrs(
 ): Promise<Output> {
   const { graphql, sleep, now, signal } = deps;
   const deadline = now() + opts.maxWaitSeconds * 1000;
+  // Decode the caller's baseline once; every wake/changed decision is a
+  // per-PR delta against it.
+  const priorMap = decodeFingerprint(opts.sinceFingerprint);
 
   // Last good snapshot, so the abort / rate-limit paths can report
   // what we last saw rather than an empty payload. Empty before the
@@ -578,7 +585,7 @@ export async function watchPrs(
 
   while (true) {
     if (signal?.aborted) {
-      return buildOutput(lastItems, lastEvaluations, opts, true);
+      return buildOutput(lastItems, lastEvaluations, opts, priorMap, true);
     }
 
     try {
@@ -590,36 +597,38 @@ export async function watchPrs(
         err instanceof RateLimitExhaustedError ||
         err instanceof AbuseDetectionError
       ) {
-        return buildRateLimited(lastItems, lastEvaluations, opts, err);
+        return buildRateLimited(lastItems, lastEvaluations, opts, priorMap, err);
       }
       throw err;
     }
 
-    // Wake if any PR is ready, or the combined fingerprint changed
-    // away from the caller's baseline and some PR satisfies the
-    // waitFor filter.
-    const combined = combinedFingerprint(lastItems, lastEvaluations);
-    const woke = lastEvaluations.some(
-      (ev) => ev !== null && prWakes(ev, combined, opts),
-    );
-    if (woke) return buildOutput(lastItems, lastEvaluations, opts, false);
+    // Wake if any PR is ready, or THIS PR's own fingerprint changed away
+    // from the caller's baseline and it satisfies the waitFor filter.
+    const woke = lastEvaluations.some((ev, i) => {
+      if (ev === null) return false;
+      const item = lastItems[i];
+      if (item === undefined) return false;
+      const changed = prChanged(prKey(item), prComponent(item, ev), priorMap);
+      return prWakes(ev, changed, opts);
+    });
+    if (woke) return buildOutput(lastItems, lastEvaluations, opts, priorMap, false);
 
     // Out of budget: a single snapshot (maxWaitSeconds:0) lands here
     // immediately, and a longer block lands here once the deadline
     // passes. Both return timedOut so the caller re-invokes.
     if (now() >= deadline) {
-      return buildOutput(lastItems, lastEvaluations, opts, true);
+      return buildOutput(lastItems, lastEvaluations, opts, priorMap, true);
     }
 
     if (signal?.aborted) {
-      return buildOutput(lastItems, lastEvaluations, opts, true);
+      return buildOutput(lastItems, lastEvaluations, opts, priorMap, true);
     }
     await sleep(opts.pollSeconds * 1000);
     // Re-check the deadline after sleeping so a sleep that consumed
     // the remaining budget doesn't kick off another full cycle past
     // the documented ceiling.
     if (now() >= deadline) {
-      return buildOutput(lastItems, lastEvaluations, opts, true);
+      return buildOutput(lastItems, lastEvaluations, opts, priorMap, true);
     }
   }
 }
@@ -722,37 +731,80 @@ function emptyItem(pr: PrInput, error: string): OutputItem {
   };
 }
 
-// Combine each PR's per-PR fingerprint into one stable digest for
-// the whole watch set. Failed PRs (null evaluation) contribute their
-// repo#number so the multiplex fingerprint still changes if a
-// previously-failing PR starts resolving (or vice versa).
-function combinedFingerprint(
+// One PR's component within the encoded watch token: its per-PR
+// fingerprint, or an error marker so a PR flipping between error and ok
+// still registers as a change.
+function prComponent(item: OutputItem, ev: PrEvaluation | null): string {
+  return ev ? ev.fingerprint : `error:${item.error ?? "unknown"}`;
+}
+
+function prKey(item: { repo: string; number: number }): string {
+  return `${item.repo}#${item.number}`;
+}
+
+// The returned `fingerprint` is an opaque token encoding the per-PR
+// component map (base64 of a {`repo#number`: component} JSON object),
+// so the caller can pass it back and the next call detects WHICH PR
+// changed, not merely that the batch changed.
+function encodeFingerprint(
   items: OutputItem[],
   evaluations: Array<PrEvaluation | null>,
 ): string {
-  const parts = items.map((item, i) => {
-    const ev = evaluations[i];
-    const fp = ev ? ev.fingerprint : `error:${item.error ?? "unknown"}`;
-    return `${item.repo}#${item.number}:${fp}`;
+  const map: Record<string, string> = {};
+  items.forEach((item, i) => {
+    map[prKey(item)] = prComponent(item, evaluations[i] ?? null);
   });
-  return createHash("sha1").update(parts.join("|")).digest("hex").slice(0, 16);
+  return Buffer.from(JSON.stringify(map), "utf8").toString("base64");
+}
+
+// Decode a prior token into its per-PR component map. A missing or
+// unparseable token yields null ("no baseline": only `ready` wakes,
+// never a transition), so a first call or a corrupt token never
+// produces spurious transition wakes.
+function decodeFingerprint(
+  token: string | null,
+): Record<string, string> | null {
+  if (token === null) return null;
+  try {
+    const parsed: unknown = JSON.parse(
+      Buffer.from(token, "base64").toString("utf8"),
+    );
+    return parsed !== null && typeof parsed === "object"
+      ? (parsed as Record<string, string>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+// Whether THIS PR's component moved away from the caller's baseline. A
+// missing baseline (first call / undecodable token) is never a
+// transition.
+function prChanged(
+  key: string,
+  component: string,
+  priorMap: Record<string, string> | null,
+): boolean {
+  return priorMap !== null && priorMap[key] !== component;
 }
 
 function buildOutput(
   items: OutputItem[],
   evaluations: Array<PrEvaluation | null>,
   opts: WatchOptions,
+  priorMap: Record<string, string> | null,
   timedOut: boolean,
 ): Output {
-  const fingerprint = combinedFingerprint(items, evaluations);
+  const fingerprint = encodeFingerprint(items, evaluations);
   const changed: Output["changed"] = [];
   for (let i = 0; i < items.length; i += 1) {
     const ev = evaluations[i];
-    if (!ev) continue;
-    const reason = wakeReason(ev, fingerprint, opts);
+    const item = items[i];
+    if (!ev || !item) continue;
+    const changedSince = prChanged(prKey(item), prComponent(item, ev), priorMap);
+    const reason = wakeReason(ev, changedSince, opts);
     if (reason !== null) {
-      const item = items[i];
-      if (item) changed.push({ repo: item.repo, number: item.number, reason });
+      changed.push({ repo: item.repo, number: item.number, reason });
     }
   }
   return {
@@ -767,9 +819,10 @@ function buildRateLimited(
   items: OutputItem[],
   evaluations: Array<PrEvaluation | null>,
   opts: WatchOptions,
+  priorMap: Record<string, string> | null,
   err: RateLimitExhaustedError | AbuseDetectionError,
 ): Output {
-  const base = buildOutput(items, evaluations, opts, true);
+  const base = buildOutput(items, evaluations, opts, priorMap, true);
   // RateLimitExhaustedError carries `resetAt` (epoch seconds);
   // AbuseDetectionError carries `retryAfterSeconds`. Surface a
   // forward-looking "seconds from now" figure for both so the caller
@@ -812,6 +865,18 @@ export function registerPRReviewWatchTool(
         parseRepoSlug(pr.repo, "gh.pr_review_watch input");
       }
       const opts = normaliseOptions(args);
+      // requiredApprovals that are not in the reviewer set would be
+      // silently ignored (the verdict loop only covers `reviewers`),
+      // letting `ready` go true without that approver. Reject it at the
+      // boundary instead. Both sets are alias-mapped + lowercased.
+      const reviewerSet = new Set(opts.reviewers);
+      for (const login of opts.requiredApprovals) {
+        if (!reviewerSet.has(login)) {
+          throw new Error(
+            `mcp-github: gh.pr_review_watch input: requiredApprovals must be a subset of reviewers ('${login}' is not in reviewers)`,
+          );
+        }
+      }
       const deps: WatchDeps = {
         graphql,
         sleep: (ms) =>
@@ -852,7 +917,11 @@ function normaliseOptions(args: Input): WatchOptions {
 }
 
 function mapReviewerAlias(login: string): string {
-  return login === COPILOT_ALIAS ? COPILOT_LOGIN : login;
+  // Canonicalise to lowercase (GitHub logins are case-insensitive) so
+  // dedup, the requiredApprovals subset check, and verdict matching all
+  // agree regardless of the case the caller passed.
+  const lower = login.toLowerCase();
+  return lower === COPILOT_ALIAS ? COPILOT_LOGIN : lower;
 }
 
 function dedupe(values: string[]): string[] {

--- a/tests/smoke/server-lists-tools.mjs
+++ b/tests/smoke/server-lists-tools.mjs
@@ -63,6 +63,7 @@ const EXPECTED_TOOLS = [
   "gh.issue_parent_get",
   "gh.issue_sub_issues_list",
   "gh.pr_review_threads_list",
+  "gh.pr_review_watch",
 ];
 
 function frame(payload) {

--- a/tests/unit/tools/pr/review_watch.test.ts
+++ b/tests/unit/tools/pr/review_watch.test.ts
@@ -1,0 +1,1008 @@
+// tests/unit/tools/pr/review_watch.test.ts
+//
+// gh.pr_review_watch: pin the per-reviewer verdict truth table
+// (DISMISSED / PENDING excluded; threads-by-author drive
+// needs-work; APPROVED gating via requiredApprovals), the strict
+// `ready` predicate (all-green + required approvals + CI), the
+// transition (fingerprint) wake semantics (fires on change, does
+// NOT re-fire on unchanged state), the `any` / `smart` / `all` /
+// `quorum` filters, the multiplex changed-PR reporting, the
+// single-shot (maxWaitSeconds:0) + timeout + abort-signal paths,
+// the rate-limit snapshot, per-PR error isolation, and the input
+// bounds.
+//
+// All per-cycle GraphQL calls share the `pr/review_watch` query
+// name, so the multi-cycle tests make the stub's handler a closure
+// over an external cycle counter that returns different responses
+// across cycles. `sleep` resolves immediately and `now` is driven
+// by a controllable clock so the suite never actually waits.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  evaluatePr,
+  registerPRReviewWatchTool,
+  watchPrs,
+} from "../../../../src/tools/pr/review_watch.ts";
+import {
+  AbuseDetectionError,
+  RateLimitExhaustedError,
+} from "../../../../src/graphql/errors.ts";
+import type { GraphqlClient } from "../../../../src/graphql/client.ts";
+import type { ToolEntry } from "../../../../src/registry.ts";
+import { stubGraphqlClient } from "./_fixtures.ts";
+
+const HEAD = "headsha1";
+
+function captureRegistration() {
+  let entry: ToolEntry | undefined;
+  const register = (name: string, e: ToolEntry) => {
+    if (name !== "gh.pr_review_watch") throw new Error(`unexpected: ${name}`);
+    entry = e;
+  };
+  return {
+    register,
+    get entry(): ToolEntry {
+      if (!entry) throw new Error("not registered");
+      return entry;
+    },
+  };
+}
+
+// Build one raw review node (latestReviews connection shape). The
+// `login` shorthand maps onto the nested `author.login`; pass
+// `author` directly to override the whole object (e.g. a null
+// author).
+function review(
+  overrides: Record<string, unknown> & { login?: string } = {},
+) {
+  const { login, ...rest } = overrides;
+  const node: Record<string, unknown> = {
+    id: "PRR_1",
+    author: { login: login ?? "alice" },
+    state: "APPROVED" as const,
+    commit: { oid: HEAD },
+    submittedAt: "2026-05-01T00:00:00Z",
+    ...rest,
+  };
+  return node;
+}
+
+// Build one raw review thread (reviewThreads connection shape).
+function thread(
+  authorLogin: string,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    id: "RT_1",
+    isResolved: false,
+    isOutdated: false,
+    path: "src/x.ts",
+    line: 10,
+    comments: { nodes: [{ author: { login: authorLogin }, body: "fix this" }] },
+    ...overrides,
+  };
+}
+
+// Assemble a full RawPR. `reviews` / `threads` default to empty so
+// each test only declares what it cares about.
+function rawPr(opts: {
+  head?: string;
+  reviewDecision?:
+    | "APPROVED"
+    | "CHANGES_REQUESTED"
+    | "REVIEW_REQUIRED"
+    | null;
+  reviews?: Array<Record<string, unknown>>;
+  threads?: Array<Record<string, unknown>>;
+  threadsHasNextPage?: boolean;
+  rollup?: "SUCCESS" | "FAILURE" | "PENDING" | "ERROR" | "EXPECTED" | null;
+  noRollup?: boolean;
+} = {}) {
+  const rollupNode = opts.noRollup
+    ? { commit: { statusCheckRollup: null } }
+    : {
+        commit: {
+          statusCheckRollup: { state: opts.rollup ?? "SUCCESS" },
+        },
+      };
+  return {
+    headRefOid: opts.head ?? HEAD,
+    reviewDecision: opts.reviewDecision ?? "APPROVED",
+    latestReviews: { nodes: opts.reviews ?? [] },
+    reviewThreads: {
+      pageInfo: {
+        hasNextPage: opts.threadsHasNextPage ?? false,
+        endCursor: null,
+      },
+      nodes: opts.threads ?? [],
+    },
+    commits: { nodes: [rollupNode] },
+  } as unknown as Parameters<typeof evaluatePr>[0];
+}
+
+// A sleep that resolves immediately; a clock the test can advance.
+function makeDeps(
+  graphql: GraphqlClient,
+  extras: {
+    nowSeq?: number[];
+    aborted?: { aborted: boolean };
+    onSleep?: () => void;
+  } = {},
+) {
+  // When a sequence of `now()` values is supplied, return them in
+  // order (clamping to the last). Otherwise return a fixed clock so
+  // maxWaitSeconds windows never elapse on their own.
+  let i = 0;
+  const seq = extras.nowSeq;
+  const now = () => {
+    if (!seq) return 1_000_000;
+    const v = seq[Math.min(i, seq.length - 1)] ?? 0;
+    i += 1;
+    return v;
+  };
+  const deps: Parameters<typeof watchPrs>[1] = {
+    graphql,
+    sleep: async () => {
+      extras.onSleep?.();
+      await new Promise((r) => setTimeout(r, 0));
+    },
+    now,
+  };
+  if (extras.aborted) deps.signal = extras.aborted;
+  return deps;
+}
+
+// ---------------------------------------------------------------
+// evaluatePr: verdict truth table
+// ---------------------------------------------------------------
+
+test("evaluatePr: no review for reviewer -> pending", () => {
+  const ev = evaluatePr(rawPr({ reviews: [] }), {
+    reviewers: ["alice"],
+    requiredApprovals: [],
+    requireCi: false,
+  });
+  assert.equal(ev.reviewers[0]?.verdict, "pending");
+  assert.equal(ev.reviewers[0]?.onHead, false);
+  assert.equal(ev.allOnHead, false);
+  assert.equal(ev.ready, false);
+});
+
+test("evaluatePr: DISMISSED review is excluded (reads pending, not green)", () => {
+  const ev = evaluatePr(
+    rawPr({ reviews: [review({ state: "DISMISSED" })] }),
+    { reviewers: ["alice"], requiredApprovals: [], requireCi: false },
+  );
+  assert.equal(ev.reviewers[0]?.verdict, "pending");
+  assert.equal(ev.reviewers[0]?.onHead, false);
+});
+
+test("evaluatePr: PENDING review is excluded (null commit, reads pending)", () => {
+  const ev = evaluatePr(
+    rawPr({ reviews: [review({ state: "PENDING", commit: null, submittedAt: null })] }),
+    { reviewers: ["alice"], requiredApprovals: [], requireCi: false },
+  );
+  assert.equal(ev.reviewers[0]?.verdict, "pending");
+});
+
+test("evaluatePr: review on an old commit -> pending (not on head)", () => {
+  const ev = evaluatePr(
+    rawPr({ reviews: [review({ commit: { oid: "oldsha" } })] }),
+    { reviewers: ["alice"], requiredApprovals: [], requireCi: false },
+  );
+  assert.equal(ev.reviewers[0]?.verdict, "pending");
+  assert.equal(ev.reviewers[0]?.onHead, false);
+});
+
+test("evaluatePr: CHANGES_REQUESTED on head -> needs-work", () => {
+  const ev = evaluatePr(
+    rawPr({
+      reviews: [review({ state: "CHANGES_REQUESTED" })],
+      reviewDecision: "CHANGES_REQUESTED",
+    }),
+    { reviewers: ["alice"], requiredApprovals: [], requireCi: false },
+  );
+  assert.equal(ev.reviewers[0]?.verdict, "needs-work");
+  assert.equal(ev.reviewers[0]?.onHead, true);
+  assert.equal(ev.actionable, true);
+});
+
+test("evaluatePr: unresolved non-outdated thread by reviewer -> needs-work (even if COMMENTED)", () => {
+  // Copilot's signal: COMMENTED state, but an open thread it authored.
+  const ev = evaluatePr(
+    rawPr({
+      reviews: [review({ state: "COMMENTED" })],
+      threads: [thread("alice")],
+    }),
+    { reviewers: ["alice"], requiredApprovals: [], requireCi: false },
+  );
+  assert.equal(ev.reviewers[0]?.verdict, "needs-work");
+  assert.equal(ev.actionable, true);
+  assert.equal(ev.unresolvedByReviewer["alice"], 1);
+});
+
+test("evaluatePr: resolved or outdated threads do NOT drive needs-work", () => {
+  const ev = evaluatePr(
+    rawPr({
+      reviews: [review({ state: "COMMENTED" })],
+      threads: [
+        thread("alice", { isResolved: true }),
+        thread("alice", { isOutdated: true }),
+      ],
+    }),
+    { reviewers: ["alice"], requiredApprovals: [], requireCi: false },
+  );
+  // COMMENTED + no open thread + not required-to-approve -> green.
+  assert.equal(ev.reviewers[0]?.verdict, "green");
+  assert.equal(ev.unresolvedByReviewer["alice"], undefined);
+});
+
+test("evaluatePr: open thread by a DIFFERENT author does not make this reviewer needs-work", () => {
+  const ev = evaluatePr(
+    rawPr({
+      reviews: [review({ login: "alice", state: "COMMENTED" })],
+      threads: [thread("bob")],
+    }),
+    { reviewers: ["alice"], requiredApprovals: [], requireCi: false },
+  );
+  assert.equal(ev.reviewers[0]?.verdict, "green");
+  assert.equal(ev.unresolvedByReviewer["bob"], 1);
+  assert.equal(ev.unresolvedByReviewer["alice"], undefined);
+});
+
+test("evaluatePr: COMMENTED on head, no open thread, not required -> green", () => {
+  const ev = evaluatePr(
+    rawPr({ reviews: [review({ state: "COMMENTED" })] }),
+    { reviewers: ["alice"], requiredApprovals: [], requireCi: false },
+  );
+  assert.equal(ev.reviewers[0]?.verdict, "green");
+});
+
+test("evaluatePr: required approver that only COMMENTED stays pending (not green)", () => {
+  const ev = evaluatePr(
+    rawPr({ reviews: [review({ state: "COMMENTED" })] }),
+    { reviewers: ["alice"], requiredApprovals: ["alice"], requireCi: false },
+  );
+  assert.equal(ev.reviewers[0]?.verdict, "pending");
+  assert.equal(ev.ready, false);
+});
+
+test("evaluatePr: required approver that APPROVED on head -> green + ready", () => {
+  const ev = evaluatePr(
+    rawPr({ reviews: [review({ state: "APPROVED" })] }),
+    { reviewers: ["alice"], requiredApprovals: ["alice"], requireCi: false },
+  );
+  assert.equal(ev.reviewers[0]?.verdict, "green");
+  assert.equal(ev.ready, true);
+  assert.equal(ev.allOnHead, true);
+});
+
+// ---------------------------------------------------------------
+// evaluatePr: ready aggregate (all-green + required approvals + CI)
+// ---------------------------------------------------------------
+
+test("evaluatePr: ready false when one of two reviewers is pending", () => {
+  const ev = evaluatePr(
+    rawPr({ reviews: [review({ login: "alice", state: "APPROVED" })] }),
+    { reviewers: ["alice", "bob"], requiredApprovals: [], requireCi: false },
+  );
+  assert.equal(ev.ready, false);
+  assert.equal(ev.reviewers.find((r) => r.login === "bob")?.verdict, "pending");
+});
+
+test("evaluatePr: requireCi + SUCCESS rollup -> ready", () => {
+  const ev = evaluatePr(
+    rawPr({ reviews: [review({ state: "APPROVED" })], rollup: "SUCCESS" }),
+    { reviewers: ["alice"], requiredApprovals: ["alice"], requireCi: true },
+  );
+  assert.equal(ev.ci, "SUCCESS");
+  assert.equal(ev.ready, true);
+});
+
+test("evaluatePr: requireCi + FAILURE rollup -> not ready", () => {
+  const ev = evaluatePr(
+    rawPr({ reviews: [review({ state: "APPROVED" })], rollup: "FAILURE" }),
+    { reviewers: ["alice"], requiredApprovals: ["alice"], requireCi: true },
+  );
+  assert.equal(ev.ready, false);
+});
+
+test("evaluatePr: null rollup passes ready when requireCi is false", () => {
+  const ev = evaluatePr(
+    rawPr({ reviews: [review({ state: "APPROVED" })], noRollup: true }),
+    { reviewers: ["alice"], requiredApprovals: ["alice"], requireCi: false },
+  );
+  assert.equal(ev.ci, null);
+  assert.equal(ev.ready, true);
+});
+
+test("evaluatePr: null rollup fails ready when requireCi is true", () => {
+  const ev = evaluatePr(
+    rawPr({ reviews: [review({ state: "APPROVED" })], noRollup: true }),
+    { reviewers: ["alice"], requiredApprovals: ["alice"], requireCi: true },
+  );
+  assert.equal(ev.ci, null);
+  assert.equal(ev.ready, false);
+});
+
+// ---------------------------------------------------------------
+// evaluatePr: fingerprint stability
+// ---------------------------------------------------------------
+
+test("evaluatePr: fingerprint is stable across identical evaluations", () => {
+  const opts = { reviewers: ["alice"], requiredApprovals: [], requireCi: false };
+  const a = evaluatePr(rawPr({ reviews: [review()] }), opts);
+  const b = evaluatePr(rawPr({ reviews: [review()] }), opts);
+  assert.equal(a.fingerprint, b.fingerprint);
+});
+
+test("evaluatePr: fingerprint changes when a verdict changes", () => {
+  const opts = { reviewers: ["alice"], requiredApprovals: [], requireCi: false };
+  const pending = evaluatePr(rawPr({ reviews: [] }), opts);
+  const green = evaluatePr(rawPr({ reviews: [review()] }), opts);
+  assert.notEqual(pending.fingerprint, green.fingerprint);
+});
+
+test("evaluatePr: fingerprint changes when the CI state changes", () => {
+  const opts = { reviewers: ["alice"], requiredApprovals: [], requireCi: false };
+  const a = evaluatePr(rawPr({ reviews: [review()], rollup: "SUCCESS" }), opts);
+  const b = evaluatePr(rawPr({ reviews: [review()], rollup: "PENDING" }), opts);
+  assert.notEqual(a.fingerprint, b.fingerprint);
+});
+
+// ---------------------------------------------------------------
+// watchPrs: single-shot, timeout, wake
+// ---------------------------------------------------------------
+
+const ONE_PR = [{ repo: "owner/repo", number: 7 }];
+
+function baseOpts(overrides: Partial<Parameters<typeof watchPrs>[0]> = {}) {
+  return {
+    prs: ONE_PR,
+    reviewers: ["alice"],
+    requiredApprovals: [],
+    waitFor: "any" as const,
+    quorum: 1,
+    sinceFingerprint: null,
+    pollSeconds: 15,
+    maxWaitSeconds: 25,
+    requireCi: false,
+    ...overrides,
+  };
+}
+
+test("watchPrs: maxWaitSeconds 0 takes a single snapshot and returns timedOut", async () => {
+  // A not-yet-ready snapshot: maxWaitSeconds:0 polls exactly once
+  // and returns timedOut without blocking (the caller re-invokes
+  // with the fingerprint).
+  let cycles = 0;
+  const { graphql } = stubGraphqlClient({
+    "pr/review_watch": () => {
+      cycles += 1;
+      return { repository: { pullRequest: rawPr({ reviews: [] }) } };
+    },
+  });
+  const out = await watchPrs(
+    baseOpts({ maxWaitSeconds: 0 }),
+    makeDeps(graphql),
+  );
+  assert.equal(cycles, 1);
+  assert.equal(out.timedOut, true);
+  assert.equal(out.items.length, 1);
+  assert.equal(out.items[0]?.reviewers[0]?.verdict, "pending");
+});
+
+test("watchPrs: maxWaitSeconds 0 with a ready snapshot returns ready (not timedOut)", async () => {
+  // A single snapshot that is already done returns immediately with
+  // ready and timedOut:false, so the agent stops looping.
+  let cycles = 0;
+  const { graphql } = stubGraphqlClient({
+    "pr/review_watch": () => {
+      cycles += 1;
+      return {
+        repository: {
+          pullRequest: rawPr({ reviews: [review({ state: "APPROVED" })] }),
+        },
+      };
+    },
+  });
+  const out = await watchPrs(
+    baseOpts({ requiredApprovals: ["alice"], maxWaitSeconds: 0 }),
+    makeDeps(graphql),
+  );
+  assert.equal(cycles, 1);
+  assert.equal(out.timedOut, false);
+  assert.equal(out.items[0]?.ready, true);
+});
+
+test("watchPrs: ready wakes immediately even on the first call (no sinceFingerprint)", async () => {
+  const { graphql } = stubGraphqlClient({
+    "pr/review_watch": () => ({
+      repository: {
+        pullRequest: rawPr({ reviews: [review({ state: "APPROVED" })] }),
+      },
+    }),
+  });
+  const out = await watchPrs(
+    baseOpts({ requiredApprovals: ["alice"], maxWaitSeconds: 25 }),
+    makeDeps(graphql),
+  );
+  assert.equal(out.timedOut, false);
+  assert.equal(out.items[0]?.ready, true);
+  assert.deepEqual(out.changed, [
+    { repo: "owner/repo", number: 7, reason: "ready" },
+  ]);
+});
+
+test("watchPrs: transition wake fires when fingerprint changes vs sinceFingerprint", async () => {
+  // Snapshot the pending fingerprint first.
+  const { graphql: g1 } = stubGraphqlClient({
+    "pr/review_watch": () => ({
+      repository: { pullRequest: rawPr({ reviews: [] }) },
+    }),
+  });
+  const first = await watchPrs(
+    baseOpts({ maxWaitSeconds: 0 }),
+    makeDeps(g1),
+  );
+  const pendingFp = first.fingerprint;
+
+  // Now alice is on head but requested changes: a real transition
+  // away from pendingFp that is NOT ready, so `any` wakes with the
+  // generic "transition" reason rather than "ready".
+  let cycles = 0;
+  const { graphql: g2 } = stubGraphqlClient({
+    "pr/review_watch": () => {
+      cycles += 1;
+      return {
+        repository: {
+          pullRequest: rawPr({
+            reviews: [review({ state: "CHANGES_REQUESTED" })],
+            reviewDecision: "CHANGES_REQUESTED",
+          }),
+        },
+      };
+    },
+  });
+  const out = await watchPrs(
+    baseOpts({ sinceFingerprint: pendingFp, maxWaitSeconds: 25 }),
+    makeDeps(g2),
+  );
+  assert.equal(cycles, 1);
+  assert.equal(out.timedOut, false);
+  assert.equal(out.items[0]?.ready, false);
+  assert.equal(out.changed[0]?.reason, "transition");
+  assert.notEqual(out.fingerprint, pendingFp);
+});
+
+test("watchPrs: transition wake does NOT re-fire on unchanged state (times out)", async () => {
+  // Capture a stable not-ready (needs-work) fingerprint. A non-ready
+  // state is required here: `ready` always wakes regardless of the
+  // fingerprint, so a green state could not exercise the
+  // "unchanged -> no wake" path.
+  const stable = () => ({
+    repository: {
+      pullRequest: rawPr({
+        reviews: [review({ state: "CHANGES_REQUESTED" })],
+        reviewDecision: "CHANGES_REQUESTED",
+      }),
+    },
+  });
+  const { graphql: g1 } = stubGraphqlClient({ "pr/review_watch": stable });
+  const first = await watchPrs(baseOpts({ maxWaitSeconds: 0 }), makeDeps(g1));
+  const stableFp = first.fingerprint;
+
+  // Re-poll with the same state; the clock advances past the budget
+  // so the loop times out instead of hot-looping.
+  let cycles = 0;
+  const { graphql: g2 } = stubGraphqlClient({
+    "pr/review_watch": () => {
+      cycles += 1;
+      return stable();
+    },
+  });
+  const out = await watchPrs(
+    baseOpts({ sinceFingerprint: stableFp, maxWaitSeconds: 30, pollSeconds: 15 }),
+    // now() sequence: deadline base, first check, post-sleep check.
+    makeDeps(g2, { nowSeq: [0, 0, 31_000] }),
+  );
+  assert.equal(out.timedOut, true);
+  assert.equal(out.changed.length, 0);
+  assert.equal(out.fingerprint, stableFp);
+  // One poll, then the post-sleep deadline check ends the loop.
+  assert.equal(cycles, 1);
+});
+
+// ---------------------------------------------------------------
+// watchPrs: waitFor filters
+// ---------------------------------------------------------------
+
+test("watchPrs: waitFor smart wakes on actionable but not on a benign change", async () => {
+  // Baseline: pending.
+  const optsEval = { reviewers: ["alice"], requiredApprovals: [], requireCi: false };
+  const baseFp = evaluatePr(rawPr({ reviews: [] }), optsEval).fingerprint;
+
+  // needs-work is actionable -> smart wakes.
+  const { graphql } = stubGraphqlClient({
+    "pr/review_watch": () => ({
+      repository: {
+        pullRequest: rawPr({
+          reviews: [review({ state: "CHANGES_REQUESTED" })],
+          reviewDecision: "CHANGES_REQUESTED",
+        }),
+      },
+    }),
+  });
+  const out = await watchPrs(
+    baseOpts({ waitFor: "smart", sinceFingerprint: baseFp, maxWaitSeconds: 25 }),
+    makeDeps(graphql),
+  );
+  assert.equal(out.timedOut, false);
+  assert.equal(out.changed[0]?.reason, "actionable");
+});
+
+test("watchPrs: waitFor smart does NOT wake on a non-actionable, non-ready change", async () => {
+  // Baseline pending for a two-reviewer set; change makes only ONE
+  // reviewer green (still not ready, not actionable) -> smart holds.
+  const optsEval = {
+    reviewers: ["alice", "bob"],
+    requiredApprovals: [],
+    requireCi: false,
+  };
+  const baseFp = evaluatePr(rawPr({ reviews: [] }), optsEval).fingerprint;
+
+  let cycles = 0;
+  const { graphql } = stubGraphqlClient({
+    "pr/review_watch": () => {
+      cycles += 1;
+      return {
+        repository: {
+          pullRequest: rawPr({
+            reviews: [review({ login: "alice", state: "COMMENTED" })],
+          }),
+        },
+      };
+    },
+  });
+  const out = await watchPrs(
+    baseOpts({
+      prs: ONE_PR,
+      reviewers: ["alice", "bob"],
+      waitFor: "smart",
+      sinceFingerprint: baseFp,
+      maxWaitSeconds: 30,
+      pollSeconds: 15,
+    }),
+    makeDeps(graphql, { nowSeq: [0, 0, 31_000] }),
+  );
+  assert.equal(out.timedOut, true);
+  assert.equal(out.changed.length, 0);
+  assert.equal(cycles, 1);
+});
+
+test("watchPrs: waitFor all wakes only once every reviewer is on head", async () => {
+  const optsEval = {
+    reviewers: ["alice", "bob"],
+    requiredApprovals: [],
+    requireCi: false,
+  };
+  const baseFp = evaluatePr(rawPr({ reviews: [] }), optsEval).fingerprint;
+
+  // Both reviewers on head but requesting changes: allOnHead is
+  // true (neither is pending) while the PR is NOT ready, so the
+  // wake is attributable to the `all` filter, not to `ready`.
+  const { graphql } = stubGraphqlClient({
+    "pr/review_watch": () => ({
+      repository: {
+        pullRequest: rawPr({
+          reviewDecision: "CHANGES_REQUESTED",
+          reviews: [
+            review({ id: "PRR_a", login: "alice", state: "CHANGES_REQUESTED" }),
+            review({ id: "PRR_b", login: "bob", state: "CHANGES_REQUESTED" }),
+          ],
+        }),
+      },
+    }),
+  });
+  const out = await watchPrs(
+    baseOpts({
+      reviewers: ["alice", "bob"],
+      waitFor: "all",
+      sinceFingerprint: baseFp,
+      maxWaitSeconds: 25,
+    }),
+    makeDeps(graphql),
+  );
+  assert.equal(out.timedOut, false);
+  assert.equal(out.items[0]?.allOnHead, true);
+  assert.equal(out.items[0]?.ready, false);
+  assert.equal(out.changed[0]?.reason, "all-on-head");
+});
+
+test("watchPrs: waitFor quorum wakes when enough reviewers are non-pending", async () => {
+  const optsEval = {
+    reviewers: ["alice", "bob", "carol"],
+    requiredApprovals: [],
+    requireCi: false,
+  };
+  const baseFp = evaluatePr(rawPr({ reviews: [] }), optsEval).fingerprint;
+
+  // alice + bob are on head (requesting changes -> non-pending);
+  // carol has not reviewed (pending). Two non-pending reviewers hit
+  // the quorum of 2 while the PR is not ready, so the wake is the
+  // quorum filter rather than `ready`.
+  const { graphql } = stubGraphqlClient({
+    "pr/review_watch": () => ({
+      repository: {
+        pullRequest: rawPr({
+          reviewDecision: "CHANGES_REQUESTED",
+          reviews: [
+            review({ id: "PRR_a", login: "alice", state: "CHANGES_REQUESTED" }),
+            review({ id: "PRR_b", login: "bob", state: "CHANGES_REQUESTED" }),
+          ],
+        }),
+      },
+    }),
+  });
+  const out = await watchPrs(
+    baseOpts({
+      reviewers: ["alice", "bob", "carol"],
+      waitFor: "quorum",
+      quorum: 2,
+      sinceFingerprint: baseFp,
+      maxWaitSeconds: 25,
+    }),
+    makeDeps(graphql),
+  );
+  assert.equal(out.timedOut, false);
+  assert.equal(out.items[0]?.ready, false);
+  assert.equal(out.changed[0]?.reason, "quorum-reached");
+});
+
+test("watchPrs: waitFor quorum holds below the threshold", async () => {
+  const optsEval = {
+    reviewers: ["alice", "bob", "carol"],
+    requiredApprovals: [],
+    requireCi: false,
+  };
+  const baseFp = evaluatePr(rawPr({ reviews: [] }), optsEval).fingerprint;
+
+  let cycles = 0;
+  const { graphql } = stubGraphqlClient({
+    "pr/review_watch": () => {
+      cycles += 1;
+      return {
+        repository: {
+          pullRequest: rawPr({
+            reviews: [review({ login: "alice", state: "COMMENTED" })],
+          }),
+        },
+      };
+    },
+  });
+  const out = await watchPrs(
+    baseOpts({
+      reviewers: ["alice", "bob", "carol"],
+      waitFor: "quorum",
+      quorum: 2,
+      sinceFingerprint: baseFp,
+      maxWaitSeconds: 30,
+      pollSeconds: 15,
+    }),
+    makeDeps(graphql, { nowSeq: [0, 0, 31_000] }),
+  );
+  assert.equal(out.timedOut, true);
+  assert.equal(cycles, 1);
+});
+
+// ---------------------------------------------------------------
+// watchPrs: multiplex, abort, rate-limit, per-PR error isolation
+// ---------------------------------------------------------------
+
+test("watchPrs: multiplex returns the changed PR + reason among several", async () => {
+  // Two PRs; only #8 becomes ready. The closure varies the payload
+  // by PR number (read off the vars), and all calls share the
+  // pr/review_watch query name.
+  const { graphql } = stubGraphqlClient({
+    "pr/review_watch": (vars: Record<string, unknown>) => {
+      const number = vars.number as number;
+      if (number === 8) {
+        return {
+          repository: {
+            pullRequest: rawPr({ reviews: [review({ state: "APPROVED" })] }),
+          },
+        };
+      }
+      return { repository: { pullRequest: rawPr({ reviews: [] }) } };
+    },
+  });
+  const out = await watchPrs(
+    baseOpts({
+      prs: [
+        { repo: "owner/repo", number: 7 },
+        { repo: "owner/repo", number: 8 },
+      ],
+      requiredApprovals: ["alice"],
+      maxWaitSeconds: 25,
+    }),
+    makeDeps(graphql),
+  );
+  assert.equal(out.timedOut, false);
+  assert.equal(out.items.length, 2);
+  assert.deepEqual(out.changed, [
+    { repo: "owner/repo", number: 8, reason: "ready" },
+  ]);
+  assert.equal(out.items.find((i) => i.number === 8)?.ready, true);
+  assert.equal(out.items.find((i) => i.number === 7)?.ready, false);
+});
+
+test("watchPrs: abort signal breaks the loop and returns timedOut", async () => {
+  const aborted = { aborted: true };
+  let cycles = 0;
+  const { graphql } = stubGraphqlClient({
+    "pr/review_watch": () => {
+      cycles += 1;
+      return { repository: { pullRequest: rawPr({ reviews: [] }) } };
+    },
+  });
+  const out = await watchPrs(
+    baseOpts({ maxWaitSeconds: 25 }),
+    makeDeps(graphql, { aborted }),
+  );
+  // Aborted before the first cycle -> no GraphQL calls, timedOut.
+  assert.equal(cycles, 0);
+  assert.equal(out.timedOut, true);
+  assert.equal(out.changed.length, 0);
+});
+
+test("watchPrs: abort mid-wait breaks before the next cycle", async () => {
+  const aborted = { aborted: false };
+  let cycles = 0;
+  const { graphql } = stubGraphqlClient({
+    "pr/review_watch": () => {
+      cycles += 1;
+      return { repository: { pullRequest: rawPr({ reviews: [] }) } };
+    },
+  });
+  // Flip the abort flag during the sleep; the post-sleep abort check
+  // then breaks the loop. now() stays fixed so the deadline never
+  // fires on its own.
+  const out = await watchPrs(
+    baseOpts({ maxWaitSeconds: 25, pollSeconds: 15 }),
+    makeDeps(graphql, {
+      aborted,
+      onSleep: () => {
+        aborted.aborted = true;
+      },
+    }),
+  );
+  assert.equal(cycles, 1);
+  assert.equal(out.timedOut, true);
+});
+
+test("watchPrs: RateLimitExhaustedError returns a rateLimited snapshot, not a throw", async () => {
+  const resetAt = Math.round(Date.now() / 1000) + 42;
+  const { graphql } = stubGraphqlClient({
+    "pr/review_watch": () => {
+      throw new RateLimitExhaustedError(resetAt, 5000);
+    },
+  });
+  const out = await watchPrs(baseOpts({ maxWaitSeconds: 25 }), makeDeps(graphql));
+  assert.equal(out.rateLimited, true);
+  assert.equal(out.timedOut, true);
+  assert.equal(typeof out.retryAfter, "number");
+  assert.ok((out.retryAfter ?? 0) >= 0);
+});
+
+test("watchPrs: AbuseDetectionError surfaces retryAfter from the error", async () => {
+  const { graphql } = stubGraphqlClient({
+    "pr/review_watch": () => {
+      throw new AbuseDetectionError(60);
+    },
+  });
+  const out = await watchPrs(baseOpts({ maxWaitSeconds: 25 }), makeDeps(graphql));
+  assert.equal(out.rateLimited, true);
+  assert.equal(out.retryAfter, 60);
+});
+
+test("watchPrs: a per-PR fetch error is isolated to that item, batch survives", async () => {
+  const { graphql } = stubGraphqlClient({
+    "pr/review_watch": (vars: Record<string, unknown>) => {
+      const number = vars.number as number;
+      if (number === 7) {
+        // repo missing for this PR -> tool throws internally; the
+        // engine captures it on the item.
+        return { repository: null };
+      }
+      return {
+        repository: {
+          pullRequest: rawPr({ reviews: [review({ state: "APPROVED" })] }),
+        },
+      };
+    },
+  });
+  const out = await watchPrs(
+    baseOpts({
+      prs: [
+        { repo: "owner/repo", number: 7 },
+        { repo: "owner/repo", number: 8 },
+      ],
+      requiredApprovals: ["alice"],
+      maxWaitSeconds: 25,
+    }),
+    makeDeps(graphql),
+  );
+  const bad = out.items.find((i) => i.number === 7);
+  const good = out.items.find((i) => i.number === 8);
+  assert.match(bad?.error ?? "", /not found or token lacks read access/);
+  assert.equal(good?.ready, true);
+  // The healthy PR still wakes the multiplex.
+  assert.equal(out.timedOut, false);
+  assert.deepEqual(out.changed, [
+    { repo: "owner/repo", number: 8, reason: "ready" },
+  ]);
+});
+
+// ---------------------------------------------------------------
+// Handler: alias mapping, requiredApprovals default, input bounds
+// ---------------------------------------------------------------
+
+test("handler: maps the `copilot` alias to copilot-pull-request-reviewer", async () => {
+  const { graphql } = stubGraphqlClient({
+    "pr/review_watch": () => ({
+      repository: {
+        pullRequest: rawPr({
+          reviews: [
+            review({ login: "copilot-pull-request-reviewer", state: "COMMENTED" }),
+          ],
+        }),
+      },
+    }),
+  });
+  const reg = captureRegistration();
+  registerPRReviewWatchTool(reg.register, graphql);
+  const out = (await reg.entry.handler({
+    prs: [{ repo: "owner/repo", number: 7 }],
+    reviewers: ["copilot"],
+    maxWaitSeconds: 0,
+  })) as {
+    items: Array<{ reviewers: Array<{ login: string; verdict: string }> }>;
+  };
+  assert.equal(
+    out.items[0]?.reviewers[0]?.login,
+    "copilot-pull-request-reviewer",
+  );
+  // copilot is a bot, so it is NOT defaulted into requiredApprovals;
+  // COMMENTED on head with no open thread reads green.
+  assert.equal(out.items[0]?.reviewers[0]?.verdict, "green");
+});
+
+test("handler: requiredApprovals defaults to the human reviewers (copilot excluded)", async () => {
+  const { graphql } = stubGraphqlClient({
+    "pr/review_watch": () => ({
+      repository: {
+        pullRequest: rawPr({
+          reviews: [
+            review({ id: "PRR_h", login: "alice", state: "COMMENTED" }),
+            review({
+              id: "PRR_c",
+              login: "copilot-pull-request-reviewer",
+              state: "COMMENTED",
+            }),
+          ],
+        }),
+      },
+    }),
+  });
+  const reg = captureRegistration();
+  registerPRReviewWatchTool(reg.register, graphql);
+  const out = (await reg.entry.handler({
+    prs: [{ repo: "owner/repo", number: 7 }],
+    reviewers: ["alice", "copilot"],
+    maxWaitSeconds: 0,
+  })) as {
+    items: Array<{
+      ready: boolean;
+      reviewers: Array<{ login: string; verdict: string }>;
+    }>;
+  };
+  // alice (human) defaults into requiredApprovals: COMMENTED is not
+  // APPROVED, so she stays pending and the PR is not ready.
+  const alice = out.items[0]?.reviewers.find((r) => r.login === "alice");
+  assert.equal(alice?.verdict, "pending");
+  assert.equal(out.items[0]?.ready, false);
+});
+
+test("handler: threadsTruncated surfaces when reviewThreads has a next page", async () => {
+  const { graphql } = stubGraphqlClient({
+    "pr/review_watch": () => ({
+      repository: {
+        pullRequest: rawPr({ reviews: [review()], threadsHasNextPage: true }),
+      },
+    }),
+  });
+  const reg = captureRegistration();
+  registerPRReviewWatchTool(reg.register, graphql);
+  const out = (await reg.entry.handler({
+    prs: [{ repo: "owner/repo", number: 7 }],
+    reviewers: ["alice"],
+    maxWaitSeconds: 0,
+  })) as { items: Array<{ threadsTruncated: boolean }> };
+  assert.equal(out.items[0]?.threadsTruncated, true);
+});
+
+test("handler: rejects empty prs at the input boundary", async () => {
+  const { graphql } = stubGraphqlClient({});
+  const reg = captureRegistration();
+  registerPRReviewWatchTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ prs: [], reviewers: ["alice"] }),
+    /gh\.pr_review_watch input/,
+  );
+});
+
+test("handler: rejects empty reviewers at the input boundary", async () => {
+  const { graphql } = stubGraphqlClient({});
+  const reg = captureRegistration();
+  registerPRReviewWatchTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({ prs: [{ repo: "owner/repo", number: 7 }], reviewers: [] }),
+    /gh\.pr_review_watch input/,
+  );
+});
+
+test("handler: rejects an unknown property on a prs item (additionalProperties:false)", async () => {
+  const { graphql } = stubGraphqlClient({});
+  const reg = captureRegistration();
+  registerPRReviewWatchTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      prs: [{ repo: "owner/repo", number: 7, extra: true }],
+      reviewers: ["alice"],
+    }),
+    /gh\.pr_review_watch input/,
+  );
+});
+
+test("handler: rejects pollSeconds below the minimum", async () => {
+  const { graphql } = stubGraphqlClient({});
+  const reg = captureRegistration();
+  registerPRReviewWatchTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      prs: [{ repo: "owner/repo", number: 7 }],
+      reviewers: ["alice"],
+      pollSeconds: 1,
+    }),
+    /gh\.pr_review_watch input/,
+  );
+});
+
+test("handler: rejects maxWaitSeconds above the maximum", async () => {
+  const { graphql } = stubGraphqlClient({});
+  const reg = captureRegistration();
+  registerPRReviewWatchTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      prs: [{ repo: "owner/repo", number: 7 }],
+      reviewers: ["alice"],
+      maxWaitSeconds: 999,
+    }),
+    /gh\.pr_review_watch input/,
+  );
+});
+
+test("handler: rejects an invalid repo slug at the input boundary", async () => {
+  const { graphql } = stubGraphqlClient({});
+  const reg = captureRegistration();
+  registerPRReviewWatchTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      prs: [{ repo: "not-a-slug", number: 7 }],
+      reviewers: ["alice"],
+    }),
+    /gh\.pr_review_watch input/,
+  );
+});

--- a/tests/unit/tools/pr/review_watch.test.ts
+++ b/tests/unit/tools/pr/review_watch.test.ts
@@ -248,7 +248,9 @@ test("evaluatePr: open thread by a DIFFERENT author does not make this reviewer 
     { reviewers: ["alice"], requiredApprovals: [], requireCi: false },
   );
   assert.equal(ev.reviewers[0]?.verdict, "green");
-  assert.equal(ev.unresolvedByReviewer["bob"], 1);
+  // bob is not a configured reviewer, so the output map (scoped to configured
+  // reviewers) excludes him; alice has no thread, so she is absent too.
+  assert.equal(ev.unresolvedByReviewer["bob"], undefined);
   assert.equal(ev.unresolvedByReviewer["alice"], undefined);
 });
 

--- a/tests/unit/tools/pr/review_watch.test.ts
+++ b/tests/unit/tools/pr/review_watch.test.ts
@@ -377,6 +377,26 @@ function baseOpts(overrides: Partial<Parameters<typeof watchPrs>[0]> = {}) {
   };
 }
 
+// A real baseline token: snapshot the all-pending state (maxWaitSeconds:0)
+// and return the encoded fingerprint a caller would pass back as
+// `sinceFingerprint`. The token now encodes a per-PR component map, so a
+// raw evaluatePr().fingerprint is no longer a valid baseline.
+async function pendingToken(
+  reviewers: string[],
+  prs: Array<{ repo: string; number: number }> = ONE_PR,
+): Promise<string> {
+  const { graphql } = stubGraphqlClient({
+    "pr/review_watch": () => ({
+      repository: { pullRequest: rawPr({ reviews: [] }) },
+    }),
+  });
+  const out = await watchPrs(
+    baseOpts({ reviewers, prs, maxWaitSeconds: 0 }),
+    makeDeps(graphql),
+  );
+  return out.fingerprint;
+}
+
 test("watchPrs: maxWaitSeconds 0 takes a single snapshot and returns timedOut", async () => {
   // A not-yet-ready snapshot: maxWaitSeconds:0 polls exactly once
   // and returns timedOut without blocking (the caller re-invokes
@@ -524,9 +544,8 @@ test("watchPrs: transition wake does NOT re-fire on unchanged state (times out)"
 // ---------------------------------------------------------------
 
 test("watchPrs: waitFor smart wakes on actionable but not on a benign change", async () => {
-  // Baseline: pending.
-  const optsEval = { reviewers: ["alice"], requiredApprovals: [], requireCi: false };
-  const baseFp = evaluatePr(rawPr({ reviews: [] }), optsEval).fingerprint;
+  // Baseline: all pending (a real token the caller would pass back).
+  const baseFp = await pendingToken(["alice"]);
 
   // needs-work is actionable -> smart wakes.
   const { graphql } = stubGraphqlClient({
@@ -550,12 +569,7 @@ test("watchPrs: waitFor smart wakes on actionable but not on a benign change", a
 test("watchPrs: waitFor smart does NOT wake on a non-actionable, non-ready change", async () => {
   // Baseline pending for a two-reviewer set; change makes only ONE
   // reviewer green (still not ready, not actionable) -> smart holds.
-  const optsEval = {
-    reviewers: ["alice", "bob"],
-    requiredApprovals: [],
-    requireCi: false,
-  };
-  const baseFp = evaluatePr(rawPr({ reviews: [] }), optsEval).fingerprint;
+  const baseFp = await pendingToken(["alice", "bob"]);
 
   let cycles = 0;
   const { graphql } = stubGraphqlClient({
@@ -587,12 +601,7 @@ test("watchPrs: waitFor smart does NOT wake on a non-actionable, non-ready chang
 });
 
 test("watchPrs: waitFor all wakes only once every reviewer is on head", async () => {
-  const optsEval = {
-    reviewers: ["alice", "bob"],
-    requiredApprovals: [],
-    requireCi: false,
-  };
-  const baseFp = evaluatePr(rawPr({ reviews: [] }), optsEval).fingerprint;
+  const baseFp = await pendingToken(["alice", "bob"]);
 
   // Both reviewers on head but requesting changes: allOnHead is
   // true (neither is pending) while the PR is NOT ready, so the
@@ -626,12 +635,7 @@ test("watchPrs: waitFor all wakes only once every reviewer is on head", async ()
 });
 
 test("watchPrs: waitFor quorum wakes when enough reviewers are non-pending", async () => {
-  const optsEval = {
-    reviewers: ["alice", "bob", "carol"],
-    requiredApprovals: [],
-    requireCi: false,
-  };
-  const baseFp = evaluatePr(rawPr({ reviews: [] }), optsEval).fingerprint;
+  const baseFp = await pendingToken(["alice", "bob", "carol"]);
 
   // alice + bob are on head (requesting changes -> non-pending);
   // carol has not reviewed (pending). Two non-pending reviewers hit
@@ -666,12 +670,7 @@ test("watchPrs: waitFor quorum wakes when enough reviewers are non-pending", asy
 });
 
 test("watchPrs: waitFor quorum holds below the threshold", async () => {
-  const optsEval = {
-    reviewers: ["alice", "bob", "carol"],
-    requiredApprovals: [],
-    requireCi: false,
-  };
-  const baseFp = evaluatePr(rawPr({ reviews: [] }), optsEval).fingerprint;
+  const baseFp = await pendingToken(["alice", "bob", "carol"]);
 
   let cycles = 0;
   const { graphql } = stubGraphqlClient({
@@ -740,6 +739,40 @@ test("watchPrs: multiplex returns the changed PR + reason among several", async 
   ]);
   assert.equal(out.items.find((i) => i.number === 8)?.ready, true);
   assert.equal(out.items.find((i) => i.number === 7)?.ready, false);
+});
+
+test("watchPrs: changed lists only the PR that actually transitioned (per-PR delta)", async () => {
+  const prs = [
+    { repo: "owner/repo", number: 7 },
+    { repo: "owner/repo", number: 8 },
+  ];
+  // Baseline: both PRs pending.
+  const baseFp = await pendingToken(["alice"], prs);
+  // Only #7 transitions (alice requests changes); #8 stays pending. A
+  // benign-or-no change to #8 must NOT make it appear in `changed`.
+  const { graphql } = stubGraphqlClient({
+    "pr/review_watch": (vars: Record<string, unknown>) => {
+      if (vars.number === 7) {
+        return {
+          repository: {
+            pullRequest: rawPr({
+              reviews: [review({ state: "CHANGES_REQUESTED" })],
+              reviewDecision: "CHANGES_REQUESTED",
+            }),
+          },
+        };
+      }
+      return { repository: { pullRequest: rawPr({ reviews: [] }) } };
+    },
+  });
+  const out = await watchPrs(
+    baseOpts({ prs, sinceFingerprint: baseFp, waitFor: "any", maxWaitSeconds: 25 }),
+    makeDeps(graphql),
+  );
+  assert.equal(out.timedOut, false);
+  assert.deepEqual(out.changed, [
+    { repo: "owner/repo", number: 7, reason: "transition" },
+  ]);
 });
 
 test("watchPrs: abort signal breaks the loop and returns timedOut", async () => {
@@ -1010,5 +1043,19 @@ test("handler: rejects an invalid repo slug at the input boundary", async () => 
       reviewers: ["alice"],
     }),
     /gh\.pr_review_watch input/,
+  );
+});
+
+test("handler: rejects requiredApprovals that is not a subset of reviewers", async () => {
+  const { graphql } = stubGraphqlClient({});
+  const reg = captureRegistration();
+  registerPRReviewWatchTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      prs: [{ repo: "owner/repo", number: 7 }],
+      reviewers: ["alice"],
+      requiredApprovals: ["dave"],
+    }),
+    /requiredApprovals must be a subset of reviewers/,
   );
 });

--- a/tests/unit/tools/pr/review_watch.test.ts
+++ b/tests/unit/tools/pr/review_watch.test.ts
@@ -349,6 +349,27 @@ test("evaluatePr: fingerprint changes when a verdict changes", () => {
   assert.notEqual(pending.fingerprint, green.fingerprint);
 });
 
+test("evaluatePr: fingerprint changes when a reviewer's unresolved count changes (verdict steady)", () => {
+  const opts = { reviewers: ["alice"], requiredApprovals: [], requireCi: false };
+  // Both needs-work (open thread by alice), but one vs two open threads: the
+  // verdict is unchanged, yet the observable output differs, so the
+  // fingerprint must change (round-4 completeness fix).
+  const one = evaluatePr(
+    rawPr({ reviews: [review({ state: "COMMENTED" })], threads: [thread("alice")] }),
+    opts,
+  );
+  const two = evaluatePr(
+    rawPr({
+      reviews: [review({ state: "COMMENTED" })],
+      threads: [thread("alice", { id: "RT_1" }), thread("alice", { id: "RT_2" })],
+    }),
+    opts,
+  );
+  assert.equal(one.reviewers[0]?.verdict, "needs-work");
+  assert.equal(two.reviewers[0]?.verdict, "needs-work");
+  assert.notEqual(one.fingerprint, two.fingerprint);
+});
+
 test("evaluatePr: fingerprint changes when the CI state changes", () => {
   const opts = { reviewers: ["alice"], requiredApprovals: [], requireCi: false };
   const a = evaluatePr(rawPr({ reviews: [review()], rollup: "SUCCESS" }), opts);

--- a/tests/unit/tools/pr/review_watch.test.ts
+++ b/tests/unit/tools/pr/review_watch.test.ts
@@ -1089,6 +1089,25 @@ test("handler: rejects quorum greater than the reviewer count", async () => {
   );
 });
 
+test("watchPrs: a PR that transitions OK -> fetch error wakes with reason error", async () => {
+  // Baseline: #7 fetches OK (pending).
+  const baseFp = await pendingToken(["alice"]);
+  // Now #7 fails to fetch -> its error component differs from the baseline,
+  // so it wakes with reason "error" rather than waiting for timeout.
+  const { graphql } = stubGraphqlClient({
+    "pr/review_watch": () => ({ repository: null }),
+  });
+  const out = await watchPrs(
+    baseOpts({ sinceFingerprint: baseFp, maxWaitSeconds: 25 }),
+    makeDeps(graphql),
+  );
+  assert.equal(out.timedOut, false);
+  assert.equal(out.items[0]?.error !== undefined, true);
+  assert.deepEqual(out.changed, [
+    { repo: "owner/repo", number: 7, reason: "error" },
+  ]);
+});
+
 test("evaluatePr: threadsTruncated forces ready false even when all green", () => {
   const ev = evaluatePr(
     rawPr({ reviews: [review({ state: "APPROVED" })], threadsHasNextPage: true }),

--- a/tests/unit/tools/pr/review_watch.test.ts
+++ b/tests/unit/tools/pr/review_watch.test.ts
@@ -260,12 +260,16 @@ test("evaluatePr: COMMENTED on head, no open thread, not required -> green", () 
   assert.equal(ev.reviewers[0]?.verdict, "green");
 });
 
-test("evaluatePr: required approver that only COMMENTED stays pending (not green)", () => {
+test("evaluatePr: required approver that only COMMENTED is green but not ready (approval is a separate gate)", () => {
   const ev = evaluatePr(
     rawPr({ reviews: [review({ state: "COMMENTED" })] }),
     { reviewers: ["alice"], requiredApprovals: ["alice"], requireCi: false },
   );
-  assert.equal(ev.reviewers[0]?.verdict, "pending");
+  // The verdict reflects review feedback only: on head, no open thread -> green.
+  assert.equal(ev.reviewers[0]?.verdict, "green");
+  assert.equal(ev.reviewers[0]?.onHead, true);
+  assert.equal(ev.allOnHead, true);
+  // ready is held back by the orthogonal required-approval gate.
   assert.equal(ev.ready, false);
 });
 
@@ -908,10 +912,12 @@ test("handler: requiredApprovals defaults to the human reviewers (copilot exclud
       reviewers: Array<{ login: string; verdict: string }>;
     }>;
   };
-  // alice (human) defaults into requiredApprovals: COMMENTED is not
-  // APPROVED, so she stays pending and the PR is not ready.
+  // alice (human) defaults into requiredApprovals. COMMENTED on head
+  // with no open thread reads green (verdict is feedback-only), but
+  // not being APPROVED holds the PR back from ready via the separate
+  // required-approval gate.
   const alice = out.items[0]?.reviewers.find((r) => r.login === "alice");
-  assert.equal(alice?.verdict, "pending");
+  assert.equal(alice?.verdict, "green");
   assert.equal(out.items[0]?.ready, false);
 });
 

--- a/tests/unit/tools/pr/review_watch.test.ts
+++ b/tests/unit/tools/pr/review_watch.test.ts
@@ -1112,6 +1112,34 @@ test("handler: rejects quorum greater than the reviewer count", async () => {
   );
 });
 
+test("watchPrs: sleep is clamped to the remaining budget (never overshoots maxWaitSeconds)", async () => {
+  const sleeps: number[] = [];
+  const { graphql } = stubGraphqlClient({
+    "pr/review_watch": () => ({
+      repository: { pullRequest: rawPr({ reviews: [] }) },
+    }),
+  });
+  // pollSeconds (120s) is far larger than maxWaitSeconds (25s); each sleep
+  // must be clamped to the remaining budget, not 120s.
+  let t = 0;
+  const deps = {
+    graphql,
+    sleep: async (ms: number) => {
+      sleeps.push(ms);
+      t += ms;
+    },
+    now: () => t,
+  };
+  await watchPrs(
+    baseOpts({ pollSeconds: 120, maxWaitSeconds: 25 }),
+    deps,
+  );
+  assert.ok(
+    sleeps.every((ms) => ms <= 25_000),
+    `a sleep exceeded the budget: ${sleeps.join(", ")}`,
+  );
+});
+
 test("watchPrs: a PR that transitions OK -> fetch error wakes with reason error", async () => {
   // Baseline: #7 fetches OK (pending).
   const baseFp = await pendingToken(["alice"]);

--- a/tests/unit/tools/pr/review_watch.test.ts
+++ b/tests/unit/tools/pr/review_watch.test.ts
@@ -1059,3 +1059,42 @@ test("handler: rejects requiredApprovals that is not a subset of reviewers", asy
     /requiredApprovals must be a subset of reviewers/,
   );
 });
+
+test("handler: rejects a bot in requiredApprovals (never reaches APPROVED)", async () => {
+  const { graphql } = stubGraphqlClient({});
+  const reg = captureRegistration();
+  registerPRReviewWatchTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      prs: [{ repo: "owner/repo", number: 7 }],
+      reviewers: ["copilot", "alice"],
+      requiredApprovals: ["copilot"],
+    }),
+    /requiredApprovals cannot include/,
+  );
+});
+
+test("handler: rejects quorum greater than the reviewer count", async () => {
+  const { graphql } = stubGraphqlClient({});
+  const reg = captureRegistration();
+  registerPRReviewWatchTool(reg.register, graphql);
+  await assert.rejects(
+    reg.entry.handler({
+      prs: [{ repo: "owner/repo", number: 7 }],
+      reviewers: ["alice", "bob"],
+      waitFor: "quorum",
+      quorum: 3,
+    }),
+    /quorum \(3\) cannot exceed/,
+  );
+});
+
+test("evaluatePr: threadsTruncated forces ready false even when all green", () => {
+  const ev = evaluatePr(
+    rawPr({ reviews: [review({ state: "APPROVED" })], threadsHasNextPage: true }),
+    { reviewers: ["alice"], requiredApprovals: ["alice"], requireCi: false },
+  );
+  assert.equal(ev.reviewers[0]?.verdict, "green");
+  assert.equal(ev.threadsTruncated, true);
+  assert.equal(ev.ready, false);
+});


### PR DESCRIPTION
## Summary

- New `gh.pr_review_watch` MCP tool: a blocking, stateless, multiplexed long-poll that watches 1..N PRs for 1..N reviewers and returns on a wake-worthy transition, `ready`, or timeout.
- Per-reviewer verdict (pending / needs-work / green) from `latestReviews` (excluding DISMISSED and PENDING) plus unresolved, non-outdated review threads authored by that reviewer (NOT `review.comments.totalCount`). `ready` = every configured reviewer green on HEAD AND required-approvers APPROVED AND (optional) CI SUCCESS; approval is an orthogonal gate.
- Eager `fingerprint`-transition wake (caller re-invokes passing it back), `waitFor` any|smart|all|quorum. `maxWaitSeconds` defaults under the ~60s client tool-call timeout.
- Adds `pr/review_watch.graphql`; pure `evaluatePr` + injected-clock `watchPrs` engine; per-PR error isolation; rate-limit + abort handling; README tool row.

## Test plan

- [x] `npm run build`, `npm run lint`, `npm test` (335 pass, incl. 44 new)
- [x] Smoke: server advertises `gh.pr_review_watch` in ListTools
- [ ] Live: call with `maxWaitSeconds: 0` against a real PR and confirm the multi-reviewer snapshot + fingerprint

Closes #43